### PR TITLE
prometheus: remove unnecessary long failureThreshold

### DIFF
--- a/monitoring/base/prometheus/statefulset.yaml
+++ b/monitoring/base/prometheus/statefulset.yaml
@@ -33,7 +33,6 @@ spec:
               port: 9090
             initialDelaySeconds: 30
             timeoutSeconds: 30
-            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /-/healthy


### PR DESCRIPTION
This `failureThreshold=30` is unnecessary because Prometheus during initializing should be set `NotReady` quickly.