### PR TITLE
[network-policy] add Rego rules to validate NetworkPolicy.

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -18,6 +18,7 @@ export GO111MODULE=on
 sudo chown -R cybozu:cybozu \$HOME/.cache
 make setup
 make kustomize-check
+make opa-test
 make test COMMIT_ID=${CIRCLE_SHA1}
 EOF
 chmod +x run.sh

--- a/network-policy/base/kustomization.yaml
+++ b/network-policy/base/kustomization.yaml
@@ -23,3 +23,11 @@ resources:
   - global-policies/ingress-all-deny.yaml
   - global-policies/network-set.yaml
   - global-policies/node-dns.yaml
+configMapGenerator:
+  - name: network-policy-validator
+    namespace: opa
+    files:
+      - validation/network-policy.rego
+generatorOptions:
+  labels:
+    openpolicyagent.org/policy: rego

--- a/network-policy/base/validation/network-policy.rego
+++ b/network-policy/base/validation/network-policy.rego
@@ -1,13 +1,14 @@
 package kubernetes.admission
 
 operations = {"CREATE", "UPDATE"}
+
 system_namespaces = {"kube-system", "argocd", "external-dns", "ingress", "internet-egress", "metallb-system", "monitoring", "opa"}
 
 deny[msg] {
-    input.request.kind.kind == "NetworkPolicy"
-    input.request.kind.group == "crd.projectcalico.org"
-    operations[input.request.operation]
-    not system_namespaces[input.request.namespace]
-    input.request.object.spec.order <= 1000
-    msg := "cannot create/update non-system NetworkPolicy with order <= 1000"
+	input.request.kind.kind == "NetworkPolicy"
+	input.request.kind.group == "crd.projectcalico.org"
+	operations[input.request.operation]
+	not system_namespaces[input.request.namespace]
+	input.request.object.spec.order <= 1000
+	msg := "cannot create/update non-system NetworkPolicy with order <= 1000"
 }

--- a/network-policy/base/validation/network-policy.rego
+++ b/network-policy/base/validation/network-policy.rego
@@ -1,0 +1,13 @@
+package kubernetes.admission
+
+operations = {"CREATE", "UPDATE"}
+system_namespaces = {"kube-system", "argocd", "external-dns", "ingress", "internet-egress", "metallb-system", "monitoring", "opa"}
+
+deny[msg] {
+    input.request.kind.kind == "NetworkPolicy"
+    input.request.kind.group == "crd.projectcalico.org"
+    operations[input.request.operation]
+    not system_namespaces[input.request.namespace]
+    input.request.object.spec.order <= 1000
+    msg := "cannot create/update non-system NetworkPolicy with order <= 1000"
+}

--- a/network-policy/base/validation/network-policy_test.rego
+++ b/network-policy/base/validation/network-policy_test.rego
@@ -1,63 +1,80 @@
 package kubernetes.test_admission
+
 import data.kubernetes.admission
 
-test_argocd_allowed {
-    count(admission.deny) == 0 with input as {
-        "request": {
-            "kind": {
-                "kind": "NetworkPolicy",
-                "group": "crd.projectcalico.org"
-            },
-            "operation": "CREATE",
-            "namespace": "argocd",
-            "object": {
-                "metadata": {
-                    "name": "foo"
-                },
-                "spec": {}
-            }
-        }
-    }
+test_allow_creating_network_policy_in_system_namespaces {
+	count(admission.deny) == 0 with input as {"request": {
+		"kind": {
+			"kind": "NetworkPolicy",
+			"group": "crd.projectcalico.org",
+		},
+		"operation": "CREATE",
+		"namespace": "argocd",
+		"object": {
+			"metadata": {"name": "foo"},
+			"spec": {},
+		},
+	}}
 }
 
-test_denied {
-    count(admission.deny) > 0 with input as {
-        "request": {
-            "kind": {
-                "kind": "NetworkPolicy",
-                "group": "crd.projectcalico.org"
-            },
-            "operation": "CREATE",
-            "namespace": "foo",
-            "object": {
-                "metadata": {
-                    "name": "foo"
-                },
-                "spec": {
-                    "order": 100.0
-                }
-            }
-        }
-    }
+test_deny_creating_high_priority_network_policy {
+	count(admission.deny) > 0 with input as {"request": {
+		"kind": {
+			"kind": "NetworkPolicy",
+			"group": "crd.projectcalico.org",
+			"version": "v1",
+		},
+		"operation": "CREATE",
+		"namespace": "foo",
+		"object": {
+			"metadata": {"name": "foo"},
+			"spec": {"order": 100},
+		},
+	}}
 }
 
-test_large_order_allowed {
-    count(admission.deny) == 0 with input as {
-        "request": {
-            "kind": {
-                "kind": "NetworkPolicy",
-                "group": "crd.projectcalico.org"
-            },
-            "operation": "CREATE",
-            "namespace": "foo",
-            "object": {
-                "metadata": {
-                    "name": "foo"
-                },
-                "spec": {
-                    "order": 2000.0
-                }
-            }
-        }
-    }
+test_deny_creating_high_priority_network_policy_with_old_version {
+	count(admission.deny) > 0 with input as {"request": {
+		"kind": {
+			"kind": "NetworkPolicy",
+			"group": "crd.projectcalico.org",
+			"version": "v1beta1",
+		},
+		"operation": "CREATE",
+		"namespace": "foo",
+		"object": {
+			"metadata": {"name": "foo"},
+			"spec": {"order": 100},
+		},
+	}}
+}
+
+test_deny_updating_high_priority_network_policy {
+	count(admission.deny) > 0 with input as {"request": {
+		"kind": {
+			"kind": "NetworkPolicy",
+			"group": "crd.projectcalico.org",
+		},
+		"operation": "UPDATE",
+		"namespace": "foo",
+		"object": {
+			"metadata": {"name": "foo"},
+			"spec": {"order": 100},
+		},
+	}}
+}
+
+test_allow_creating_low_priority_network_policy {
+	count(admission.deny) == 0 with input as {"request": {
+		"kind": {
+			"kind": "NetworkPolicy",
+			"group": "crd.projectcalico.org",
+		},
+		"operation": "CREATE",
+		"namespace": "foo",
+		"object": {
+			"metadata": {"name": "foo"},
+			"spec": {"order": 2000},
+		},
+	}}
 }

--- a/network-policy/base/validation/network-policy_test.rego
+++ b/network-policy/base/validation/network-policy_test.rego
@@ -1,0 +1,63 @@
+package kubernetes.test_admission
+import data.kubernetes.admission
+
+test_argocd_allowed {
+    count(admission.deny) == 0 with input as {
+        "request": {
+            "kind": {
+                "kind": "NetworkPolicy",
+                "group": "crd.projectcalico.org"
+            },
+            "operation": "CREATE",
+            "namespace": "argocd",
+            "object": {
+                "metadata": {
+                    "name": "foo"
+                },
+                "spec": {}
+            }
+        }
+    }
+}
+
+test_denied {
+    count(admission.deny) > 0 with input as {
+        "request": {
+            "kind": {
+                "kind": "NetworkPolicy",
+                "group": "crd.projectcalico.org"
+            },
+            "operation": "CREATE",
+            "namespace": "foo",
+            "object": {
+                "metadata": {
+                    "name": "foo"
+                },
+                "spec": {
+                    "order": 100.0
+                }
+            }
+        }
+    }
+}
+
+test_large_order_allowed {
+    count(admission.deny) == 0 with input as {
+        "request": {
+            "kind": {
+                "kind": "NetworkPolicy",
+                "group": "crd.projectcalico.org"
+            },
+            "operation": "CREATE",
+            "namespace": "foo",
+            "object": {
+                "metadata": {
+                    "name": "foo"
+                },
+                "spec": {
+                    "order": 2000.0
+                }
+            }
+        }
+    }
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,7 @@ export GOFLAGS
 # https://github.com/cybozu/neco-containers/blob/master/argocd/Dockerfile#L32
 KUSTOMIZE_VERSION = 2.0.3
 OPA_VERSION = 0.12.0
+REGO_FILES = $(shell find .. -path ../vendor -prune -o -name '*.rego' -print)
 
 install.yaml: $(shell find ../argocd/base)
 	kustomize build ../argocd/base/ > install.yaml
@@ -22,7 +23,8 @@ validation:
 	go test -v ./validation_test.go
 
 opa-test:
-	opa test -v ../network-policy/base/validation/
+	test -z "$$(opa fmt -l ../ | grep -v '^vendor' | tee /dev/stderr)"
+	opa test -v $(REGO_FILES)
 
 test: install.yaml validation
 	./test.sh

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,12 +13,16 @@ export GOFLAGS
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/master/argocd/Dockerfile#L32
 KUSTOMIZE_VERSION = 2.0.3
+OPA_VERSION = 0.12.0
 
 install.yaml: $(shell find ../argocd/base)
 	kustomize build ../argocd/base/ > install.yaml
 
 validation:
 	go test -v ./validation_test.go
+
+opa-test:
+	opa test -v ../network-policy/base/validation/
 
 test: install.yaml validation
 	./test.sh
@@ -34,6 +38,9 @@ setup:
 	curl -sSLf -O https://github.com/kubernetes-sigs/kustomize/releases/download/v$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64
 	sudo mv kustomize_$(KUSTOMIZE_VERSION)_linux_amd64 /usr/local/bin/kustomize
 	chmod +x /usr/local/bin/kustomize
+	curl -sSLf -O https://github.com/open-policy-agent/opa/releases/download/v$(OPA_VERSION)/opa_linux_amd64
+	sudo mv opa_linux_amd64 /usr/local/bin/opa
+	chmod +x /usr/local/bin/opa
 	go install github.com/onsi/ginkgo/ginkgo
 
 save:
@@ -42,4 +49,4 @@ save:
 clean:
 	rm -f install.yaml
 
-.PHONY:	validation test kustomize-check setup save clean
+.PHONY:	validation opa-test test kustomize-check setup save clean

--- a/test/contour_test.go
+++ b/test/contour_test.go
@@ -81,7 +81,7 @@ metadata:
   name: ingress-httpdtest
   namespace: test-ingress
 spec:
-  order: 1000.0
+  order: 2000.0
   selector: run == 'testhttpd'
   types:
     - Ingress

--- a/test/metallb_test.go
+++ b/test/metallb_test.go
@@ -64,7 +64,7 @@ metadata:
   name: ingress-httpdtest
   namespace: default
 spec:
-  order: 1000.0
+  order: 2000.0
   selector: run == 'testhttpd'
   types:
     - Ingress

--- a/test/network-policy_test.go
+++ b/test/network-policy_test.go
@@ -62,7 +62,7 @@ metadata:
   name: ingress-httpdtest
   namespace: test-netpol
 spec:
-  order: 1000.0
+  order: 2000.0
   selector: run == 'testhttpd'
   types:
     - Ingress
@@ -355,6 +355,31 @@ spec:
 		Expect(err).To(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
 
 		// switch -- not tested for now because address range for switches is 10.0.1.0/24 in placemat env, not 10.72.0.0/20.
+	})
+
+	It("should deny network policy in non-system namespace with order <= 1000", func() {
+		By("creating invalid network policy")
+		policyYAML := `
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-httpdtest-high-prio
+  namespace: test-netpol
+spec:
+  order: 1000.0
+  selector: run == 'testhttpd'
+  types:
+    - Ingress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - 8000
+`
+		_, stderr, err := ExecAtWithInput(boot0, []byte(policyYAML), "kubectl", "apply", "-f", "-")
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("validating-webhook.openpolicyagent.org"))
 	})
 }
 


### PR DESCRIPTION
In this pull request, the following changes were made.

- add rego rules to prevent from creating or updating network policy resources with less than or equal to 1000 order defined by calico in some namespaces 
- add Open Policy Agent test cases 
