### PR TITLE
test: extend Eventually() timeout mainly for reboot test.

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -24,7 +24,7 @@ var _ = BeforeSuite(func() {
 	fmt.Println("Preparing...")
 
 	SetDefaultEventuallyPollingInterval(time.Second)
-	SetDefaultEventuallyTimeout(10 * time.Minute)
+	SetDefaultEventuallyTimeout(30 * time.Minute)
 
 	prepare()
 


### PR DESCRIPTION
Pulling a container image sometimes gets stuck in the reboot test.
This seems to be a temporary problem caused by the instability of the HTTP proxy.
It takes ~16 minutes to be solved due to `net.ipv4.tcp_retries2` in Linux, so this PR extends the default timeout of `Eventually()` to 30 minutes.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>