### PR TITLE
Add namespace and application for bmc-reverse-proxy.

### DIFF
--- a/app-sync-order.txt
+++ b/app-sync-order.txt
@@ -13,3 +13,4 @@ network-policy
 neco-admission
 team-management
 argocd-ingress
+bmc-reverse-proxy

--- a/argocd-config/base/bmc-reverse-proxy.yaml
+++ b/argocd-config/base/bmc-reverse-proxy.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bmc-reverse-proxy
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
+    targetRevision: release
+    path: bmc-reverse-proxy/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: bmc-reverse-proxy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd-config/base/kustomization.yaml
+++ b/argocd-config/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - argocd-ingress.yaml
 - argocd.yaml
+- bmc-reverse-proxy.yaml
 - cert-manager.yaml
 - elastic.yaml
 - external-dns.yaml

--- a/argocd-config/overlays/gcp/bmc-reverse-proxy.yaml
+++ b/argocd-config/overlays/gcp/bmc-reverse-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bmc-reverse-proxy
+  namespace: argocd
+spec:
+  source:
+    path: bmc-reverse-proxy/overlays/gcp

--- a/argocd-config/overlays/gcp/kustomization.yaml
+++ b/argocd-config/overlays/gcp/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - argocd-ingress.yaml
+- bmc-reverse-proxy.yaml
 - external-dns.yaml
 - monitoring.yaml
 - metallb.yaml

--- a/argocd-config/overlays/kind/bmc-reverse-proxy.yaml
+++ b/argocd-config/overlays/kind/bmc-reverse-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bmc-reverse-proxy
+  namespace: argocd
+spec:
+  source:
+    path: bmc-reverse-proxy/overlays/kind

--- a/argocd-config/overlays/kind/kustomization.yaml
+++ b/argocd-config/overlays/kind/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 patchesStrategicMerge:
 - argocd-ingress.yaml
 - external-dns.yaml
+- bmc-reverse-proxy.yaml
 - cert-manager.yaml
 - ingress.yaml
 - metallb.yaml

--- a/argocd-config/overlays/osaka0/bmc-reverse-proxy.yaml
+++ b/argocd-config/overlays/osaka0/bmc-reverse-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bmc-reverse-proxy
+  namespace: argocd
+spec:
+  source:
+    path: bmc-reverse-proxy/overlays/osaka0

--- a/argocd-config/overlays/osaka0/kustomization.yaml
+++ b/argocd-config/overlays/osaka0/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 patchesStrategicMerge:
 - argocd.yaml
 - argocd-ingress.yaml
+- bmc-reverse-proxy.yaml
 - external-dns.yaml
 - metallb.yaml
 - monitoring.yaml

--- a/argocd-config/overlays/stage0/bmc-reverse-proxy.yaml
+++ b/argocd-config/overlays/stage0/bmc-reverse-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bmc-reverse-proxy
+  namespace: argocd
+spec:
+  source:
+    path: bmc-reverse-proxy/overlays/stage0

--- a/argocd-config/overlays/stage0/kustomization.yaml
+++ b/argocd-config/overlays/stage0/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 patchesStrategicMerge:
 - argocd.yaml
 - argocd-ingress.yaml
+- bmc-reverse-proxy.yaml
 - elastic.yaml
 - external-dns.yaml
 - ingress.yaml

--- a/argocd-config/overlays/tokyo0/bmc-reverse-proxy.yaml
+++ b/argocd-config/overlays/tokyo0/bmc-reverse-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bmc-reverse-proxy
+  namespace: argocd
+spec:
+  source:
+    path: bmc-reverse-proxy/overlays/tokyo0

--- a/argocd-config/overlays/tokyo0/kustomization.yaml
+++ b/argocd-config/overlays/tokyo0/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 patchesStrategicMerge:
 - argocd.yaml
 - argocd-ingress.yaml
+- bmc-reverse-proxy.yaml
 - external-dns.yaml
 - metallb.yaml
 - monitoring.yaml

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/deployment.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bmc-reverse-proxy
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bmc-reverse-proxy
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bmc-reverse-proxy
+    spec:
+      containers:
+        - image: quay.io/cybozu/bmc-reverse-proxy:0.1.1
+          name: bmc-reverse-proxy
+          volumeMounts:
+          - name: secret-fs
+            mountPath: "/etc/bmc-reverse-proxy"
+            readOnly: true
+          ports:
+          - name: web
+            containerPort: 8443
+            protocol: TCP
+          - name: virtual-console
+            containerPort: 5900
+            protocol: TCP
+      volumes:
+        - name: secret-fs
+          secret:
+            secretName: bmc-reverse-proxy-tls
+      serviceAccountName: bmc-reverse-proxy

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/role.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bmc-reverse-proxy
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/rolebinding.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bmc-reverse-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bmc-reverse-proxy
+subjects:
+  - kind: ServiceAccount
+    name: bmc-reverse-proxy
+    namespace: bmc-reverse-proxy

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/service.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: bmc-reverse-proxy
   annotations:
-    metallb.universe.tf/address-pool: internet
+    metallb.universe.tf/address-pool: bastion
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/service.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bmc-reverse-proxy
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
+  annotations:
+    metallb.universe.tf/address-pool: internet
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: web
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    - name: virtual-console
+      port: 5900
+      protocol: TCP
+      targetPort: 5900
+  selector:
+    app.kubernetes.io/name: bmc-reverse-proxy

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/serviceaccount.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bmc-reverse-proxy

--- a/bmc-reverse-proxy/base/kustomization.yaml
+++ b/bmc-reverse-proxy/base/kustomization.yaml
@@ -1,6 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - bmc-reverse-proxy/deployment.yaml
+  - bmc-reverse-proxy/role.yaml
+  - bmc-reverse-proxy/rolebinding.yaml
+  - bmc-reverse-proxy/service.yaml
+  - bmc-reverse-proxy/serviceaccount.yaml
   - machines-endpoints/cronjob.yaml
   - machines-endpoints/role.yaml
   - machines-endpoints/rolebinding.yaml

--- a/bmc-reverse-proxy/base/kustomization.yaml
+++ b/bmc-reverse-proxy/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - machines-endpoints/cronjob.yaml
+  - machines-endpoints/role.yaml
+  - machines-endpoints/rolebinding.yaml
+  - machines-endpoints/serviceaccount.yaml
+  - machines-endpoints/pod-security-policy.yaml

--- a/bmc-reverse-proxy/base/machines-endpoints/cronjob.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: machines-endpoints-cronjob
+  labels:
+    cronjob: machines-endpoints-cronjob
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: machines-endpoints
+              image: quay.io/cybozu/machines-endpoints:0.4.0
+              args:
+                - --bmc-configmap
+              imagePullPolicy: IfNotPresent
+          hostNetwork: true
+          restartPolicy: OnFailure
+          serviceAccountName: machines-endpoints

--- a/bmc-reverse-proxy/base/machines-endpoints/pod-security-policy.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/pod-security-policy.yaml
@@ -1,0 +1,46 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: machines-endpoints-bmc
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true

--- a/bmc-reverse-proxy/base/machines-endpoints/role.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: machines-endpoints
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmap
+    verbs: ["get", "update", "create"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["machines-endpoints-bmc"]

--- a/bmc-reverse-proxy/base/machines-endpoints/role.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-      - configmap
+      - configmaps
     verbs: ["get", "update", "create"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/bmc-reverse-proxy/base/machines-endpoints/rolebinding.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machines-endpoints
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: machines-endpoints
+subjects:
+  - kind: ServiceAccount
+    name: machines-endpoints
+    namespace: bmc-reverse-proxy

--- a/bmc-reverse-proxy/base/machines-endpoints/serviceaccount.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: machines-endpoints

--- a/bmc-reverse-proxy/overlays/gcp/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/gcp/bmc-reverse-proxy/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: bmc-reverse-proxy-tls
+spec:
+  secretName: bmc-reverse-proxy-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: clouddns
+  commonName: "*.bmc.gcp0.dev-ne.co"
+  dnsNames:
+    - "*.bmc.gcp0.dev-ne.co"

--- a/bmc-reverse-proxy/overlays/gcp/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/gcp/bmc-reverse-proxy/certificate.yaml
@@ -1,12 +1,47 @@
 apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: bmc-reverse-proxy-selfsign
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: bmc-reverse-proxy-ca
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
+spec:
+  secretName: bmc-reverse-proxy-ca
+  duration: 87600h0m0s # 10y
+  issuerRef:
+    name: bmc-reverse-proxy-selfsign
+  commonName: "ca.bmc-reverse-proxy"
+  isCA: true
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: bmc-reverse-proxy-ca
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
+spec:
+  ca:
+    secretName: bmc-reverse-proxy-ca
+---
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: bmc-reverse-proxy-tls
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
 spec:
   secretName: bmc-reverse-proxy-tls
+  duration: 8760h0m0s # 1y
   issuerRef:
-    kind: ClusterIssuer
-    name: clouddns
+    name: bmc-reverse-proxy-ca
   commonName: "*.bmc.gcp0.dev-ne.co"
   dnsNames:
     - "*.bmc.gcp0.dev-ne.co"

--- a/bmc-reverse-proxy/overlays/gcp/kustomization.yaml
+++ b/bmc-reverse-proxy/overlays/gcp/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../../base
-patches:
-  - bmc-reverse-proxy/deployment.yaml
-  - machines-endpoints/cronjob.yaml
+resources:
+  - bmc-reverse-proxy/certificate.yaml

--- a/bmc-reverse-proxy/overlays/kind/bmc-reverse-proxy/deployment.yaml
+++ b/bmc-reverse-proxy/overlays/kind/bmc-reverse-proxy/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bmc-reverse-proxy
+  labels:
+    app.kubernetes.io/name: bmc-reverse-proxy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bmc-reverse-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bmc-reverse-proxy
+    spec:
+      containers:
+        - image: quay.io/cybozu/testhttpd:0
+          name: bmc-reverse-proxy

--- a/bmc-reverse-proxy/overlays/kind/kustomization.yaml
+++ b/bmc-reverse-proxy/overlays/kind/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+patches:
+  - machines-endpoints/cronjob.yaml

--- a/bmc-reverse-proxy/overlays/kind/machines-endpoints/cronjob.yaml
+++ b/bmc-reverse-proxy/overlays/kind/machines-endpoints/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: machines-endpoints-cronjob
+  labels:
+    cronjob: machines-endpoints-cronjob
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: machines-endpoints
+              image: quay.io/cybozu/ubuntu:18.04
+              imagePullPolicy: IfNotPresent
+              command:
+              - "true"
+          hostNetwork: false
+          restartPolicy: OnFailure
+          serviceAccountName: machines-endpoints

--- a/bmc-reverse-proxy/overlays/osaka0/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/osaka0/bmc-reverse-proxy/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: bmc-reverse-proxy-tls
+spec:
+  secretName: bmc-reverse-proxy-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: clouddns
+  commonName: "*.bmc.osaka0.cybozu-ne.co"
+  dnsNames:
+    - "*.bmc.osaka0.cybozu-ne.co"

--- a/bmc-reverse-proxy/overlays/osaka0/kustomization.yaml
+++ b/bmc-reverse-proxy/overlays/osaka0/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../../base
-patches:
-  - bmc-reverse-proxy/deployment.yaml
-  - machines-endpoints/cronjob.yaml
+resources:
+  - bmc-reverse-proxy/certificate.yaml

--- a/bmc-reverse-proxy/overlays/stage0/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/stage0/bmc-reverse-proxy/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: bmc-reverse-proxy-tls
+spec:
+  secretName: bmc-reverse-proxy-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: clouddns
+  commonName: "*.bmc.stage0.cybozu-ne.co"
+  dnsNames:
+    - "*.bmc.stage0.cybozu-ne.co"

--- a/bmc-reverse-proxy/overlays/stage0/kustomization.yaml
+++ b/bmc-reverse-proxy/overlays/stage0/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../../base
-patches:
-  - bmc-reverse-proxy/deployment.yaml
-  - machines-endpoints/cronjob.yaml
+resources:
+  - bmc-reverse-proxy/certificate.yaml

--- a/bmc-reverse-proxy/overlays/tokyo0/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/tokyo0/bmc-reverse-proxy/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: bmc-reverse-proxy-tls
+spec:
+  secretName: bmc-reverse-proxy-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: clouddns
+  commonName: "*.bmc.tokyo0.cybozu-ne.co"
+  dnsNames:
+    - "*.bmc.tokyo0.cybozu-ne.co"

--- a/bmc-reverse-proxy/overlays/tokyo0/kustomization.yaml
+++ b/bmc-reverse-proxy/overlays/tokyo0/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../../base
-patches:
-  - bmc-reverse-proxy/deployment.yaml
-  - machines-endpoints/cronjob.yaml
+resources:
+  - bmc-reverse-proxy/certificate.yaml

--- a/monitoring/base/machines-endpoints/cronjob.yaml
+++ b/monitoring/base/machines-endpoints/cronjob.yaml
@@ -12,7 +12,9 @@ spec:
         spec:
           containers:
             - name: machines-endpoints
-              image: quay.io/cybozu/machines-endpoints:0.3.2
+              image: quay.io/cybozu/machines-endpoints:0.4.0
+              args:
+                - --monitoring-endpoints
               imagePullPolicy: IfNotPresent
           hostNetwork: true
           restartPolicy: OnFailure

--- a/namespaces/base/bmc-reverse-proxy.yaml
+++ b/namespaces/base/bmc-reverse-proxy.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bmc-reverse-proxy
+  labels:
+    control-plane: "true"
+spec:
+  finalizers:
+    - kubernetes

--- a/namespaces/base/kustomization.yaml
+++ b/namespaces/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - argocd.yaml
+- bmc-reverse-proxy.yaml
 - elastic.yaml
 - external-dns.yaml
 - ingress.yaml

--- a/network-policy/base/kustomization.yaml
+++ b/network-policy/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - calico/rbac.yaml
   - calico/service.yaml
   - calico/serviceaccount.yaml
+  - policies/bmc-reverse-proxy.yaml
   - policies/ingress.yaml
   - policies/internet-egress.yaml
   - policies/monitoring.yaml

--- a/network-policy/base/policies/bmc-reverse-proxy.yaml
+++ b/network-policy/base/policies/bmc-reverse-proxy.yaml
@@ -1,4 +1,17 @@
 apiVersion: crd.projectcalico.org/v1
+kind: NetworkSet
+metadata:
+  name: bmc
+  namespace: bmc-reverse-proxy
+  labels:
+    role: bmc
+spec:
+  nets:
+    - 10.72.16.0/20
+    - 10.76.16.0/20
+    - 10.78.16.0/20
+---
+apiVersion: crd.projectcalico.org/v1
 kind: NetworkPolicy
 metadata:
   name: egress-bmc-allow

--- a/network-policy/base/policies/bmc-reverse-proxy.yaml
+++ b/network-policy/base/policies/bmc-reverse-proxy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-bmc-allow
+  namespace: bmc-reverse-proxy
+spec:
+  order: 500.0
+  types:
+    - Egress
+  egress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: role == 'bmc'
+        ports:
+          - 443
+          - 5900
+      source:
+        selector: app.kubernetes.io/name == 'bmc-reverse-proxy'
+        namespaceSelector: team == 'neco'

--- a/test/bmc-reverse-proxy_test.go
+++ b/test/bmc-reverse-proxy_test.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func testBMCReverseProxy() {
+	It("should be deployed successfully", func() {
+		Eventually(func() error {
+			stdout, stderr, err := ExecAt(boot0, "kubectl", "--namespace=bmc-reverse-proxy",
+				"get", "deployment", "bmc-reverse-proxy", "-o=json")
+			if err != nil {
+				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+
+			deployment := new(appsv1.Deployment)
+			err = json.Unmarshal(stdout, deployment)
+			if err != nil {
+				return fmt.Errorf("stdout: %s, err: %v", stdout, err)
+			}
+
+			if deployment.Status.AvailableReplicas != 2 {
+				return fmt.Errorf("bmc-reverse-proxy deployment's AvailableReplica is not 2: %d", int(deployment.Status.AvailableReplicas))
+			}
+
+			return nil
+		}).Should(Succeed())
+	})
+
+	It("should create ConfigMap", func() {
+		Eventually(func() error {
+			stdout, stderr, err := ExecAt(boot0, "kubectl", "--namespace=bmc-reverse-proxy",
+				"get", "configmap", "bmc-reverse-proxy", "-o=json")
+			if err != nil {
+				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+
+			cm := new(corev1.ConfigMap)
+			err = json.Unmarshal(stdout, cm)
+			if err != nil {
+				return fmt.Errorf("stdout: %s, err: %v", stdout, err)
+			}
+
+			data := cm.Data
+			if data["rack3-cs4"] != "10.72.17.100" {
+				return fmt.Errorf("bmc-reverse-proxy rack3-cs4 IP Adress is not 10.72.17.100: %s", data["rack3-cs4"])
+			}
+
+			if data["10-69-2-68"] != "10.72.17.100" {
+				return fmt.Errorf("bmc-reverse-proxy 10-69-2-68 IP Adress is not 10.72.17.100: %s", data["10-69-2-68"])
+			}
+
+			if data["168799a36a60da24f934e2adf9e455e25a3ad4ef"] != "10.72.17.100" {
+				return fmt.Errorf("bmc-reverse-proxy 168799a36a60da24f934e2adf9e455e25a3ad4ef IP Adress is not 10.72.17.100: %s", data["168799a36a60da24f934e2adf9e455e25a3ad4ef"])
+			}
+
+			return nil
+		}).Should(Succeed())
+	})
+
+	It("should be accessed via https", func() {
+		Eventually(func() error {
+			stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "bmc-reverse-proxy", "get", "service", "bmc-reverse-proxy",
+				"--output=jsonpath={.status.loadBalancer.ingress[0].ip}")
+			if err != nil {
+				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+			addr := string(stdout)
+
+			cmd := exec.Command("curl", "--fail", "--insecure", "-H", "Host: rack3-cs4.bmc.gcp0.dev-ne.co", fmt.Sprintf("https://%s", addr))
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("output: %s, err: %v", output, err)
+			}
+
+			return nil
+		}).Should(Succeed())
+	})
+}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -67,4 +67,7 @@ var _ = Describe("Test applications", func() {
 		Context("argocd-ingress", testArgoCDIngress)
 	}
 	Context("admission", testAdmission)
+	if !withKind {
+		Context("bmc-reverse-proxy", testBMCReverseProxy)
+	}
 })

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -67,7 +67,8 @@ var _ = Describe("Test applications", func() {
 		Context("argocd-ingress", testArgoCDIngress)
 	}
 	Context("admission", testAdmission)
-	if !withKind {
+	// TODO: When cybozu-go/neco:release branch becomes to use bmc-https-server feature, remove !doUpgrade condition.
+	if !withKind && !doUpgrade {
 		Context("bmc-reverse-proxy", testBMCReverseProxy)
 	}
 })

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -67,8 +67,7 @@ var _ = Describe("Test applications", func() {
 		Context("argocd-ingress", testArgoCDIngress)
 	}
 	Context("admission", testAdmission)
-	// TODO: When cybozu-go/neco:release branch becomes to use bmc-https-server feature, remove !doUpgrade condition.
-	if !withKind && !doUpgrade {
+	if !withKind {
 		Context("bmc-reverse-proxy", testBMCReverseProxy)
 	}
 })


### PR DESCRIPTION
Add namespace and application for bmc-reverse-proxy
Update network policy to let bmc-reverse-proxy in namespace of neco to access to BMC server
Update machines-endpoints version and arguments
