### PR TITLE
[monitoring] Revert alert rule of LogicalDatabaseUsageIncreaseRapidly

### DIFF
--- a/monitoring/base/prometheus/alert_rules.yaml
+++ b/monitoring/base/prometheus/alert_rules.yaml
@@ -44,7 +44,7 @@ groups:
           summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space uses more than 90%"
           runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
       - alert: LogicalDatabaseUsageIncreaseRapidly
-        expr: rate(etcd_mvcc_db_total_size_in_use_in_bytes[1h]) * 3600 > 10000000
+        expr: delta(etcd_mvcc_db_total_size_in_use_in_bytes[1h]) > 30000000
         for: 1m
         labels:
           severity: warning

--- a/monitoring/base/prometheus/test_rules.yaml
+++ b/monitoring/base/prometheus/test_rules.yaml
@@ -116,7 +116,7 @@ tests:
   - interval: 30m
     input_series:
       - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="10.0.0.1:2379", job="etcd", __name__="etcd"}'
-        values: '0 6000000'
+        values: '0+15000001x2'
     alert_rule_test:
       - eval_time: 60m
         alertname: LogicalDatabaseUsageIncreaseRapidly
@@ -126,7 +126,7 @@ tests:
               instance: 10.0.0.1:2379
               severity: warning
             exp_annotations:
-              summary: "10.0.0.1:2379, etcd of etcd DB space increases 12MB/h"
+              summary: "10.0.0.1:2379, etcd of etcd DB space increases 30MB/h"
               runbook: "Please consider to find root causes, and solve the problems"
   - interval: 1m
     input_series:


### PR DESCRIPTION
rate() expects counter but etcd_mvcc_db_total_size_in_use_in_bytes[1h]
is gauge. And the value is possibly decreased by compaction.