### PR TITLE
Fix sync process for cert-manager.

### DIFF
--- a/namespaces/base/kustomization.yaml
+++ b/namespaces/base/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
 - monitoring.yaml
 - teleport.yaml
 - topolvm.yaml
+- cert-manager.yaml
 commonLabels:
   team: neco

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -327,7 +327,14 @@ func applyAndWaitForApplications() {
 
 		// cert-manager often fails to synchronize due to unidentified reasons.
 		Eventually(func() error {
-			stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", "--prune", appName)
+			// It is temporary code for remove Namespace in cert-manager app
+			ExecAt(boot0, "argocd", "app", "sync", "--prune", appName)
+			stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", "--prune", "namespaces")
+			if err != nil {
+				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+
+			stdout, stderr, err = ExecAt(boot0, "argocd", "app", "sync", "--prune", appName)
 			if err != nil {
 				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 			}

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -203,6 +203,17 @@ func testSetup() {
 		})
 	}
 
+	// This is a temporal code. Remove this once after cert-manager application does not manage cert-manager namespace resource.
+	It("should remove APIService", func() {
+		if doUpgrade {
+			stdout, stderr, err := ExecAt(boot0, "argocd", "app", "set", "cert-manager", "--sync-policy", "none")
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+
+			stdout, stderr, err = ExecAt(boot0, "kubectl", "delete", "apiservices", "v1beta1.webhook.cert-manager.io")
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+		}
+	})
+
 	It("should checkout neco-apps repository@"+commitID, func() {
 		ExecSafeAt(boot0, "rm", "-rf", "neco-apps")
 		if !withKind {


### PR DESCRIPTION
As cert-manager namespace accidentally managed by cert-manager Application, CI test always fails now.

To fix the problem above, this pull request made the following changes.
- manage cert-manager namespace by namespaces Application
- fix test