### PR TITLE
[monitoring] Add alert rules for the applications.

### DIFF
--- a/monitoring/base/prometheus/README.md
+++ b/monitoring/base/prometheus/README.md
@@ -45,6 +45,15 @@ $ promtool test rules ./test/alert_test/*.yaml
 $ promtool test rules ./test/alert_test/argocd.yaml
 ```
 
+Severity Levels
+---------------
+
+All alert rules should have the `severity` labels. This label indicates the level of the severity of the alert.
+
+- `warning`: Investigate to decide whether any action is required.
+- `minor`: Action is required, but the situation is not serious at this time.
+- `critical`: Action is required immediately because the problem gets worse. Investigate and resolve the causes of alert as soon as possible.
+
 Notice
 ------
 

--- a/monitoring/base/prometheus/alert_rules/argocd.yaml
+++ b/monitoring/base/prometheus/alert_rules/argocd.yaml
@@ -5,7 +5,7 @@ groups:
         expr: argocd_app_sync_status{sync_status="Synced",project="default"} == 0
         for: 20m
         labels:
-          severity: page
+          severity: minor
         annotations:
           summary: "{{ $labels.exported_name }} is out-of-sync."
           runbook: "See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync"
@@ -13,7 +13,7 @@ groups:
         expr: |
           absent(up{job="argocd"} == 1)
         labels:
-          severity: critical
+          severity: minor
         for: 10m
         annotations:
           summary: ArgoCD has disappeared from Prometheus target discovery.

--- a/monitoring/base/prometheus/alert_rules/cert-manager.yaml
+++ b/monitoring/base/prometheus/alert_rules/cert-manager.yaml
@@ -7,6 +7,13 @@ groups:
             runbook: TBD
           expr: |
             absent(up{job="cert-manager"} == 1)
-          for: 15m
+          for: 10m
           labels:
             severity: critical
+        - alert: CertificateDoesNotReady
+          expr: |
+            certmanager_certificate_ready_status{condition="False"} > 0
+          for: 10m
+          annotations:
+            summary: Certificate resource does not ready.
+            runbook: Please check the status of Cert Manager and Certificate resources.

--- a/monitoring/base/prometheus/alert_rules/cert-manager.yaml
+++ b/monitoring/base/prometheus/alert_rules/cert-manager.yaml
@@ -9,11 +9,13 @@ groups:
             absent(up{job="cert-manager"} == 1)
           for: 10m
           labels:
-            severity: critical
+            severity: minor
         - alert: CertificateDoesNotReady
           expr: |
             certmanager_certificate_ready_status{condition="False"} > 0
           for: 10m
+          labels:
+            severity: minor
           annotations:
             summary: Certificate resource does not ready.
             runbook: Please check the status of Cert Manager and Certificate resources.

--- a/monitoring/base/prometheus/alert_rules/elastic-operator.yaml
+++ b/monitoring/base/prometheus/alert_rules/elastic-operator.yaml
@@ -9,4 +9,4 @@ groups:
             absent(up{job="elastic-operator"} == 1)
           for: 15m
           labels:
-            severity: critical
+            severity: minor

--- a/monitoring/base/prometheus/alert_rules/etcd.yaml
+++ b/monitoring/base/prometheus/alert_rules/etcd.yaml
@@ -5,7 +5,7 @@ groups:
         expr: etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes > 0.80
         for: 1m
         labels:
-          severity: warning
+          severity: minor
         annotations:
           summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space uses more than 80%"
           runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
@@ -13,7 +13,7 @@ groups:
         expr: etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes > 0.90
         for: 1m
         labels:
-          severity: critical
+          severity: minor
         annotations:
           summary: "{{ $labels.instance }}, {{ $labels.job }} of etcd DB space uses more than 90%"
           runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"

--- a/monitoring/base/prometheus/alert_rules/external-dns.yaml
+++ b/monitoring/base/prometheus/alert_rules/external-dns.yaml
@@ -10,3 +10,21 @@ groups:
         annotations:
           summary: ExternalDNS has disappeared from Prometheus target discovery.
           runbook: Please consider to find root causes, and solve the problems
+      - alert: ExternalDNSRegistryError
+        expr: |
+          rate(external_dns_registry_errors_total[5m]) > 0
+        labels:
+          severity: critical
+        for: 30m
+        annotations:
+          summary: Registrations of DNS Endpoints return error.
+          runbook: Please check the status of External DNS.
+      - alert: ExternalDNSEndpointsError
+        expr: |
+          rate(external_dns_source_errors_total[5m]) > 0
+        labels:
+          severity: critical
+        for: 10m
+        annotations:
+          summary: Endpoints corresponding to a DNS name return error.
+          runbook: Please check the status of backend Endpoints of DNS names.

--- a/monitoring/base/prometheus/alert_rules/external-dns.yaml
+++ b/monitoring/base/prometheus/alert_rules/external-dns.yaml
@@ -5,7 +5,7 @@ groups:
         expr: |
           absent(up{job="external-dns"} == 1)
         labels:
-          severity: critical
+          severity: minor
         for: 10m
         annotations:
           summary: ExternalDNS has disappeared from Prometheus target discovery.
@@ -14,7 +14,7 @@ groups:
         expr: |
           rate(external_dns_registry_errors_total[5m]) > 0
         labels:
-          severity: critical
+          severity: minor
         for: 30m
         annotations:
           summary: Registrations of DNS Endpoints return error.
@@ -23,7 +23,7 @@ groups:
         expr: |
           rate(external_dns_source_errors_total[5m]) > 0
         labels:
-          severity: critical
+          severity: minor
         for: 10m
         annotations:
           summary: Endpoints corresponding to a DNS name return error.

--- a/monitoring/base/prometheus/alert_rules/ingress.yaml
+++ b/monitoring/base/prometheus/alert_rules/ingress.yaml
@@ -59,7 +59,7 @@ groups:
         expr: |
           rate(contour_httpproxy_invalid_total[5m]) > 0
         labels:
-          severity: critical
+          severity: minor
         for: 10m
         annotations:
           summary: Invalid HTTPProxy resource exists.

--- a/monitoring/base/prometheus/alert_rules/ingress.yaml
+++ b/monitoring/base/prometheus/alert_rules/ingress.yaml
@@ -55,3 +55,12 @@ groups:
         annotations:
           summary: Ingress has disappeared from Prometheus target discovery.
           runbook: Please consider to find root causes, and solve the problems
+      - alert: InvalidHTTPProxyExist
+        expr: |
+          rate(contour_httpproxy_invalid_total[5m]) > 0
+        labels:
+          severity: critical
+        for: 10m
+        annotations:
+          summary: Invalid HTTPProxy resource exists.
+          runbook: Please check the status of HTTPProxy.

--- a/monitoring/base/prometheus/alert_rules/kube-state-metrics.yaml
+++ b/monitoring/base/prometheus/alert_rules/kube-state-metrics.yaml
@@ -13,7 +13,7 @@ groups:
       > 0.01
     for: 15m
     labels:
-      severity: critical
+      severity: minor
   - alert: KubeStateMetricsWatchErrors
     annotations:
       message: kube-state-metrics is experiencing errors at an elevated rate in watch
@@ -26,4 +26,4 @@ groups:
       > 0.01
     for: 15m
     labels:
-      severity: critical
+      severity: minor

--- a/monitoring/base/prometheus/alert_rules/kubernetes.yaml
+++ b/monitoring/base/prometheus/alert_rules/kubernetes.yaml
@@ -211,12 +211,12 @@ groups:
           absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubernetesCAdvisorDown
         expr: |
           absent(up{job="kubernetes-cadvisor"} == 1)
         labels:
-          severity: critical
+          severity: minor
         for: 10m
         annotations:
           summary: KubernetesCAdvisor has disappeared from Prometheus target discovery.
@@ -259,7 +259,7 @@ groups:
           rate(kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace!~"maneki|sandbox"}[15m]) * 60 * 5 > 0
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubePodNotReady
         annotations:
           summary: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
@@ -269,7 +269,7 @@ groups:
           sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown",namespace!~"maneki|sandbox"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job"}) > 0
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeDeploymentGenerationMismatch
         annotations:
           summary: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -282,7 +282,7 @@ groups:
           kube_deployment_metadata_generation{job="kube-state-metrics",namespace!~"maneki|sandbox"}
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeDeploymentReplicasMismatch
         annotations:
           summary: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
@@ -294,7 +294,7 @@ groups:
           kube_deployment_status_replicas_available{job="kube-state-metrics",namespace!~"maneki|sandbox"}
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeStatefulSetReplicasMismatch
         annotations:
           summary: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
@@ -306,7 +306,7 @@ groups:
           kube_statefulset_status_replicas{job="kube-state-metrics",namespace!~"maneki|sandbox"}
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeStatefulSetGenerationMismatch
         annotations:
           summary: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -319,7 +319,7 @@ groups:
           kube_statefulset_metadata_generation{job="kube-state-metrics",namespace!~"maneki|sandbox"}
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeStatefulSetUpdateNotRolledOut
         annotations:
           summary: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
@@ -339,7 +339,7 @@ groups:
           )
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeDaemonSetRolloutStuck
         annotations:
           summary: Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace
@@ -351,7 +351,7 @@ groups:
           kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics",namespace!~"maneki|sandbox"} * 100 < 100
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeDaemonSetNotScheduled
         annotations:
           summary: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
@@ -363,7 +363,7 @@ groups:
           kube_daemonset_status_current_number_scheduled{job="kube-state-metrics",namespace!~"maneki|sandbox"} > 0
         for: 10m
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeDaemonSetMisScheduled
         annotations:
           summary: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
@@ -373,7 +373,7 @@ groups:
           kube_daemonset_status_number_misscheduled{job="kube-state-metrics",namespace!~"maneki|sandbox"} > 0
         for: 10m
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeCronJobRunning
         annotations:
           summary: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
@@ -402,7 +402,7 @@ groups:
           kube_job_failed{job="kube-state-metrics",namespace!~"maneki|sandbox"}  > 0
         for: 15m
         labels:
-          severity: warning
+          severity: minor
   - name: kubernetes-system
     rules:
       - alert: KubeNodeNotReady
@@ -413,7 +413,7 @@ groups:
           kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
         for: 15m
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeVersionMismatch
         annotations:
           summary: There are {{ $value }} different semantic versions of Kubernetes
@@ -445,7 +445,7 @@ groups:
           100 * max(max(kubelet_running_pod_count{job="kubernetes-nodes"}) by(instance) * on(instance) group_left(node) kubelet_node_name{job="kubernetes-nodes"}) by(node) / max(kube_node_status_capacity_pods{job="kube-state-metrics"}) by(node) > 95
         for: 15m
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeAPILatencyHigh
         annotations:
           summary: The API server has a 99th percentile latency of {{ $value }} seconds
@@ -465,7 +465,7 @@ groups:
           cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="kubernetes-apiservers",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
         for: 10m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeAPIErrorsHigh
         annotations:
           summary: API server is returning errors for {{ $value }}% of requests.
@@ -487,7 +487,7 @@ groups:
           sum(rate(apiserver_request_total{job="kubernetes-apiservers"}[5m])) * 100 > 1
         for: 10m
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeAPIErrorsHigh
         annotations:
           summary: API server is returning errors for {{ $value }}% of requests for
@@ -499,7 +499,7 @@ groups:
           sum(rate(apiserver_request_total{job="kubernetes-apiservers"}[5m])) by (resource,subresource,verb) * 100 > 10
         for: 10m
         labels:
-          severity: critical
+          severity: minor
       - alert: KubeAPIErrorsHigh
         annotations:
           summary: API server is returning errors for {{ $value }}% of requests for
@@ -511,7 +511,7 @@ groups:
           sum(rate(apiserver_request_total{job="kubernetes-apiservers"}[5m])) by (resource,subresource,verb) * 100 > 5
         for: 10m
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeClientCertificateExpiration
         annotations:
           summary: A client certificate used to authenticate to the apiserver is expiring
@@ -520,7 +520,7 @@ groups:
         expr: |
           apiserver_client_certificate_expiration_seconds_count{job="kubernetes-apiservers"} > 0 and histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="kubernetes-apiservers"}[5m]))) < 604800
         labels:
-          severity: warning
+          severity: minor
       - alert: KubeClientCertificateExpiration
         annotations:
           summary: A client certificate used to authenticate to the apiserver is expiring
@@ -529,7 +529,7 @@ groups:
         expr: |
           apiserver_client_certificate_expiration_seconds_count{job="kubernetes-apiservers"} > 0 and histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="kubernetes-apiservers"}[5m]))) < 86400
         labels:
-          severity: critical
+          severity: minor
       - alert: K8sAPIServersDegraded
         expr: count(up{job="kubernetes-apiservers"} == 1) < 3
         labels:
@@ -558,7 +558,7 @@ groups:
         expr: delta(kubelet_volume_stats_used_bytes[10m]) / (1024 * 1024 * 1024) > 10
         for: 1m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Disk usage of `{{ $labels.persistentvolumeclaim }}, {{ $labels.namespace }}` increases rapidly over 10GiB in 10 minutes.
           runbook: TBD

--- a/monitoring/base/prometheus/alert_rules/metallb.yaml
+++ b/monitoring/base/prometheus/alert_rules/metallb.yaml
@@ -10,3 +10,29 @@ groups:
         annotations:
           summary: MetalLB has disappeared from Prometheus target discovery.
           runbook: Please consider to find root causes, and solve the problems
+      - alert: MetalLBBGPSessionDown
+        expr: |
+          metallb_bgp_session_up == 0
+        labels:
+          severity: critical
+        for: 10m
+        annotations:
+          summary: BGP session of MetalLB down.
+          runbook: Please check the status of MetalLB.
+      - alert: MetalLBConfigStale
+        expr: |
+          metallb_k8s_client_config_stale_bool != 0               
+        for: 10m                                                          
+        annotations:                                     
+          description: '{{ $labels.instance }}: MetalLB instance has stale configuration.'
+          summary: '{{ $labels.instance }}: MetalLB stale configuration.'
+      - alert: MetalLBAddressPoolHighUtilization
+        expr: |
+          (sum((metallb_allocator_addresses_in_use_total / metallb_allocator_addresses_total)) by (pool)
+          / count(metallb_allocator_addresses_in_use_total) by (pool) * 100) > 75
+        labels:
+          severity: critical
+        for: 10m
+        annotations:
+          description: Address Pool of MetalLB will be exhausted.
+          runbook: Please re-consider the address allocation planning.

--- a/monitoring/base/prometheus/alert_rules/metallb.yaml
+++ b/monitoring/base/prometheus/alert_rules/metallb.yaml
@@ -22,8 +22,10 @@ groups:
       - alert: MetalLBConfigStale
         expr: |
           metallb_k8s_client_config_stale_bool != 0               
-        for: 10m                                                          
-        annotations:                                     
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
           description: '{{ $labels.instance }}: MetalLB instance has stale configuration.'
           summary: '{{ $labels.instance }}: MetalLB stale configuration.'
       - alert: MetalLBAddressPoolHighUtilization
@@ -31,7 +33,7 @@ groups:
           (sum((metallb_allocator_addresses_in_use_total / metallb_allocator_addresses_total)) by (pool)
           / count(metallb_allocator_addresses_in_use_total) by (pool) * 100) > 75
         labels:
-          severity: critical
+          severity: warning
         for: 10m
         annotations:
           description: Address Pool of MetalLB will be exhausted.

--- a/monitoring/base/prometheus/alert_rules/monitoring.yaml
+++ b/monitoring/base/prometheus/alert_rules/monitoring.yaml
@@ -9,7 +9,7 @@ groups:
           absent(up{job="alertmanager"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: PrometheusDown
         annotations:
           summary: Prometheus has disappeared from Prometheus target discovery.
@@ -18,4 +18,4 @@ groups:
           absent(up{job="prometheus"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: minor

--- a/monitoring/base/prometheus/alert_rules/network-policy.yaml
+++ b/monitoring/base/prometheus/alert_rules/network-policy.yaml
@@ -9,4 +9,25 @@ groups:
         for: 10m
         annotations:
           summary: CalicoNode has disappeared from Prometheus target discovery.
-          runbook: Please consider to find root causes, and solve the problems
+          runbook: Please consider to find root causes, and solve the problems.
+      - alert: CalicoDataplaneApplyTime
+        expr: |
+          felix_int_dataplane_apply_time_seconds{quantile="0.9"} * 1000 > 100
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: Applying Calico dataplane takes long time (over 100ms).
+          runbook: Please check the status of Calico components.
+      - alert: CalicoDataplaneFailures
+        expr: |
+          rate(felix_int_dataplane_failures[5m]) > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: Applying Calico dataplane has some errors.
+          runbook: Please check the status of Calico components.
+
+
+          

--- a/monitoring/base/prometheus/alert_rules/node.yaml
+++ b/monitoring/base/prometheus/alert_rules/node.yaml
@@ -9,12 +9,12 @@ groups:
           absent(up{job="node-exporter"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: minor
       - alert: MonitorHWDown
         expr: |
           absent(up{job="metallb"} == 1)
         labels:
-          severity: critical
+          severity: minor
         for: 10m
         annotations:
           summary: MonitorHW has disappeared from Prometheus target discovery.
@@ -24,7 +24,7 @@ groups:
           (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) * 100 > 75
         for: 1h
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: Conntrack entries will be reach limit.
           runbook: Please re-configure the limit or plan some solutions.

--- a/monitoring/base/prometheus/alert_rules/node.yaml
+++ b/monitoring/base/prometheus/alert_rules/node.yaml
@@ -19,3 +19,12 @@ groups:
         annotations:
           summary: MonitorHW has disappeared from Prometheus target discovery.
           runbook: Please consider to find root causes, and solve the problems
+      - alert: ConntrackEntriesReachLimit
+        expr: |
+          (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) * 100 > 75
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: Conntrack entries will be reach limit.
+          runbook: Please re-configure the limit or plan some solutions.

--- a/monitoring/base/prometheus/alert_rules/topolvm.yaml
+++ b/monitoring/base/prometheus/alert_rules/topolvm.yaml
@@ -1,2 +1,21 @@
 groups:
   - name: topolvm
+    rules:
+      - alert: AvailableBytesHighUtilizationInShortTerm
+        expr: |
+          sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24)) without (instance,node) <= 0
+        labels:
+          severity: critical
+        for: 10m
+        annotations:
+          summary: Total available bytes of CS nodes will be exhausted in 1 day.
+          runbook: Please check the disk utilization of applications and contact the developer team.
+      - alert: AvailableBytesHighUtilizationInLongTerm
+        expr: |
+          sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24*30)) without (instance,node) <= 0
+        labels:
+          severity: critical
+        for: 1h
+        annotations:
+          summary: Total available bytes of CS nodes will be exhausted in 1 month.
+          runbook: Please consider the disk allocation policy and the equipment planning.

--- a/monitoring/base/prometheus/alert_rules/topolvm.yaml
+++ b/monitoring/base/prometheus/alert_rules/topolvm.yaml
@@ -5,7 +5,7 @@ groups:
         expr: |
           sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24)) without (instance,node) <= 0
         labels:
-          severity: critical
+          severity: warning
         for: 10m
         annotations:
           summary: Total available bytes of CS nodes will be exhausted in 1 day.
@@ -14,7 +14,7 @@ groups:
         expr: |
           sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24*30)) without (instance,node) <= 0
         labels:
-          severity: critical
+          severity: warning
         for: 1h
         annotations:
           summary: Total available bytes of CS nodes will be exhausted in 1 month.

--- a/test/alert_test/argocd.yaml
+++ b/test/alert_test/argocd.yaml
@@ -16,7 +16,7 @@ tests:
         exp_alerts:
           - exp_labels:
               exported_name: monitoring
-              severity: page
+              severity: minor
               sync_status: Synced
               project: default
             exp_annotations:
@@ -24,7 +24,7 @@ tests:
               runbook: See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync
           - exp_labels:
               exported_name: metallb
-              severity: page
+              severity: minor
               sync_status: Synced
               project: default
             exp_annotations:
@@ -39,7 +39,7 @@ tests:
         alertname: ArgoCDDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: Please consider to find root causes, and solve the problems
               summary: ArgoCD has disappeared from Prometheus target discovery.

--- a/test/alert_test/etcd.yaml
+++ b/test/alert_test/etcd.yaml
@@ -15,7 +15,7 @@ tests:
           - exp_labels:
               job: etcd
               instance: 10.0.0.1:2379
-              severity: warning
+              severity: minor
             exp_annotations:
               summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 80%"
               runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
@@ -32,14 +32,14 @@ tests:
           - exp_labels:
               job: etcd
               instance: 10.0.0.1:2379
-              severity: warning
+              severity: minor
             exp_annotations:
               summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 80%"
               runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"
           - exp_labels:
               job: etcd
               instance: 10.0.0.1:2379
-              severity: critical
+              severity: minor
             exp_annotations:
               summary: "10.0.0.1:2379, etcd of etcd DB space uses more than 90%"
               runbook: "Please consider manual compaction and defrag. https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md"

--- a/test/alert_test/external-dns.yaml
+++ b/test/alert_test/external-dns.yaml
@@ -11,7 +11,7 @@ tests:
         alertname: ExternalDNSDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: Please consider to find root causes, and solve the problems
               summary: ExternalDNS has disappeared from Prometheus target discovery.

--- a/test/alert_test/kubernetes.yaml
+++ b/test/alert_test/kubernetes.yaml
@@ -60,7 +60,7 @@ tests:
         alertname: KubeStateMetricsDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: KubeStateMetrics has disappeared from Prometheus target discovery.
@@ -73,7 +73,7 @@ tests:
         alertname: KubernetesCAdvisorDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: Please consider to find root causes, and solve the problems
               summary: KubernetesCAdvisor has disappeared from Prometheus target discovery.
@@ -99,7 +99,7 @@ tests:
         alertname: KubePodCrashLooping
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: kube-system
               pod: calico-node
@@ -130,7 +130,7 @@ tests:
         alertname: KubePodNotReady
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               namespace: kube-system
               pod: calico-node
             exp_annotations:
@@ -147,7 +147,7 @@ tests:
         alertname: KubeDeploymentGenerationMismatch
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: kube-system
               deployment: a
@@ -165,7 +165,7 @@ tests:
         alertname: KubeDeploymentReplicasMismatch
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: monitoring
               deployment: alertmanager
@@ -183,7 +183,7 @@ tests:
         alertname: KubeStatefulSetReplicasMismatch
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: monitoring
               statefulset: prometheus
@@ -201,7 +201,7 @@ tests:
         alertname: KubeStatefulSetGenerationMismatch
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: monitoring
               statefulset: prometheus
@@ -237,7 +237,7 @@ tests:
         alertname: KubeStatefulSetUpdateNotRolledOut
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: monitoring
               statefulset: prometheus
@@ -255,7 +255,7 @@ tests:
         alertname: KubeDaemonSetRolloutStuck
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kube-state-metrics
               namespace: kube-system
               daemonset: calico-node
@@ -273,7 +273,7 @@ tests:
         alertname: KubeDaemonSetNotScheduled
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: minor
               job: kube-state-metrics
               namespace: kube-system
               daemonset: calico-node
@@ -289,7 +289,7 @@ tests:
         alertname: KubeDaemonSetMisScheduled
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: minor
               namespace: default
               job: kube-state-metrics
               daemonset: test-ds
@@ -339,7 +339,7 @@ tests:
         alertname: KubeJobFailed
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: minor
               namespace: default
               job: kube-state-metrics
               job_name: test-job
@@ -355,7 +355,7 @@ tests:
         alertname: KubeNodeNotReady
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: minor
               condition: Ready
               job: kube-state-metrics
               node: 10.0.0.1
@@ -413,7 +413,7 @@ tests:
         exp_alerts:
           - exp_labels:
               node: node-a
-              severity: warning
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: Kubelet 'node-a' is running at 96% of its Pod capacity.
@@ -447,7 +447,7 @@ tests:
               quantile: 0.99
               verb: GET
               resource: foo
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: The API server has a 99th percentile latency of 4.1 seconds for GET foo.
@@ -471,7 +471,7 @@ tests:
         alertname: KubeAPIErrorsHigh
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: API server is returning errors for 2% of requests.
@@ -486,12 +486,12 @@ tests:
         alertname: KubeAPIErrorsHigh
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: API server is returning errors for 20% of requests.
           - exp_labels:
-              severity: warning
+              severity: critical
             exp_annotations:
               runbook: TBD
               summary: API server is returning errors for 20% of requests.
@@ -499,7 +499,7 @@ tests:
               verb: GET
               resource: foo
               subresource: bar
-              severity: warning
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: API server is returning errors for 20% of requests for GET foo bar.
@@ -507,7 +507,7 @@ tests:
               verb: GET
               resource: foo
               subresource: bar
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: API server is returning errors for 20% of requests for GET foo bar.
@@ -534,13 +534,13 @@ tests:
         alertname: KubeClientCertificateExpiration
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: minor
               job: kubernetes-apiservers
             exp_annotations:
               runbook: TBD
               summary: A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.
           - exp_labels:
-              severity: critical
+              severity: minor
               job: kubernetes-apiservers
             exp_annotations:
               runbook: TBD
@@ -597,7 +597,7 @@ tests:
         alertname: PersistentVolumeUsageRapidIncrease
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: warning
               job: prometheus
               namespace: bar
               persistentvolumeclaim: volume2
@@ -605,7 +605,7 @@ tests:
               runbook: TBD
               summary: Disk usage of `volume2, bar` increases rapidly over 10GiB in 10 minutes.
           - exp_labels:
-              severity: critical
+              severity: warning
               job: prometheus
               namespace: foobar
               persistentvolumeclaim: volume4

--- a/test/alert_test/metallb.yaml
+++ b/test/alert_test/metallb.yaml
@@ -30,7 +30,7 @@ tests:
         alertname: MetalLBAddressPoolHighUtilization
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: warning
               pool: a
             exp_annotations:
               description: Address Pool of MetalLB will be exhausted.

--- a/test/alert_test/metallb.yaml
+++ b/test/alert_test/metallb.yaml
@@ -15,3 +15,23 @@ tests:
             exp_annotations:
               runbook: Please consider to find root causes, and solve the problems
               summary: MetalLB has disappeared from Prometheus target discovery.
+  - interval: 1m
+    input_series:
+      - series: 'metallb_allocator_addresses_in_use_total{pool="a"}'
+        values: '76+0x10'
+      - series: 'metallb_allocator_addresses_in_use_total{pool="b"}'
+        values: '75+0x10'
+      - series: 'metallb_allocator_addresses_total{pool="a"}'
+        values: '100+0x10'
+      - series: 'metallb_allocator_addresses_total{pool="b"}'
+        values: '100+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: MetalLBAddressPoolHighUtilization
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              pool: a
+            exp_annotations:
+              description: Address Pool of MetalLB will be exhausted.
+              runbook: Please re-consider the address allocation planning.

--- a/test/alert_test/monitoring.yaml
+++ b/test/alert_test/monitoring.yaml
@@ -10,7 +10,7 @@ tests:
         alertname: AlertmanagerDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: Alertmanager has disappeared from Prometheus target discovery.
@@ -23,7 +23,7 @@ tests:
         alertname: PrometheusDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: Prometheus has disappeared from Prometheus target discovery.

--- a/test/alert_test/network-policy.yaml
+++ b/test/alert_test/network-policy.yaml
@@ -13,5 +13,5 @@ tests:
           - exp_labels:
               severity: critical
             exp_annotations:
-              runbook: Please consider to find root causes, and solve the problems
+              runbook: Please consider to find root causes, and solve the problems.
               summary: CalicoNode has disappeared from Prometheus target discovery.

--- a/test/alert_test/node.yaml
+++ b/test/alert_test/node.yaml
@@ -11,7 +11,7 @@ tests:
         alertname: NodeExporterDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: TBD
               summary: NodeExporter has disappeared from Prometheus target discovery.
@@ -24,7 +24,7 @@ tests:
         alertname: MonitorHWDown
         exp_alerts:
           - exp_labels:
-              severity: critical
+              severity: minor
             exp_annotations:
               runbook: Please consider to find root causes, and solve the problems
               summary: MonitorHW has disappeared from Prometheus target discovery.


### PR DESCRIPTION
Add alert rules for applications on Kubernetes.
The generic rules are already exists in neco-apps, so this PR introduces application specific alert rules.

In addition, set the policy for the `severity` label.

---

#### external-dns
- Alert if registry has any errors
- Alert if dns endpoints have any errors

#### cert-manager
- Alert if the status of Certificate is not Ready

#### contour
- Alert if the count of invalid httpproxy resources is increasing

#### metallb
- Alert if any BGP sessions are down
- Alert if configurations are stale
- Alert if the address pool will be exhausted

#### network policy
- Alert if the time to apply data plane become slowly
- Alert if the count of errors in data plane is increasing

#### node-exporter
- Alert if the count of conntrack entries will be exhausted

#### topolvm
- Alert if the disk size in the whole of cluster will be exhausted

