### PR TITLE
teleport: mount emptyDir on /tmp for teleport-auth

### DIFF
--- a/teleport/base/statefulset.yaml
+++ b/teleport/base/statefulset.yaml
@@ -65,6 +65,8 @@ spec:
           readOnly: true
         - mountPath: /var/lib/teleport
           name: teleport-storage
+        - mountPath: /tmp
+          name: tmp
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
@@ -76,6 +78,8 @@ spec:
       - name: teleport-auth-secret
         secret:
           secretName: teleport-auth-secret
+      - name: tmp
+        emptyDir: {}
       serviceAccountName: teleport
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Fix https://github.com/cybozu-go/neco/issues/542