### PR TITLE
[teleport] fix rolebinding policy

### DIFF
--- a/teleport/base/validation/rolebinding-policy.rego
+++ b/teleport/base/validation/rolebinding-policy.rego
@@ -6,6 +6,7 @@ groupset[role] {
 
 deny[msg] {
 	not groupset["system:masters"]
+	input.request.userInfo.username != "system:serviceaccount:argocd:argocd-application-controller"
 	input.request.kind.kind == "RoleBinding"
 	input.request.object.roleRef.kind == "ClusterRole"
 	msg := "using ClusterRole in RoleBinding is not allowed for this user"

--- a/teleport/base/validation/rolebinding-policy_test.rego
+++ b/teleport/base/validation/rolebinding-policy_test.rego
@@ -34,6 +34,22 @@ test_allow_binding_clusterrole_in_rolebinding_by_admin {
 	}}
 }
 
+test_allow_binding_clusterrole_in_rolebinding_by_argocd {
+	count(admission.deny) == 0 with input as {"request": {
+		"kind": {"kind": "RoleBinding"},
+		"userInfo": {
+			"username": "system:serviceaccount:argocd:argocd-application-controller",
+			"uid": "014fbff9a07c",
+			"groups": ["system:serviceaccounts", "system:serviceaccounts:argocd", "system:authenticated"],
+		},
+		"object": {"roleRef": {
+			"apiGroup": "apiGroup: rbac.authorization.k8s.io",
+			"kind": "ClusterRole",
+			"name": "foo",
+		}},
+	}}
+}
+
 test_allow_binding_clusterrole_in_clusterrolebinding {
 	count(admission.deny) == 0 with input as {"request": {
 		"kind": {"kind": "ClusterRoleBinding"},


### PR DESCRIPTION
Argocd creates `rolebinding` resource with `clusterrole`, but currently we allow the operation for only `system:masters`.
To fix this, this pull request made the following changes
- fix `rolebinding` rule and permit argocd controller to create such resources
- add test