### PR TITLE
monitroing: Fix wrong labels and missing alerts

### DIFF
--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -15,6 +15,8 @@ Directory tree
 │       └── stage
 │           ├── kustumization.yaml # Argo CD CRD deployment for stage.
 │           └── monitoring.yaml    # overlays for base/monitoring.yaml.
+├─── namespaces # App "namespaces". All namespaces for neco-apps application is managed in this App.
+├─── secrets # App "secrets". This is dummy secrets for testing. Real secret is located in the private repository.
 ├─── monitoring # App "monitoring" deployment manifests.
 |   ├── base
 |   │   ├── deployment.yaml    # Plain manifest files of each K8s object name
@@ -76,3 +78,9 @@ resources:   # It includes all K8s objects for monitoring.
 - deployment.yaml
 - service.yaml
 ```
+
+Caveats
+-------
+
+- Please do not add sensitive secrets in this repository.
+- When you add `Namespace` manifest for new applications except `team-management` App, please put in `namespaces` App, not in new application tree.

--- a/monitoring/base/prometheus/alert_rules.yaml
+++ b/monitoring/base/prometheus/alert_rules.yaml
@@ -68,13 +68,73 @@ groups:
         annotations:
           summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space increases {{ $value | humanize }}B/h"
           runbook: "Please consider to find root causes, and solve the problems"
-      - alert: CKEEtcdMissing
-        expr: absent(up{job="cke-etcd"} == 1)
+      - alert: ArgoCDDown
+        expr: |
+          absent(up{job="argocd"} == 1)
         labels:
           severity: critical
         for: 10m
       - alert: BootserverEtcdMissing
         expr: absent(up{job="bootserver-etcd"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: CalicoNodeDown
+        expr: |
+          absent(up{job="calico-node"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: CKEEtcdMissing
+        expr: absent(up{job="cke-etcd"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: ContourDown
+        expr: |
+          absent(up{job="contour"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: ExternalDNSDown
+        expr: |
+          absent(up{job="external-dns"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: IngressDown
+        expr: |
+          absent(up{job="ingress"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: KubernetesCAdvisorDown
+        expr: |
+          absent(up{job="kubernetes-cadvisor"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: KubernetesNodesDown
+        expr: |
+          absent(up{job="kubernetes-nodes"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: MetalLBDown
+        expr: |
+          absent(up{job="metallb"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: MonitorHWDown
+        expr: |
+          absent(up{job="metallb"} == 1)
+        labels:
+          severity: critical
+        for: 10m
+      - alert: TeleportDown
+        expr: |
+          absent(up{job="teleport"} == 1)
         labels:
           severity: critical
         for: 10m

--- a/monitoring/base/prometheus/kube_prometheus_alert_rules.yaml
+++ b/monitoring/base/prometheus/kube_prometheus_alert_rules.yaml
@@ -208,7 +208,7 @@ groups:
           message: Alertmanager has disappeared from Prometheus target discovery.
           runbook_url: TBD
         expr: |
-          absent(up{job="alertmanager-main",namespace="monitoring"} == 1)
+          absent(up{job="alertmanager",namespace="monitoring"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -24,7 +24,7 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: ${1}
         target_label: __address__
-  - job_name: "alertmanager"
+  - job_name: "alertmanager-main"
     kubernetes_sd_configs:
       - role: pod
         namespaces:

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -16,28 +16,40 @@ scrape_configs:
         namespaces:
           names: ["monitoring"]
     relabel_configs:
+      # Discovered Labels
+      #   __meta_kubernetes_pod_label_app_kubernetes_io_name="prometheus"
+      #   __address__="10.64.13.225:9090"
+      # Expected Target Labels
+      #   job="prometheus"
+      #   instance="10.64.13.225"
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: prometheus
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      - source_labels: [__address__]
         action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
+        regex: ([^:]+)(?::\d+)?
         replacement: ${1}
-        target_label: __address__
-  - job_name: "alertmanager-main"
+        target_label: instance
+  - job_name: "alertmanager"
     kubernetes_sd_configs:
       - role: pod
         namespaces:
           names: ["monitoring"]
     relabel_configs:
+      # Discovered Labels
+      #   __meta_kubernetes_pod_label_app_kubernetes_io_name="alertmanager"
+      #   __address__="10.64.11.130:9093"
+      # Expected Target Labels
+      #   job="alertmanager"
+      #   instance="10.64.11.130"
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: alertmanager
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      - source_labels: [__address__]
         action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
+        regex: ([^:]+)(?::\d+)?
         replacement: ${1}
-        target_label: __address__
+        target_label: instance
   - job_name: 'kubernetes-apiservers'
     kubernetes_sd_configs:
     - role: endpoints
@@ -167,9 +179,21 @@ scrape_configs:
         namespaces:
           names: ["kube-system"]
     relabel_configs:
+      # Discovered Labels
+      #   __meta_kubernetes_endpoints_name="cke-etcd"
+      #   __address__="10.69.1.149:2379"
+      # Expected Target Labels
+      #   job="cke-etcd"
+      #   instance="10.69.1.149"
+      #   __address__="10.69.1.149:2381"
       - source_labels: [__meta_kubernetes_endpoints_name]
         action: keep
         regex: cke-etcd
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
@@ -181,9 +205,21 @@ scrape_configs:
         namespaces:
           names: ["kube-system"]
     relabel_configs:
+      # Discovered Labels
+      #   __meta_kubernetes_pod_label_app_kubernetes_io_name="calico-node"
+      #   __address__="10.69.0.6"
+      # Expected Target Labels
+      #   job="calico-node"
+      #   instance="10.69.0.6"
+      #   __address__="10.69.0.6:9091"
       - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
         action: keep
         regex: calico-node
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
@@ -195,9 +231,19 @@ scrape_configs:
         namespaces:
           names: ["monitoring"]
     relabel_configs:
+      # Discovered Labels
+      #   __address__="10.69.0.204:9100"
+      # Expected Target Labels
+      #   instance="10.69.0.204"
+      #   __address__="10.69.0.204:9105"
       - source_labels: [__meta_kubernetes_endpoints_name]
         action: keep
         regex: prometheus-node-targets
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
@@ -235,11 +281,23 @@ scrape_configs:
         namespaces:
           names: ["ingress"]
     relabel_configs:
+      # Discovered Labels
+      #   __address__="10.64.17.66"
+      #   __meta_kubernetes_pod_annotation_prometheus_io_path="/stats/prometheus"
+      #   __meta_kubernetes_pod_annotation_prometheus_io_format="prometheus"
+      # Expected Target Labels
+      #   __address__="10.64.17.66:8002"
+      #   instance="10.64.17.66"
+      #    __metrics_path__="/stats/prometheus"
+      #    __param_format="prometheus"
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: ${1}:${2}
         target_label: __address__
+      - source_labels: [__address__]
+        action: keep
+        target_label: instance
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
         target_label: __metrics_path__
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_format]
@@ -259,8 +317,21 @@ scrape_configs:
         namespaces:
           names: ["teleport"]
     relabel_configs:
+      # Discovered Labels
+      #   __address__="10.64.15.33:3025"
+      #   __meta_kubernetes_pod_label_app_kubernetes_io_name="teleport"
+      #   __meta_kubernetes_pod_annotation_prometheus_io_port="3020"
+      # Expected Target Labels
+      #   __address__="10.64.15.33:3020"
+      #   job="teleport"
+      #   instance="10.64.15.33"
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: ${1}:${2}
         target_label: __address__
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -150,7 +150,7 @@ scrape_configs:
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: ${1}
+        replacement: ${1}:${2}
         target_label: __address__
   - job_name: "argocd"
     kubernetes_sd_configs:
@@ -173,7 +173,7 @@ scrape_configs:
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
-        replacement: ${1}
+        replacement: ${1}:2381
         target_label: __address__
   - job_name: "calico-node"
     kubernetes_sd_configs:
@@ -187,7 +187,7 @@ scrape_configs:
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
-        replacement: ${1}
+        replacement: ${1}:9091
         target_label: __address__
   - job_name: "monitor-hw"
     kubernetes_sd_configs:
@@ -201,7 +201,7 @@ scrape_configs:
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
-        replacement: ${1}
+        replacement: ${1}:9105
         target_label: __address__
   - job_name: "contour"
     kubernetes_sd_configs:
@@ -238,7 +238,7 @@ scrape_configs:
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: ${1}
+        replacement: ${1}:${2}
         target_label: __address__
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
         target_label: __metrics_path__
@@ -262,5 +262,5 @@ scrape_configs:
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: ${1}
+        replacement: ${1}:${2}
         target_label: __address__

--- a/monitoring/base/prometheus/test_rules.yaml
+++ b/monitoring/base/prometheus/test_rules.yaml
@@ -131,7 +131,7 @@ tests:
               runbook: "Please consider to find root causes, and solve the problems"
   - interval: 1m
     input_series:
-      - series: 'up{job="alertmanager-main"}'
+      - series: 'up{job="alertmanager"}'
         values: '0+0x15'
     alert_rule_test:
       - eval_time: 15m

--- a/monitoring/base/prometheus/test_rules.yaml
+++ b/monitoring/base/prometheus/test_rules.yaml
@@ -131,34 +131,7 @@ tests:
               runbook: "Please consider to find root causes, and solve the problems"
   - interval: 1m
     input_series:
-      - series: 'up{job="foo"}'
-        values: '0+0x10'
-    alert_rule_test:
-      - eval_time: 10m
-        alertname: CKEEtcdMissing
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-  - interval: 1m
-    input_series:
-      - series: 'up{job="foo"}'
-        values: '0+0x10'
-    alert_rule_test:
-      - eval_time: 10m
-        alertname: BootserverEtcdMissing
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-  - interval: 1m
-    input_series:
-      - series: 'up{job="foo"}'
-        values: '0+0x9'
-    alert_rule_test:
-      - eval_time: 9m
-        alertname: BootserverEtcdMissing
-  - interval: 1m
-    input_series:
-      - series: 'up{job="foo"}'
+      - series: 'up{job="alertmanager-main"}'
         values: '0+0x15'
     alert_rule_test:
       - eval_time: 15m
@@ -171,7 +144,94 @@ tests:
               runbook_url: TBD
   - interval: 1m
     input_series:
-      - series: 'up{job="foo"}'
+      - series: 'up{job="argocd"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ArgoCDDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="bootserver-etcd"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BootserverEtcdMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="bootserver-etcd"}'
+        values: '0+0x9'
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: BootserverEtcdMissing
+  - interval: 1m
+    input_series:
+      - series: 'up{job="calico-node"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CalicoNodeDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="cke-etcd"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CKEEtcdMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="calico-node"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CalicoNodeDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="contour"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ContourDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="external-dns"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ExternalDNSDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="ingress"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: IngressDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="kube-state-metrics"}'
         values: '0+0x15'
     alert_rule_test:
       - eval_time: 15m
@@ -184,7 +244,47 @@ tests:
               runbook_url: TBD
   - interval: 1m
     input_series:
-      - series: 'up{job="foo"}'
+      - series: 'up{job="kubernetes-cadvisor"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KubernetesCAdvisorDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="kubernetes-nodes"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KubernetesNodesDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="metallb"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: MetalLBDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="monitor-hw"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: MonitorHWDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+  - interval: 1m
+    input_series:
+      - series: 'up{job="node-exporter"}'
         values: '0+0x15'
     alert_rule_test:
       - eval_time: 15m
@@ -197,7 +297,7 @@ tests:
               runbook_url: TBD
   - interval: 1m
     input_series:
-      - series: 'up{job="foo"}'
+      - series: 'up{job="prometheus"}'
         values: '0+0x15'
     alert_rule_test:
       - eval_time: 15m
@@ -208,6 +308,16 @@ tests:
             exp_annotations:
               message: Prometheus has disappeared from Prometheus target discovery.
               runbook_url: TBD
+  - interval: 1m
+    input_series:
+      - series: 'up{job="teleport"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: TeleportDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="kube-system", pod="calico-node", container="unbound"}'


### PR DESCRIPTION
In this PR https://github.com/cybozu-go/neco-apps/pull/161, some
alert rules are moved to `kube_prometheus_alert_rules.yaml`, This change
drops other alert rules which evaluate `absent(up{job="xx"} == 1)`.
This PR adds missing alert rules when exporters are down.

Also fixes instance label dropped port number.