### PR TITLE
[monitoring] Enable to scrape Prometheus and Alertmanager

### DIFF
--- a/monitoring/base/alertmanager/deployment.yaml
+++ b/monitoring/base/alertmanager/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: alertmanager
   labels:
     app.kubernetes.io/name: alertmanager
+  annotations:
+    prometheus.io/port: "9093"
 spec:
   replicas: 1
   selector:

--- a/monitoring/base/alertmanager/neco.template
+++ b/monitoring/base/alertmanager/neco.template
@@ -1,3 +1,3 @@
 {{/* print summary, followed by runbook if any */}}
-{{ define "slack.neco.text" }}{{ .CommonAnnotations.summary }}{{ with .CommonAnnotations.runbook }}
+{{ define "slack.neco.text" }}{{ .Annotations.summary }}{{ with .Annotations.runbook }}
 {{ . }}{{ end }}{{ end }}

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -29,13 +29,13 @@ scrape_configs:
         namespaces:
           names: ["monitoring"]
     relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: keep
         regex: alertmanager
       - source_labels: [__address__]
         action: replace
-        regex: ([^:]+)(?::\d+)?
-        replacement: ${1}:9093
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: ${1}:${2}
         target_label: __address__
   - job_name: 'kubernetes-apiservers'
     kubernetes_sd_configs:

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -9,6 +9,34 @@ alerting:
     - targets:
       - alertmanager:9093
 scrape_configs:
+  - job_name: "prometheus"
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ["monitoring"]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: prometheus
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}:9090
+        target_label: __address__
+  - job_name: "alertmanager"
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ["monitoring"]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: alertmanager
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}:9093
+        target_label: __address__
   - job_name: 'kubernetes-apiservers'
     kubernetes_sd_configs:
     - role: endpoints

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -18,10 +18,10 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: prometheus
-      - source_labels: [__address__]
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
-        regex: ([^:]+)(?::\d+)?
-        replacement: ${1}:9090
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: ${1}:${2}
         target_label: __address__
   - job_name: "alertmanager"
     kubernetes_sd_configs:

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -63,7 +63,7 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_port_name]
         action: keep
         regex: http-metrics
-  - job_name: 'machines-endpoints'
+  - job_name: 'node-exporter'
     kubernetes_sd_configs:
       - role: endpoints
         namespaces:

--- a/monitoring/base/prometheus/statefulset.yaml
+++ b/monitoring/base/prometheus/statefulset.yaml
@@ -4,6 +4,8 @@ metadata:
   name: prometheus
   labels:
     app.kubernetes.io/name: prometheus
+  annotations:
+    prometheus.io/port: "9090"
 spec:
   serviceName: prometheus
   selector:


### PR DESCRIPTION
- https://github.com/cybozu-go/neco/issues/527 Use `.Annotations` instead of `.CommonAnnotations` for cases without summary annotation 
- Enable to scrape prometheus and alertmanager pods 
- Rename machines-endpoints targets to node-exporter targets