### PR TITLE
Change the service type of argocd-server

### DIFF
--- a/argocd-config/overlays/osaka0/argocd.yaml
+++ b/argocd-config/overlays/osaka0/argocd.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: argocd
 spec:
   source:
-    targetRevision: stage
-    path: argocd/overlays/stage0
+    path: argocd/overlays/osaka0

--- a/argocd-config/overlays/osaka0/kustomization.yaml
+++ b/argocd-config/overlays/osaka0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
+- argocd.yaml
 - external-dns.yaml
 - metallb.yaml
 - monitoring.yaml

--- a/argocd-config/overlays/tokyo0/argocd.yaml
+++ b/argocd-config/overlays/tokyo0/argocd.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: argocd
 spec:
   source:
-    targetRevision: stage
-    path: argocd/overlays/stage0
+    path: argocd/overlays/tokyo0

--- a/argocd-config/overlays/tokyo0/kustomization.yaml
+++ b/argocd-config/overlays/tokyo0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
+- argocd.yaml
 - external-dns.yaml
 - metallb.yaml
 - monitoring.yaml

--- a/argocd/base/service.yaml
+++ b/argocd/base/service.yaml
@@ -89,4 +89,4 @@ spec:
       targetPort: 8080
   selector:
     app.kubernetes.io/name: argocd-server
-  type: NodePort
+  type: LoadBalancer

--- a/argocd/base/service.yaml
+++ b/argocd/base/service.yaml
@@ -90,25 +90,3 @@ spec:
   selector:
     app.kubernetes.io/name: argocd-server
   type: NodePort
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-lb
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-lb
-spec:
-  ports:
-    - name: http
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-    - name: https
-      port: 443
-      protocol: TCP
-      targetPort: 8080
-  selector:
-    app.kubernetes.io/name: argocd-server
-  type: LoadBalancer

--- a/argocd/base/service.yaml
+++ b/argocd/base/service.yaml
@@ -83,10 +83,12 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 8080
+      nodePort: 32011
     - name: https
       port: 443
       protocol: TCP
       targetPort: 8080
+      nodePort: 32563
   selector:
     app.kubernetes.io/name: argocd-server
-  type: NodePort
+  type: LoadBalancer

--- a/argocd/base/service.yaml
+++ b/argocd/base/service.yaml
@@ -83,12 +83,10 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 8080
-      nodePort: 32011
     - name: https
       port: 443
       protocol: TCP
       targetPort: 8080
-      nodePort: 32563
   selector:
     app.kubernetes.io/name: argocd-server
-  type: LoadBalancer
+  type: NodePort

--- a/argocd/base/service.yaml
+++ b/argocd/base/service.yaml
@@ -90,3 +90,25 @@ spec:
   selector:
     app.kubernetes.io/name: argocd-server
   type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-lb
+    app.kubernetes.io/part-of: argocd
+  name: argocd-server-lb
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server
+  type: LoadBalancer

--- a/argocd/overlays/osaka0/ingressroute.yaml
+++ b/argocd/overlays/osaka0/ingressroute.yaml
@@ -1,0 +1,19 @@
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  virtualhost:
+    fqdn: argocd-server.argocd.osaka0.cybozu-ne.co
+    tls:
+      secretName: argocd-server-tls
+  routes:
+    - match: /
+      timeoutPolicy:
+        request: 2m
+      services:
+        - name: argocd-server
+          port: 80

--- a/argocd/overlays/osaka0/kustomization.yaml
+++ b/argocd/overlays/osaka0/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+resources:
+  - ingressroute.yaml

--- a/argocd/overlays/stage0/ingressroute.yaml
+++ b/argocd/overlays/stage0/ingressroute.yaml
@@ -1,0 +1,19 @@
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  virtualhost:
+    fqdn: argocd-server.argocd.stage0.cybozu-ne.co
+    tls:
+      secretName: argocd-server-tls
+  routes:
+    - match: /
+      timeoutPolicy:
+        request: 2m
+      services:
+        - name: argocd-server
+          port: 80

--- a/argocd/overlays/stage0/kustomization.yaml
+++ b/argocd/overlays/stage0/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+resources:
+  - ingressroute.yaml

--- a/argocd/overlays/tokyo0/ingressroute.yaml
+++ b/argocd/overlays/tokyo0/ingressroute.yaml
@@ -1,0 +1,19 @@
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  virtualhost:
+    fqdn: argocd-server.argocd.tokyo0.cybozu-ne.co
+    tls:
+      secretName: argocd-server-tls
+  routes:
+    - match: /
+      timeoutPolicy:
+        request: 2m
+      services:
+        - name: argocd-server
+          port: 80

--- a/argocd/overlays/tokyo0/kustomization.yaml
+++ b/argocd/overlays/tokyo0/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+resources:
+  - ingressroute.yaml


### PR DESCRIPTION
refs: https://github.com/cybozu-go/neco/issues/585

- Change the service type of argocd-server to LoadBalancer type
- Register a subdomain for argocd-server with Google Cloud DNS by creating an IngressRoute resource.