### PR TITLE
[cert-manager] Update cert-manager to 0.11.1

### DIFF
--- a/cert-manager/base/deployment.yaml
+++ b/cert-manager/base/deployment.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: cainjector
-          image: quay.io/cybozu/cert-manager:0.11.0.1
+          image: quay.io/cybozu/cert-manager:0.11.1.1
           command:
           - cainjector
 ---
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: cert-manager
-          image: quay.io/cybozu/cert-manager:0.11.0.1
+          image: quay.io/cybozu/cert-manager:0.11.1.1
           command:
           - controller
           args:
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
         - name: cert-manager
-          image: quay.io/cybozu/cert-manager:0.11.0.1
+          image: quay.io/cybozu/cert-manager:0.11.1.1
           command:
           - webhook
           volumeMounts:

--- a/cert-manager/base/kustomization.yaml
+++ b/cert-manager/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - upstream/cert-manager.yaml
+  - upstream/cert-manager_nsremoved.yaml
 patches:
   - apiservice.yaml
   - deployment.yaml

--- a/cert-manager/base/rbac.yaml
+++ b/cert-manager/base/rbac.yaml
@@ -1,25 +1,3 @@
-# This manifest refer role which does not exist and does not work
-# This will be deleted at the next cert-manager release
-# For workaround, this refers `view` role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-leaderelection
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.11.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: view 
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -29,7 +7,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.11.0
+    helm.sh/chart: cert-manager-v0.11.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cert-manager/base/upstream/cert-manager_nsremoved.yaml
+++ b/cert-manager/base/upstream/cert-manager_nsremoved.yaml
@@ -5352,10 +5352,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager
+
 
 ---
 ---

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -64,14 +64,14 @@ TBD
 cert-manager
 ------------
 
-Download manifests as follows:
+Download manifests and remove `Namespace` resource from it as follows:
 
 ```console
 wget https://github.com/jetstack/cert-manager/releases/download/vX.Y.Z/cert-manager.yaml
+sed 'N;N;N;N;N;s/apiVersion: v1\nkind: Namespace\nmetadata:\n  name: cert-manager//' cert-manager.yaml > cert-manager_nsremoved.yaml
 ```
 
-Compare each resource by your eyes.
-**Be warned that `cert-manager` namespaces must be replaced with `external-dns`.**
+Note that `cert-manager_nsremoved.yaml` is used for input of `kustomize build`.
 
 external-dns
 ------------


### PR DESCRIPTION
This pull request made the following changes.
- Remove namespace resource as it is managed in a different directory
- Update cert-manager to v0.11.1
- Fix maintenance doc.