### PR TITLE
Recreate Certificate if CertificateRequest fails

### DIFF
--- a/test/cert-manager_test.go
+++ b/test/cert-manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cybozu-go/log"
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -168,6 +169,10 @@ OUTER:
 
 	reason := targetCertReq.Status.Conditions[0].Reason
 	if reason == "Failed" {
+		log.Error("CertificateRequest failed", map[string]interface{}{
+			"certificate name":         cert.Name,
+			"certificate request name": targetCertReq.Name,
+		})
 		return true, nil
 	}
 	return false, fmt.Errorf("CertificateRequest is not ready")

--- a/test/cert-manager_test.go
+++ b/test/cert-manager_test.go
@@ -112,6 +112,9 @@ spec:
 			}
 
 			for _, st := range cert.Status.Conditions {
+				if st.Type != certmanagerv1alpha2.CertificateConditionReady {
+					continue
+				}
 				if st.Reason != "Ready" {
 					failed, err := isCertificateRequestFailed(cert)
 					if err != nil {
@@ -122,9 +125,9 @@ spec:
 						if err != nil {
 							return err
 						}
-						return fmt.Errorf("recreate Certificate")
+						return fmt.Errorf("Certificate is recreated")
 					}
-					continue
+					return fmt.Errorf("Certificate is not ready")
 				}
 				return nil
 			}

--- a/test/contour_test.go
+++ b/test/contour_test.go
@@ -241,8 +241,7 @@ spec:
 				}
 
 				for _, st := range cert.Status.Conditions {
-					if st.Type != certmanagerv1alpha2.CertificateConditionReady {
-						// Check if recreate Certificate resource is necessary
+					if st.Reason != "Ready" {
 						failed, err := isCertificateRequestFailed(cert)
 						if err != nil {
 							return err
@@ -254,11 +253,9 @@ spec:
 							}
 							return fmt.Errorf("recreate Certificate")
 						}
-						return fmt.Errorf("CertificateRequest is not ready")
+						continue
 					}
-					if st.Status == "True" {
-						return nil
-					}
+					return nil
 				}
 				return errors.New("certificate is not ready")
 			})

--- a/test/contour_test.go
+++ b/test/contour_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -221,6 +222,47 @@ spec:
 				}
 				return nil
 			}).Should(Succeed())
+
+			By("confirming created Certificate")
+			Eventually(func() error {
+				// return checkCertificate("tls", "test-ingress", certificate)
+				stdout, stderr, err := ExecAt(boot0, "kubectl", "get", "-n", "test-ingress", "certificate", "tls", "-o", "json")
+				if err != nil {
+					return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+				}
+
+				var cert certmanagerv1alpha2.Certificate
+				err = json.Unmarshal(stdout, &cert)
+				if err != nil {
+					return err
+				}
+
+				if len(cert.Status.Conditions) == 0 {
+					return errors.New("status not found")
+				}
+
+				for _, st := range cert.Status.Conditions {
+					if st.Type != certmanagerv1alpha2.CertificateConditionReady {
+						// Check if recreate Certificate resource is necessary
+						failed, err := isCertificateRequestFailed(cert)
+						if err != nil {
+							return err
+						}
+						if failed {
+							ExecAt(boot0, "kubectl", "delete", "-n", "test-ingress", "certificate", "tls", "-o", "json")
+							if err != nil {
+								return err
+							}
+							return fmt.Errorf("recreate Certificate")
+						}
+						return fmt.Errorf("CertificateRequest is not ready")
+					}
+					if st.Status == "True" {
+						return nil
+					}
+				}
+				return errors.New("certificate is not ready")
+			})
 		}
 
 		By("accessing with curl: http")

--- a/test/contour_test.go
+++ b/test/contour_test.go
@@ -225,7 +225,6 @@ spec:
 
 			By("confirming created Certificate")
 			Eventually(func() error {
-				// return checkCertificate("tls", "test-ingress", certificate)
 				stdout, stderr, err := ExecAt(boot0, "kubectl", "get", "-n", "test-ingress", "certificate", "tls", "-o", "json")
 				if err != nil {
 					return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)

--- a/test/contour_test.go
+++ b/test/contour_test.go
@@ -241,6 +241,9 @@ spec:
 				}
 
 				for _, st := range cert.Status.Conditions {
+					if st.Type != certmanagerv1alpha2.CertificateConditionReady {
+						continue
+					}
 					if st.Reason != "Ready" {
 						failed, err := isCertificateRequestFailed(cert)
 						if err != nil {
@@ -253,7 +256,7 @@ spec:
 							}
 							return fmt.Errorf("recreate Certificate")
 						}
-						continue
+						return fmt.Errorf("Certificate is not ready")
 					}
 					return nil
 				}


### PR DESCRIPTION
When CertificateRequest fails, `cert-manager` does not retry in 1h.
See [this](https://github.com/jetstack/cert-manager/blob/v0.11.1/pkg/controller/certificates/sync.go#L410-L440)

However, it is too long for our tests and `neco-apps` CIs sometimes fail.
To fix this, this pull request made the following changes.
- recreate Certificate when its CertificateRequest fails
- delete Certificate when `contour-plus` failed to succeed its CertificateRequest.
