### PR TITLE
[kustomize] kustomize edit fix

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -26,10 +26,6 @@ test: install.yaml validation
 kustomize-check:
 	./kustomize-check.sh
 
-# NOTE: Enable this target when Argo CD uses kustomize 2.0.0
-#kustomize-fix:
-#	./kustomize-fix.sh
-
 setup:
 	curl -sSLf -O https://github.com/kubernetes-sigs/kustomize/releases/download/v$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64
 	sudo mv kustomize_$(KUSTOMIZE_VERSION)_linux_amd64 /usr/local/bin/kustomize

--- a/test/kustomize-fix.sh
+++ b/test/kustomize-fix.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -ex
-
-for dir in ${KUSTOMIZATION_DIRS}; do
-    (cd ${dir}; kustomize edit fix)
-done


### PR DESCRIPTION
As `kustomize edit fix` command migrates a kustomization file working with previous versions to one working with 2.0.0.

See the link below.
https://github.com/kubernetes-sigs/kustomize/blob/master/docs/v2.0.0.md#compatible-changes-new-features

Unfortunately, the command automatically edits the original kustomization file and applys without any warning and such behavior is not appropriate in CI test.

Therefore, in this pull request, the following changes were made.
- run `kustomize edit fix` command to all kustomization.yaml files to work with 2.0.0
- delete `kustomize edit fix` script to prevent from working in CI test