### PR TITLE
Add internet-egress namespace

### DIFF
--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: internet-egress
+  labels:
+    control-plane: "true"
+    topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/kustomization.yaml
+++ b/namespaces/base/kustomization.yaml
@@ -2,11 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - argocd.yaml
+- elastic.yaml
 - external-dns.yaml
+- ingress.yaml
+- internet-egress.yaml
 - kube-system.yaml
 - metallb.yaml
 - monitoring.yaml
 - teleport.yaml
 - topolvm.yaml
-- ingress.yaml
-- elastic.yaml


### PR DESCRIPTION
internet-egress namespace is used for Squid and Unbound
to connect to the Internet.  To apply network policy w/o
restriction enforced by neco-admission, the namespace
need to have label "control-plane: true".