### PR TITLE
team-management: Update ClusterRole to use HTTPProxy

### DIFF
--- a/team-management/base/common/clusterrole.yaml
+++ b/team-management/base/common/clusterrole.yaml
@@ -148,9 +148,9 @@ rules:
   - delete
   - deletecollection
 - apiGroups:
-  - contour.heptio.com
+  - projectcontour.io
   resources:
-  - ingressroutes
+  - httpproxies
   verbs:
   - get
   - list


### PR DESCRIPTION
- Allow using `HTTPProxy` for Neco developers instead of `IngressRoute`.