### PR TITLE
Fix argocd-config to use branch of stage on stage environment.

### DIFF
--- a/argocd-config/overlays/stage0/bmc-reverse-proxy.yaml
+++ b/argocd-config/overlays/stage0/bmc-reverse-proxy.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: argocd
 spec:
   source:
+    targetRevision: stage
     path: bmc-reverse-proxy/overlays/stage0


### PR DESCRIPTION
Set targetRevision parameter for argocd-config to use the branch of `stage` on the stage environment.