### PR TITLE
Test with neco's feature branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,15 @@ commands:
       - unless:
           condition: <<parameters.neco-release-branch>>
           steps:
-          - run:
-              name: Checkout Neco (specified branch)
-              command: |
-                # If CIRCLE_BRANCH has specified prefix("with-neco-branch-"), change the branch to be cloned.
-                NECO_BRANCH=${CIRCLE_BRANCH#with-neco-branch-}
+            - run:
+                name: Checkout Neco (specified branch)
+                command: |
+                  # If CIRCLE_BRANCH has specified prefix("with-neco-branch-"), change the branch to be cloned.
+                  NECO_BRANCH=${CIRCLE_BRANCH#with-neco-branch-}
 
-                # If there is not NECO_BRANCH branch in the cybozu-go/neco repository, git clone will fail.
-                echo "checkout $NECO_BRANCH"
-                git clone --depth 1 https://github.com/cybozu-go/neco -b $NECO_BRANCH
+                  # If there is not NECO_BRANCH branch in the cybozu-go/neco repository, git clone will fail.
+                  echo "checkout $NECO_BRANCH"
+                  git clone --depth 1 https://github.com/cybozu-go/neco -b $NECO_BRANCH
       - run:
           name: Store Service Account
           command: |
@@ -47,21 +47,21 @@ commands:
       - when:
           condition: <<parameters.neco-release-branch>>
           steps:
-          - run:
-              name: dctest(bootstrap) TAG=release
-              command: |
-                cd neco
-                ./bin/run-dctest.sh bootstrap "" release
-              no_output_timeout: 20m
+            - run:
+                name: dctest(bootstrap) TAG=release
+                command: |
+                  cd neco
+                  ./bin/run-dctest.sh bootstrap release
+                no_output_timeout: 20m
       - unless:
           condition: <<parameters.neco-release-branch>>
           steps:
-          - run:
-              name: dctest(bootstrap) TAG=""
-              command: |
-                cd neco
-                ./bin/run-dctest.sh bootstrap "" ""
-              no_output_timeout: 20m
+            - run:
+                name: dctest(bootstrap) TAG=""
+                command: |
+                  cd neco
+                  ./bin/run-dctest.sh bootstrap
+                no_output_timeout: 20m
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,29 @@ version: 2.1
 commands:
   boot-dctest:
     description: "datacenter test"
+    parameters:
+      neco-release-branch:
+        type: boolean
     steps:
-      - run:
-          name: Checkout Neco
-          command: |
-            git clone --depth 1 https://github.com/cybozu-go/neco -b release
+      - when:
+          condition: <<parameters.neco-release-branch>>
+          steps:
+          - run:
+              name: Checkout Neco (release)
+              command: |
+                git clone --depth 1 https://github.com/cybozu-go/neco -b release
+      - unless:
+          condition: <<parameters.neco-release-branch>>
+          steps:
+          - run:
+              name: Checkout Neco (specified branch)
+              command: |
+                # If CIRCLE_BRANCH has specified prefix("with-neco-branch-"), change the branch to be cloned.
+                NECO_BRANCH=${CIRCLE_BRANCH#with-neco-branch-}
+
+                # If there is not NECO_BRANCH branch in the cybozu-go/neco repository, git clone will fail.
+                echo "checkout $NECO_BRANCH"
+                git clone --depth 1 https://github.com/cybozu-go/neco -b $NECO_BRANCH
       - run:
           name: Store Service Account
           command: |
@@ -26,12 +44,24 @@ commands:
             cd neco
             ./bin/watch_podlogs
           background: true
-      - run:
-          command: |
-            cd neco
-            sed -i 's/^trap/#trap/' bin/run-dctest-release.sh
-            ./bin/run-dctest-release.sh bootstrap
-          no_output_timeout: 20m
+      - when:
+          condition: <<parameters.neco-release-branch>>
+          steps:
+          - run:
+              name: dctest(bootstrap) TAG=release
+              command: |
+                cd neco
+                ./bin/run-dctest.sh bootstrap "" release
+              no_output_timeout: 20m
+      - unless:
+          condition: <<parameters.neco-release-branch>>
+          steps:
+          - run:
+              name: dctest(bootstrap) TAG=""
+              command: |
+                cd neco
+                ./bin/run-dctest.sh bootstrap "" ""
+              no_output_timeout: 20m
 
 jobs:
   test:
@@ -51,9 +81,14 @@ jobs:
   bootstrap:
     docker:
       - image: google/cloud-sdk
+    parameters:
+      neco-release-branch:
+        type: boolean
+        default: true
     steps:
       - checkout
-      - boot-dctest
+      - boot-dctest:
+          neco-release-branch: <<parameters.neco-release-branch>>
       - run:
           name: Test neco-apps
           command: |
@@ -70,9 +105,14 @@ jobs:
   upgrade-master:
     docker:
       - image: google/cloud-sdk
+    parameters:
+      neco-release-branch:
+        type: boolean
+        default: true
     steps:
       - checkout
-      - boot-dctest
+      - boot-dctest:
+          neco-release-branch: <<parameters.neco-release-branch>>
       - run:
           name: Bootstrap neco-apps at master
           command: |
@@ -89,9 +129,14 @@ jobs:
   upgrade-release:
     docker:
       - image: google/cloud-sdk
+    parameters:
+      neco-release-branch:
+        type: boolean
+        default: true
     steps:
       - checkout
-      - boot-dctest
+      - boot-dctest:
+          neco-release-branch: <<parameters.neco-release-branch>>
       - run:
           name: Bootstrap neco-apps at release
           command: |
@@ -153,6 +198,22 @@ workflows:
           filters:
             branches:
               ignore: ["master", "release"]
+      # If branch name has specified prefix("with-neco-branch-hoge-piyo"), testing with the specified neco branch("hoge-piyo").
+      - bootstrap:
+          neco-release-branch: false
+          filters:
+            branches:
+              only: /^with-neco-branch-.*$/
+      - upgrade-master:
+          neco-release-branch: false
+          filters:
+            branches:
+              only: /^with-neco-branch-.*$/
+      - upgrade-release:
+          neco-release-branch: false
+          filters:
+            branches:
+              only: /^with-neco-branch-.*$/
 
   production-release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ commands:
     parameters:
       neco-release-branch:
         type: boolean
+        default: true
     steps:
       - when:
           condition: <<parameters.neco-release-branch>>
@@ -105,14 +106,9 @@ jobs:
   upgrade-master:
     docker:
       - image: google/cloud-sdk
-    parameters:
-      neco-release-branch:
-        type: boolean
-        default: true
     steps:
       - checkout
-      - boot-dctest:
-          neco-release-branch: <<parameters.neco-release-branch>>
+      - boot-dctest
       - run:
           name: Bootstrap neco-apps at master
           command: |
@@ -129,14 +125,9 @@ jobs:
   upgrade-release:
     docker:
       - image: google/cloud-sdk
-    parameters:
-      neco-release-branch:
-        type: boolean
-        default: true
     steps:
       - checkout
-      - boot-dctest:
-          neco-release-branch: <<parameters.neco-release-branch>>
+      - boot-dctest
       - run:
           name: Bootstrap neco-apps at release
           command: |
@@ -200,16 +191,6 @@ workflows:
               ignore: ["master", "release"]
       # If branch name has specified prefix("with-neco-branch-hoge-piyo"), testing with the specified neco branch("hoge-piyo").
       - bootstrap:
-          neco-release-branch: false
-          filters:
-            branches:
-              only: /^with-neco-branch-.*$/
-      - upgrade-master:
-          neco-release-branch: false
-          filters:
-            branches:
-              only: /^with-neco-branch-.*$/
-      - upgrade-release:
           neco-release-branch: false
           filters:
             branches:

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -7,30 +7,43 @@ Overview
 ![overview](http://www.plantuml.com/plantuml/svg/fPJVQzim4CVVzLSSUMeXCRJTZyuFeoFTkZ6wbRQmbq9Hv8kZMPQCT6u8e__xv9ljQY6mj7loMVfyxuTqfxD0qbDR6o4LEG-JStputWH0MsgBw2SWdtu6vXeVDAxxJT__26LSMy3aGjFdTZ61Nm80uguYQKk3CB6et4msJRYp1xShtIaR5tJqk3baJnrmtm7YKIIwc6693B3LE-wZVMqNw2qIXhZI1kgJgax3VKflfVB1bmxcvupAQAlY3pso1uVTIJJ6RMgq5APtTkxiKfUNifa2aifOMZ1nz2BLyOjK9xkgaGOzrTBAigy-NH2Z8YqKPeLRszdxeOGStcQzlGz__4p-P9j__FkA6-yAphmpzhvWXlUyNuPtXLvKJ2sglSCokbVGYEuA6IUa6x5R3AHjoJn5-ry9nB7X4N8DnG3K3rIddC35_AexkvynoE6OQE9qAuEvzYf-vr-OLVodz331DqQgYdT2PwN2ZxNKXhUmiuGOdeRnmiSXXXoEChYK5SBLzHIKgsjDucbxvdMvegWOmaV1SSQd0kGQhM3XfLKhY8sibt4rY94SWdKLvd0ILNuJHNs7WLh5T37b3IufJIw7LndShDmQF8RMa1XUiT5rWhwEPQ0lCKb-eDAUp-5D1ZyanPGRwKchraZV5p65fZLcJ6pRqOnTZNtwFvuILulg6OvsJc_waEHmci4dvzVI5w3jqlbQadPMfD2evCx9uLq6tnpf9TyEzzLkdBjf2-TU4sTeYxOslm40)
 
 - Template based or plain K8s manifests is stored in the neco-apps repository.
-- To verify changed manifests deploy, CI runs deployment to the `neco-apps-release` and `neco-apps-master` instance in the GCP. See details in `neco-apps` section in this file.
+- To verify changed manifests deploy, CI creates some GCP instances and runs bootstrap/upgrade tests on those instances.
 - [Argo CD][] watches changes of this repository, then synchronize(deploy) automatically when new commit detected.
 - After the deployment process finished, [Argo CD][] sends alert to the [Alertmanager][] where is running on the same cluster. Then it notifies to Slack channel and/or Email address.
 
-`neco-apps-*` instance
--------------------
+GCP instance
+------------
 
-`neco-apps-master` and `neco-apps-relase` are Google Compute Engine instance for GitOps testing of this repository. It is automatically created and deleted by [CircleCI scheduled workflow](https://circleci.com/docs/2.0/workflows).
+This repository uses Google Compute Engine instance for GitOps testing. The instances are automatically created and deleted by [CircleCI][] depending on the job contents.
 
-- `neco-apps-master` is used for testing update from master branch HEAD to feature branch
-- `neco-apps-release` is used for testing update from release branch HEAD to feature branch
+The GCP instance name is `neco-apps-<CircleCI Build Number>`. If the job succeeds, the corresponding GCP instance will be deleted immediately. When the job failed, the GCP instance remains for a while.
 
-The following describes an example of timeline based development flow with the Kubernetes cluster in `neco-apps-master` instance.
-This is the same for `neco-apps-release` instance.
+CircleCI Workflow
+-----------------
 
-1. `neco-apps-master`: Launch an instance early morning.
-2. `neco-apps-master`: Construct dctest environment.
-3. `neco-apps-master`: Download and load virtual machine snapshots from Google Cloud Storage.
-4. `neco-apps-master`: Ready as Kubernetes cluster.
-5. `Developer`: Write some code and push commits.
-6. `CircleCI`: Deploy commits to `neco-apps-master` cluster for testing through `Argo CD`.
-7. `neco-apps-master`: Delete an instance at night.
-8. `CircleCI`: CI does not work because of no `neco-apps-master` cluster in this time.
-9. Go back to 1. tomorrow.
+This repository has 2 CircleCI workflows, `main` and `production-release`.
+
+### `main` workflow
+
+`main` workflow is used for testing feature branch of `neco-apps`. This is consists of the following 5 jobs.
+
+| job name          | description                                         | target branch                              |
+| ----------------- | --------------------------------------------------- | ------------------------------------------ |
+| `test`            | Syntax check for go lang                            | all branches                               |
+| `bootstrap-1`     | Bootstrap test                                      | all branches except `master` and `release` |
+| `bootstrap-2`     | Bootstrap test with `neco`'s feature branch         | `with-neco-branch-*` branch                |
+| `upgrade-master`  | Upgrade test from `master` branch (staging env)     | all branches except `master` and `release` |
+| `upgrade-release` | Upgrade test from `release` branch (production env) | all branches except `master` and `release` |
+
+`bootstrap-1`, `upgrade-master` and `upgrade-release` are tested with `neco`'s `release` branch.
+
+`bootstrap-2` is tested with `neco`'s feature branch which extracted from `neco-apps`'s branch name.
+For example, when `with-neco-branch-foo-bar` branch of `neco-apps`, it's tested with `foo-bar` branch of `neco`.
+
+### `production-release` workflow
+
+`production-release` workflow is used for releasing `neco-apps` to a production environment.
+This workflow is executed only when a `release-*` tag is created. And it creates a pull request for the release.
 
 CD of each cluster
 ------------------
@@ -43,3 +56,4 @@ See details of the deployment step in [deploy.md](deploy.md).
 
 [Argo CD]: https://github.com/argoproj/argo-cd
 [Alertmanager]: https://prometheus.io/docs/alerting/alertmanager/
+[CircleCI]: https://circleci.com/


### PR DESCRIPTION
Enable bootstrap test with the `neco`'s feature branch.
When the branch has a specific prefix(`with-neco-branch-`), it's tested with neco feature branch which extracted from neco-apps's branch name.

Example:
When `with-neco-branch-foo-bar` branch of `neco-apps` has pushed, it's tested with `foo-bar` branch of `neco`.