### PR TITLE
[network-policy] add egress network policy tests

### DIFF
--- a/test/network-policy_test.go
+++ b/test/network-policy_test.go
@@ -364,8 +364,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: ubuntu
-  labels:
-    app: ubuntu
 spec:
   securityContext:
     runAsUser: 10000


### PR DESCRIPTION
In this pull request, the following changes were made.
- add egress network policy tests.
- add missing ingress network policy test
- add `ingressroute` resource in the test to run tests properly