### PR TITLE
Fix monitoring stack

### DIFF
--- a/monitoring/base/grafana/dashboards/etcd.json
+++ b/monitoring/base/grafana/dashboards/etcd.json
@@ -105,7 +105,7 @@
                     "tableColumn": "",
                     "targets": [
                         {
-                            "expr": "max(etcd_server_has_leader)",
+                            "expr": "max(etcd_server_has_leader{job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "refId": "A",
@@ -186,7 +186,7 @@
                     "tableColumn": "",
                     "targets": [
                         {
-                            "expr": "max(etcd_server_leader_changes_seen_total)",
+                            "expr": "max(etcd_server_leader_changes_seen_total{job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "refId": "A",
@@ -262,7 +262,7 @@
                     "tableColumn": "",
                     "targets": [
                         {
-                            "expr": "max(etcd_server_leader_changes_seen_total)",
+                            "expr": "max(etcd_server_leader_changes_seen_total{job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "refId": "A",
@@ -328,7 +328,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\"}[5m]))",
+                            "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\",job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "RPC Rate",
@@ -337,7 +337,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "sum(rate(grpc_server_handled_total{grpc_type=\"unary\",grpc_code!=\"OK\"}[5m]))",
+                            "expr": "sum(rate(grpc_server_handled_total{grpc_type=\"unary\",grpc_code!=\"OK\",job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "RPC Failed Rate",
@@ -417,7 +417,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+                            "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\",job='$Job'}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\",job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Watch Streams",
@@ -426,7 +426,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+                            "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\",job='$Job'}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\",job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Lease Streams",
@@ -520,7 +520,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "etcd_debugging_mvcc_db_total_size_in_bytes",
+                            "expr": "etcd_debugging_mvcc_db_total_size_in_bytes{job='$Job'}",
                             "format": "time_series",
                             "hide": false,
                             "interval": "",
@@ -601,7 +601,7 @@
                     "steppedLine": true,
                     "targets": [
                         {
-                            "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))",
+                            "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job='$Job'}[5m])) by (instance, le))",
                             "format": "time_series",
                             "hide": false,
                             "intervalFactor": 2,
@@ -611,7 +611,7 @@
                             "step": 120
                         },
                         {
-                            "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))",
+                            "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job='$Job'}[5m])) by (instance, le))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "{{instance}} DB fsync",
@@ -689,7 +689,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "process_resident_memory_bytes",
+                            "expr": "process_resident_memory_bytes{job='$Job'}",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "{{instance}} Resident Memory",
@@ -781,7 +781,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "rate(etcd_network_client_grpc_received_bytes_total[5m])",
+                            "expr": "rate(etcd_network_client_grpc_received_bytes_total{job='$Job'}[5m])",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "{{instance}} Client Traffic In",
@@ -861,7 +861,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "rate(etcd_network_client_grpc_sent_bytes_total[5m])",
+                            "expr": "rate(etcd_network_client_grpc_sent_bytes_total{job='$Job'}[5m])",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "{{instance}} Client Traffic Out",
@@ -941,7 +941,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)",
+                            "expr": "sum(rate(etcd_network_peer_received_bytes_total{job='$Job'}[5m])) by (instance)",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "{{instance}} Peer Traffic In",
@@ -1023,7 +1023,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)",
+                            "expr": "sum(rate(etcd_network_peer_sent_bytes_total{job='$Job'}[5m])) by (instance)",
                             "format": "time_series",
                             "hide": false,
                             "interval": "",
@@ -1115,7 +1115,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_server_proposals_failed_total[5m]))",
+                            "expr": "sum(rate(etcd_server_proposals_failed_total{job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Proposal Failure Rate",
@@ -1124,7 +1124,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "sum(etcd_server_proposals_pending)",
+                            "expr": "sum(etcd_server_proposals_pending{job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Proposal Pending Total",
@@ -1133,7 +1133,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "sum(rate(etcd_server_proposals_committed_total[5m]))",
+                            "expr": "sum(rate(etcd_server_proposals_committed_total{job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Proposal Commit Rate",
@@ -1142,7 +1142,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "sum(rate(etcd_server_proposals_applied_total[5m]))",
+                            "expr": "sum(rate(etcd_server_proposals_applied_total{job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Proposal Apply Rate",
@@ -1224,7 +1224,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "changes(etcd_server_leader_changes_seen_total[1d])",
+                            "expr": "changes(etcd_server_leader_changes_seen_total{job='$Job'}[1d])",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "{{instance}} Total Leader Elections Per Day",
@@ -1317,7 +1317,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_server_proposals_committed_total[5m]))",
+                            "expr": "sum(rate(etcd_server_proposals_committed_total{job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "total number of consensus proposals committed",
@@ -1326,7 +1326,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "sum(rate(etcd_server_proposals_applied_total[5m]))",
+                            "expr": "sum(rate(etcd_server_proposals_applied_total{job='$Job'}[5m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "total number of consensus proposals applied",
@@ -1404,7 +1404,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(etcd_server_proposals_pending)",
+                            "expr": "sum(etcd_server_proposals_pending{job='$Job'})",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "Proposals pending",
@@ -1492,7 +1492,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_disk_wal_fsync_duration_seconds_sum[1m]))",
+                            "expr": "sum(rate(etcd_disk_wal_fsync_duration_seconds_sum{job='$Job'}[1m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "\tThe latency distributions of fsync called by wal",
@@ -1500,7 +1500,7 @@
                             "step": 30
                         },
                         {
-                            "expr": "sum(rate(etcd_disk_backend_commit_duration_seconds_sum[1m]))",
+                            "expr": "sum(rate(etcd_disk_backend_commit_duration_seconds_sum{job='$Job'}[1m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "The latency distributions of commit called by backend",
@@ -1588,7 +1588,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total[1m]))",
+                            "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total{job='$Job'}[1m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "The total number of bytes received by grpc clients",
@@ -1596,7 +1596,7 @@
                             "step": 30
                         },
                         {
-                            "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total[1m]))",
+                            "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total{job='$Job'}[1m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "The total number of bytes sent to grpc clients",
@@ -1685,7 +1685,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum[1m]))",
+                            "expr": "sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum{job='$Job'}[1m]))",
                             "format": "time_series",
                             "intervalFactor": 2,
                             "legendFormat": "The total latency distributions of save called by snapshot",
@@ -1742,7 +1742,31 @@
     "style": "dark",
     "tags": [],
     "templating": {
-        "list": []
+        "list": [
+            {
+                "allValue": ".*",
+                "current": {
+                    "text": "bootserver-etcd",
+                    "value": "bootserver-etcd"
+                },
+                "datasource": "prometheus",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "Job",
+                "options": [],
+                "query": "label_values(etcd_server_has_leader,job)",
+                "refresh": 1,
+                "regex": "",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
     },
     "time": {
         "from": "now-6h",

--- a/monitoring/base/grafana/statefulset.yaml
+++ b/monitoring/base/grafana/statefulset.yaml
@@ -1,3 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-init-script
+data:
+  init.sh: |-
+    #!/bin/bash
+    # Download node-exporter-full dashboard JSON,
+    # then replace ${DS_PROMETHEUS} to "prometheus"
+    # because ${DS_PROMETHEUS} is not available in provisioning
+    curl -sSLf https://grafana.com/api/dashboards/1860/revisions/14/download | \
+    jq '(.rows[].panels[] | select(.datasource == "${DS_PROMETHEUS}") | .datasource) |= "prometheus"' | \
+    jq '(.templating.list[] | select(.datasource == "${DS_PROMETHEUS}") | .datasource) |= "prometheus"' \
+    > /config/node-exporter.json
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -16,19 +31,17 @@ spec:
     spec:
       initContainers:
         # JSON of https://grafana.com/api/dashboards/1860 is too large to create ConfigMap by kubectl, so use init container
-        - image: quay.io/cybozu/grafana:6.2.5.1
+        - image: quay.io/cybozu/ubuntu-debug:18.0.4
           imagePullPolicy: IfNotPresent
           name: grafana-initconfig
-          command: ["curl"]
-          args:
-            - -sSLf
-            - -o
-            - /config/node-exporter.json
-            - https://grafana.com/api/dashboards/1860/revisions/14/download
+          command: ["/bin/init.sh"]
           env:
             - name: HTTPS_PROXY
               value: http://squid.internet-egress.svc.cluster.local:3128
           volumeMounts:
+            - name: grafana-init-script-volume
+              mountPath: /bin
+              readOnly: true
             - name: dashboard-node-exporter-volume
               mountPath: /config
       containers:
@@ -99,6 +112,10 @@ spec:
         fsGroup: 10000
         runAsUser: 10000
       volumes:
+        - name: grafana-init-script-volume
+          configMap:
+            name: grafana-init-script
+            defaultMode: 0777
         - configMap:
             defaultMode: 420
             name: grafana

--- a/monitoring/base/grafana/statefulset.yaml
+++ b/monitoring/base/grafana/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       initContainers:
         # JSON of https://grafana.com/api/dashboards/1860 is too large to create ConfigMap by kubectl, so use init container
-        - image: quay.io/cybozu/ubuntu-debug:18.0.4
+        - image: quay.io/cybozu/ubuntu-debug:18.04
           imagePullPolicy: IfNotPresent
           name: grafana-initconfig
           command: ["/bin/init.sh"]
@@ -40,8 +40,9 @@ spec:
               value: http://squid.internet-egress.svc.cluster.local:3128
           volumeMounts:
             - name: grafana-init-script-volume
-              mountPath: /bin
               readOnly: true
+              mountPath: /bin/init.sh
+              subPath: init.sh
             - name: dashboard-node-exporter-volume
               mountPath: /config
       containers:

--- a/monitoring/base/prometheus/alert_rules.yaml
+++ b/monitoring/base/prometheus/alert_rules.yaml
@@ -51,3 +51,13 @@ groups:
         annotations:
           summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space increases {{ $value | humanize }}B/h"
           runbook: "Please consider to find root causes, and solve the problems"
+      - alert: CKEEtcdMissing
+        expr: absent(up{job="cke-etcd"})
+        labels:
+          severity: warning
+        for: 10m
+      - alert: BootserverEtcdMissing
+        expr: absent(up{job="bootserver-etcd"})
+        labels:
+          severity: warning
+        for: 10m

--- a/monitoring/base/prometheus/alert_rules.yaml
+++ b/monitoring/base/prometheus/alert_rules.yaml
@@ -61,3 +61,13 @@ groups:
         labels:
           severity: warning
         for: 10m
+#  TODO: Uncomment after setting up the staging machines
+#  - name: all
+#    rules:
+#      - alert: TargetDown
+#        expr: up == 0
+#        labels:
+#          severity: warning
+#        for: 1h
+#        annotations:
+#          summary: "{{ $labels.job }} in {{ $labels.instance }} is down"

--- a/monitoring/base/prometheus/alert_rules.yaml
+++ b/monitoring/base/prometheus/alert_rules.yaml
@@ -28,12 +28,12 @@ groups:
   - name: etcd
     rules:
       - alert: DatabaseSpaceExceeded
-        expr: etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes > 0.70
+        expr: etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes > 0.80
         for: 1m
         labels:
           severity: warning
         annotations:
-          summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space uses more than 70%"
+          summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space uses more than 80%"
           runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
       - alert: DatabaseSpaceExceeded
         expr: etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes > 0.90
@@ -44,7 +44,7 @@ groups:
           summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space uses more than 90%"
           runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
       - alert: LogicalDatabaseUsageIncreaseRapidly
-        expr: delta(etcd_mvcc_db_total_size_in_use_in_bytes[1h]) > 10000000
+        expr: delta(etcd_mvcc_db_total_size_in_use_in_bytes[1h]) > 30000000
         for: 1m
         labels:
           severity: warning

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -132,7 +132,7 @@ scrape_configs:
         namespaces:
           names: ["kube-system"]
     relabel_configs:
-      - source_labels: ["__meta_kubernetes_label_app_kubernetes_io_name"]
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: calico-node
       - source_labels: [__address__]

--- a/monitoring/base/prometheus/test_rules.yaml
+++ b/monitoring/base/prometheus/test_rules.yaml
@@ -157,3 +157,27 @@ tests:
     alert_rule_test:
       - eval_time: 9m
         alertname: BootserverEtcdMissing
+#  TODO: Uncomment after setting up the staging machines
+#  - interval: 1m
+#    input_series:
+#      - series: 'up{job="foo"}'
+#        values: '0+0x59'
+#    alert_rule_test:
+#      - eval_time: 59m
+#        alertname: TargetDown
+#  - interval: 1m
+#    input_series:
+#      - series: 'up{job="foo",instance="10.0.0.1"}'
+#        values: '0+0x60'
+#      - series: 'up{job="bar",instance="10.0.0.2"}'
+#        values: '0+0x59 1'
+#    alert_rule_test:
+#      - eval_time: 1h
+#        alertname: TargetDown
+#        exp_alerts:
+#          - exp_labels:
+#              job: foo
+#              instance: 10.0.0.1
+#              severity: warning
+#            exp_annotations:
+#              summary: "foo in 10.0.0.1 is down"

--- a/monitoring/base/prometheus/test_rules.yaml
+++ b/monitoring/base/prometheus/test_rules.yaml
@@ -128,3 +128,32 @@ tests:
             exp_annotations:
               summary: "10.0.0.1:2379, etcd of etcd DB space increases 30MB/h"
               runbook: "Please consider to find root causes, and solve the problems"
+  - interval: 1m
+    input_series:
+      - series: 'up{job="foo"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CKEEtcdMissing
+        exp_alerts:
+          - exp_labels:
+              job: cke-etcd
+              severity: warning
+  - interval: 1m
+    input_series:
+      - series: 'up{job="foo"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BootserverEtcdMissing
+        exp_alerts:
+          - exp_labels:
+              job: bootserver-etcd
+              severity: warning
+  - interval: 1m
+    input_series:
+      - series: 'up{job="foo"}'
+        values: '0+0x9'
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: BootserverEtcdMissing

--- a/monitoring/base/prometheus/test_rules.yaml
+++ b/monitoring/base/prometheus/test_rules.yaml
@@ -75,7 +75,7 @@ tests:
   - interval: 1m
     input_series:
       - series: 'etcd_mvcc_db_total_size_in_bytes{instance="10.0.0.1:2379", job="etcd"}'
-        values: '10+0x10 71+0x10'
+        values: '10+0x10 81+0x10'
       - series: 'etcd_server_quota_backend_bytes{instance="10.0.0.1:2379", job="etcd"}'
         values: '100+0x20'
     alert_rule_test:
@@ -87,7 +87,7 @@ tests:
               instance: 10.0.0.1:2379
               severity: warning
             exp_annotations:
-              summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 70%"
+              summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 80%"
               runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
   - interval: 1m
     input_series:
@@ -104,7 +104,7 @@ tests:
               instance: 10.0.0.1:2379
               severity: warning
             exp_annotations:
-              summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 70%"
+              summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 80%"
               runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
           - exp_labels:
               job: etcd
@@ -116,7 +116,7 @@ tests:
   - interval: 30m
     input_series:
       - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="10.0.0.1:2379", job="etcd", __name__="etcd"}'
-        values: '0+5000001x2'
+        values: '0+15000001x2'
     alert_rule_test:
       - eval_time: 60m
         alertname: LogicalDatabaseUsageIncreaseRapidly
@@ -126,5 +126,5 @@ tests:
               instance: 10.0.0.1:2379
               severity: warning
             exp_annotations:
-              summary: "10.0.0.1:2379, etcd of etcd DB space increases 10MB/h"
+              summary: "10.0.0.1:2379, etcd of etcd DB space increases 30MB/h"
               runbook: "Please consider to find root causes, and solve the problems"

--- a/monitoring/overlays/stage0/grafana/statefulset.yaml
+++ b/monitoring/overlays/stage0/grafana/statefulset.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: topolvm-provisioner
+        resources:
+          requests:
+            storage: 10Gi

--- a/monitoring/overlays/stage0/kustomization.yaml
+++ b/monitoring/overlays/stage0/kustomization.yaml
@@ -4,6 +4,9 @@ bases:
   - ../../base
 resources:
   - grafana/ingressroute.yaml
+patches:
+  - grafana/statefulset.yaml
+  - prometheus/statefulset.yaml
 configMapGenerator:
   - name: alertmanager
     behavior: merge

--- a/monitoring/overlays/stage0/prometheus/statefulset.yaml
+++ b/monitoring/overlays/stage0/prometheus/statefulset.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  volumeClaimTemplates:
+    - metadata:
+        name: prometheus-storage-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: topolvm-provisioner
+        resources:
+          requests:
+            storage: 10Gi

--- a/network-policy/base/policies/monitoring.yaml
+++ b/network-policy/base/policies/monitoring.yaml
@@ -31,3 +31,23 @@ spec:
           - 9093
           - 9100
           - 9105
+---
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-prometheus-etcd-allow
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  order: 500.0
+  selector: app.kubernetes.io/name == 'prometheus'
+  types:
+    - Egress
+  egress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: role == 'node'
+        ports:
+          - 2381

--- a/network-policy/base/policies/monitoring.yaml
+++ b/network-policy/base/policies/monitoring.yaml
@@ -35,7 +35,7 @@ spec:
 apiVersion: crd.projectcalico.org/v1
 kind: NetworkPolicy
 metadata:
-  name: egress-prometheus-etcd-allow
+  name: egress-prometheus-etcd-metrics-allow
   namespace: monitoring
   annotations:
     argocd.argoproj.io/sync-wave: "1"
@@ -51,3 +51,23 @@ spec:
         selector: role == 'node'
         ports:
           - 2381
+---
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-prometheus-calico-node-metrics-allow
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  order: 500.0
+  selector: app.kubernetes.io/name == 'prometheus'
+  types:
+    - Egress
+  egress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: role == 'node'
+        ports:
+          - 9091

--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -237,35 +237,23 @@ func testGrafana() {
 			}
 			loadBalancerIP := service.Status.LoadBalancer.Ingress[0].IP
 
-			type res struct {
-				ID int `json:"id"`
-			}
-
-			By("getting data sources from grafana")
-			stdout, stderr, err := ExecAt(boot0, "curl", "-u", "admin:AUJUl1K2xgeqwMdZ3XlEFc1QhgEQItODMNzJwQme", loadBalancerIP+"/api/datasources")
+			By("getting admin stats from grafana")
+			stdout, stderr, err := ExecAt(boot0, "curl", "-u", "admin:AUJUl1K2xgeqwMdZ3XlEFc1QhgEQItODMNzJwQme", loadBalancerIP+"/api/admin/stats")
 			if err != nil {
-				return fmt.Errorf("unable to get data sources, stderr: %s, err: %v", stderr, err)
+				return fmt.Errorf("unable to get admin stats, stderr: %s, err: %v", stderr, err)
 			}
-			var datasources []res
-			err = json.Unmarshal(stdout, &datasources)
+			var adminStats struct {
+				Dashboards  int `json:"dashboards"`
+				Datasources int `json:"datasources"`
+			}
+			err = json.Unmarshal(stdout, &adminStats)
 			if err != nil {
 				return err
 			}
-			if len(datasources) == 0 {
+			if adminStats.Datasources == 0 {
 				return fmt.Errorf("no data sources")
 			}
-
-			By("getting dashboards from grafana")
-			stdout, stderr, err = ExecAt(boot0, "curl", "-u", "admin:AUJUl1K2xgeqwMdZ3XlEFc1QhgEQItODMNzJwQme", loadBalancerIP+"/api/search?folderIds=0&query=&starred=false")
-			if err != nil {
-				return fmt.Errorf("unable to get dashboards, stderr: %s, err: %v", stderr, err)
-			}
-			var dashboards []res
-			err = json.Unmarshal(stdout, &dashboards)
-			if err != nil {
-				return err
-			}
-			if len(dashboards) == 0 {
+			if adminStats.Dashboards == 0 {
 				return fmt.Errorf("no dashboards")
 			}
 			return nil


### PR DESCRIPTION
- Allow prometheus access to cke-etcd's metrics
- Allow prometheus access to felix's metrics
- Fix node-exporter-full.json for provisioning Grafana
- Request 10Gi PV for Grafana and Prometheus on staging environment
- Relaxed etcd alert rules threshold
- Added alert rule using `up` metrics
- Enable to switch etcd cluster on the dashboard