### PR TITLE
bmc-reverse-proxy: remove volumes in kindtest

### DIFF
--- a/bmc-reverse-proxy/overlays/kind/bmc-reverse-proxy/deployment.yaml
+++ b/bmc-reverse-proxy/overlays/kind/bmc-reverse-proxy/deployment.yaml
@@ -16,3 +16,5 @@ spec:
       containers:
         - image: quay.io/cybozu/testhttpd:0
           name: bmc-reverse-proxy
+          volumeMounts: null
+      volumes: null


### PR DESCRIPTION
Remove `volumes` and `volumeMounts` fields from dummy deployment as follows:

```
$ diff -u15 kind-deploy-before.yaml kind-deploy-after.yaml 
--- kind-deploy-before.yaml     2019-12-18 09:12:41.860136271 +0000
+++ kind-deploy-after.yaml      2019-12-18 09:18:06.144451405 +0000
@@ -145,39 +145,31 @@
   template:
     metadata:
       labels:
         app.kubernetes.io/name: bmc-reverse-proxy
     spec:
       containers:
       - image: quay.io/cybozu/testhttpd:0
         name: bmc-reverse-proxy
         ports:
         - containerPort: 8443
           name: web
           protocol: TCP
         - containerPort: 5900
           name: virtual-console
           protocol: TCP
-        volumeMounts:
-        - mountPath: /etc/bmc-reverse-proxy
-          name: secret-fs
-          readOnly: true
       serviceAccountName: bmc-reverse-proxy
-      volumes:
-      - name: secret-fs
-        secret:
-          secretName: bmc-reverse-proxy-tls
 ---
```