### PR TITLE
[monitoring] allocate 8GB RAM and 2 CPU cores to Prometheus container

### DIFF
--- a/monitoring/overlays/osaka0/prometheus/statefulset.yaml
+++ b/monitoring/overlays/osaka0/prometheus/statefulset.yaml
@@ -11,11 +11,11 @@ spec:
         - name: prometheus
           resources:
             limits:
-              memory: 1Gi
-              cpu: 1
+              memory: 8Gi
+              cpu: 2
             requests:
-              memory: 1Gi
-              cpu: 1
+              memory: 8Gi
+              cpu: 2
   volumeClaimTemplates:
     - metadata:
         name: prometheus-storage-volume

--- a/monitoring/overlays/stage0/prometheus/statefulset.yaml
+++ b/monitoring/overlays/stage0/prometheus/statefulset.yaml
@@ -11,11 +11,11 @@ spec:
         - name: prometheus
           resources:
             limits:
-              memory: 1Gi
-              cpu: 1
+              memory: 8Gi
+              cpu: 2
             requests:
-              memory: 1Gi
-              cpu: 1
+              memory: 8Gi
+              cpu: 2
   volumeClaimTemplates:
     - metadata:
         name: prometheus-storage-volume

--- a/monitoring/overlays/tokyo0/prometheus/statefulset.yaml
+++ b/monitoring/overlays/tokyo0/prometheus/statefulset.yaml
@@ -11,11 +11,11 @@ spec:
         - name: prometheus
           resources:
             limits:
-              memory: 1Gi
-              cpu: 1
+              memory: 8Gi
+              cpu: 2
             requests:
-              memory: 1Gi
-              cpu: 1
+              memory: 8Gi
+              cpu: 2
   volumeClaimTemplates:
     - metadata:
         name: prometheus-storage-volume


### PR DESCRIPTION
According to "Prometheus Up and Running",
8GB of RAM is a good starting point for the environment having 100,000 ingests per second,
and more +1 core should be prepared for Prometheus to compute recording rules and queries.