### PR TITLE
remove unnecessary lables

### DIFF
--- a/network-policy/base/policies/internet-egress.yaml
+++ b/network-policy/base/policies/internet-egress.yaml
@@ -20,7 +20,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   order: 100.0
-  selector: app.kubernetes.io/name == 'squid' || k8s-app == 'squid'
+  selector: app.kubernetes.io/name == 'squid'
   types:
     - Egress
   egress:
@@ -40,7 +40,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   order: 100.0
-  selector: app.kubernetes.io/name == 'unbound' || k8s-app == 'unbound'
+  selector: app.kubernetes.io/name == 'unbound'
   types:
     - Egress
   egress:

--- a/topolvm/base/namespace.yaml
+++ b/topolvm/base/namespace.yaml
@@ -4,5 +4,4 @@ metadata:
   name: topolvm-system
   labels:
     app.kubernetes.io/name: topolvm-system
-    name: topolvm-system
     control-plane: "true"


### PR DESCRIPTION
This pull request made the following changes.

-  remove `k8s-app` label condition from network policy because such labels are already removed and from deployments.
- remove `name: topolvm-system` label from `topolvm-system` namespace as `topolvm` is no longer use `name` label for `namespaceSelector` in its `MutatingWebhookConfiguration` resource.