### PR TITLE
prometheus: fix target configuration

### DIFF
--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -328,34 +328,15 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}
         target_label: instance
-  - job_name: "envoy"
-    kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names: ["ingress-global", "ingress-forest", "ingress-bastion"]
-    relabel_configs:
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_service_name]
-        action: keep
-        regex: contour-metrics
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        action: keep
-        regex: envoy-metrics
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-        target_label: __metrics_path__
-      - source_labels: [__address__]
-        action: replace
-        regex: ([^:]+)(?::\d+)?
-        replacement: ${1}
-        target_label: instance
-  - job_name: "ingress"
+  - job_name: "contour-envoy"
     kubernetes_sd_configs:
       - role: pod
         namespaces:
           names: ["ingress-global", "ingress-forest", "ingress-bastion"]
     relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: envoy
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: kubernetes_namespace

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -97,6 +97,11 @@ scrape_configs:
       action: replace
       regex: ([^:]+)(?::\d+)?
       replacement: ${1}:10252
+      target_label: __address__
+    - source_labels: [__address__]
+      action: replace
+      regex: ([^:]+)(?::\d+)?
+      replacement: ${1}
       target_label: instance
   - job_name: 'kubernetes-scheduler'
     kubernetes_sd_configs:
@@ -112,6 +117,11 @@ scrape_configs:
       action: replace
       regex: ([^:]+)(?::\d+)?
       replacement: ${1}:10251
+      target_label: __address__
+    - source_labels: [__address__]
+      action: replace
+      regex: ([^:]+)(?::\d+)?
+      replacement: ${1}
       target_label: instance
   - job_name: 'kubernetes-nodes'
     scheme: https

--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -365,6 +365,8 @@ func testMetrics() {
 						if target.Health != promv1.HealthGood {
 							return fmt.Errorf("target is not up, job_name: %s", jobName)
 						}
+					} else {
+						return fmt.Errorf("target is not found, job_name: %s", jobName)
 					}
 				}
 			}


### PR DESCRIPTION
1. Fix Prometheus configuration:
    - Fix scheduler/controller-manager target.
    - Rename ingress target to contour-envoy target.
    - Remove envoy target since it is not used.
1. Fix test to make sure all targets are `up`.
