### PR TITLE
[grafana][prometheus] Fix monitoring settings

### DIFF
--- a/monitoring/base/grafana/dashboards/calico.json
+++ b/monitoring/base/grafana/dashboards/calico.json
@@ -1141,8 +1141,8 @@
         "list": []
     },
     "time": {
-        "from": "2017-09-18T04:55:00.138Z",
-        "to": "2017-09-18T06:36:59.405Z"
+        "from": "now-30m",
+        "to": "now"
     },
     "timepicker": {
         "refresh_intervals": [

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -158,6 +158,17 @@ scrape_configs:
         target_label: __address__
       - action: labelmap
         regex: __meta_kubernetes_endpoint_(.+)
+  - job_name: "contour"
+    kubernetes_sd_configs:
+      - role: service
+        namespaces:
+          names: ["ingress"]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name]
+        action: keep
+        regex: contour-metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_(.+)
   - job_name: "ingress"
     kubernetes_sd_configs:
       - role: pod

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -32,10 +32,10 @@ scrape_configs:
     relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_cke_cybozu_com_(.+)
-        replacement: cke.cybozu.com.${1}
+        replacement: cke_${1}
       - action: labelmap
         regex: __meta_kubernetes_node_label_sabakan_cke_cybozu_com_(.+)
-        replacement: sabakan.cke.cybozu.com.${1}
+        replacement: sabakan_${1}
       - target_label: __address__
         replacement: kubernetes.default.svc:443
       - source_labels: [__meta_kubernetes_node_name]

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -31,7 +31,11 @@ scrape_configs:
       - role: node
     relabel_configs:
       - action: labelmap
-        regex: __meta_kubernetes_node_label_(.+)
+        regex: __meta_kubernetes_node_label_cke_cybozu_com_(.+)
+        replacement: cke.cybozu.com.${1}
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_sabakan_cke_cybozu_com_(.+)
+        replacement: sabakan.cke.cybozu.com.${1}
       - target_label: __address__
         replacement: kubernetes.default.svc:443
       - source_labels: [__meta_kubernetes_node_name]
@@ -47,8 +51,6 @@ scrape_configs:
       - action: keep
         source_labels: [__meta_kubernetes_service_name]
         regex: "kube-state-metrics"
-      - action: labelmap
-        regex: __meta_kubernetes_service_(.+)
       - source_labels: [__meta_kubernetes_service_port_name]
         action: keep
         regex: http-metrics
@@ -61,8 +63,6 @@ scrape_configs:
       - action: keep
         source_labels: [__meta_kubernetes_endpoints_name]
         regex: prometheus-node-targets
-      - action: labelmap
-        regex: __meta_kubernetes_endpoint_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: kubernetes_namespace
@@ -78,8 +78,6 @@ scrape_configs:
       - action: keep
         source_labels: [__meta_kubernetes_endpoints_name]
         regex: bootserver-etcd-metrics
-      - action: labelmap
-        regex: __meta_kubernetes_endpoint_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: kubernetes_namespace
@@ -97,8 +95,6 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: ${1}:${2}
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_pod_(.+)
   - job_name: "argocd"
     kubernetes_sd_configs:
       - role: service
@@ -108,8 +104,6 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: keep
         regex: argocd-metrics
-      - action: labelmap
-        regex: __meta_kubernetes_service_(.+)
   - job_name: "cke-etcd"
     kubernetes_sd_configs:
       - role: endpoints
@@ -124,8 +118,6 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}:2381
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_endpoint_(.+)
   - job_name: "calico-node"
     kubernetes_sd_configs:
       - role: pod
@@ -140,8 +132,6 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}:9091
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_endpoint_(.+)
   - job_name: "monitor-hw"
     kubernetes_sd_configs:
       - role: endpoints
@@ -156,8 +146,6 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}:9105
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_endpoint_(.+)
   - job_name: "contour"
     kubernetes_sd_configs:
       - role: service
@@ -167,8 +155,6 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: keep
         regex: contour-metrics
-      - action: labelmap
-        regex: __meta_kubernetes_service_(.+)
   - job_name: "ingress"
     kubernetes_sd_configs:
       - role: pod
@@ -184,8 +170,6 @@ scrape_configs:
         target_label: __metrics_path__
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_format]
         target_label: __param_format
-      - action: labelmap
-        regex: __meta_kubernetes_pod_(.+)
   - job_name: "external-dns"
     kubernetes_sd_configs:
       - role: service
@@ -195,8 +179,6 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: keep
         regex: external-dns-metrics
-      - action: labelmap
-        regex: __meta_kubernetes_service_(.+)
   - job_name: "teleport"
     kubernetes_sd_configs:
       - role: pod
@@ -208,5 +190,3 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: ${1}:${2}
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_pod_(.+)

--- a/monitoring/overlays/stage0/prometheus/statefulset.yaml
+++ b/monitoring/overlays/stage0/prometheus/statefulset.yaml
@@ -13,4 +13,4 @@ spec:
         storageClassName: topolvm-provisioner
         resources:
           requests:
-            storage: 10Gi
+            storage: 150Gi # TODO: tune the storage size if more machines are brought up in DC


### PR DESCRIPTION
- Allow Prometheus to scrape Contour's metrics.
- Fix default time range of Calico dashboard.
- Disable excessive labelmap.
- [stage0] Resize the storage of Prometheus 10Gi to 150Gi