### PR TITLE
[monitoring] scrape kube-state-metrics's own metrics

### DIFF
--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -90,7 +90,7 @@ scrape_configs:
         regex: "kube-state-metrics"
       - source_labels: [__meta_kubernetes_service_port_name]
         action: keep
-        regex: http-metrics
+        regex: (http-metrics|telemetry)
   - job_name: 'node-exporter'
     kubernetes_sd_configs:
       - role: endpoints


### PR DESCRIPTION
Fix the missing configuration of Prometheus for scraping kube-state-metrics's own metrics.
- The port is configured by [`--telemetry-port`](https://github.com/cybozu/neco-containers/blob/master/kube-state-metrics/Dockerfile#L22).
- The port is already specified in [kube-state-metrics](https://github.com/cybozu-go/neco-apps/blob/master/monitoring/base/kube-state-metrics/service.yaml#L16-L18) service.
