### PR TITLE
ingress: fix imagePullPolicy of envoy's init container.

### DIFF
--- a/ingress/base/template/deployment.yaml
+++ b/ingress/base/template/deployment.yaml
@@ -206,7 +206,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: quay.io/cybozu/contour:1.0.1.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:
         - mountPath: /config


### PR DESCRIPTION
Check all "image:" and "imagePullPolicy" in the staging environment, and fix inappropriate ones.

```
for r in deployment daemonset statefulset; do kubectl get $r -A -o yaml | grep image: ; done
for r in deployment daemonset statefulset; do kubectl get $r -A -o yaml | grep imagePullPolicy: ; done
```

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>