### PR TITLE
Add metrics settings of local-pv-provisioner

### DIFF
--- a/local-pv-provisioner/base/daemonset.yaml
+++ b/local-pv-provisioner/base/daemonset.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: local-pv-provisioner
+      annotations:
+        prometheus.io/port: "8080"
     spec:
       containers:
         - name: local-pv-provisioner
@@ -33,6 +35,11 @@ spec:
             runAsUser: 0
             runAsGroup: 0
             privileged: true
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+              scheme: HTTP
       serviceAccountName: local-pv-provisioner
       volumes:
         - name: dev

--- a/monitoring/base/grafana/configmap.yaml
+++ b/monitoring/base/grafana/configmap.yaml
@@ -130,6 +130,13 @@ data:
       editable: false
       options:
         path: /var/lib/grafana/dashboards/topolvm-volumegroup
+    - name: 'local-pv-provisioner'
+      folder: ''
+      type: file
+      disableDeletion: false
+      editable: false
+      options:
+        path: /var/lib/grafana/dashboards/local-pv-provisioner
     - name: 'all-nodes'
       folder: ''
       type: file

--- a/monitoring/base/grafana/dashboards/local-pv-provisioner.json
+++ b/monitoring/base/grafana/dashboards/local-pv-provisioner.json
@@ -1,0 +1,256 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 18,
+    "iteration": 1578989589528,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 3,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "local_pv_provisioner_available_devices{node=~\"$node\"}",
+            "legendFormat": "{{node}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Available Devices",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "none",
+            "label": "",
+            "logBase": 1,
+            "max": "20",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 8
+        },
+        "hiddenSeries": false,
+        "id": 4,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "local_pv_provisioner_error_devices{node=~\"$node\"}",
+            "legendFormat": "{{node}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Error Devices",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "none",
+            "label": "",
+            "logBase": 1,
+            "max": "20",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "schemaVersion": 21,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(local_pv_provisioner_available_devices, node)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Node",
+          "multi": false,
+          "name": "node",
+          "options": [],
+          "query": "label_values(local_pv_provisioner_available_devices, node)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": "local-pv-provisioner devices",
+    "uid": "In7tvBPZz",
+    "version": 2
+  }

--- a/monitoring/base/grafana/statefulset.yaml
+++ b/monitoring/base/grafana/statefulset.yaml
@@ -121,6 +121,8 @@ spec:
               mountPath: /var/lib/grafana/dashboards/cpu-usage
             - name: dashboard-topolvm-volumegroup-volume
               mountPath: /var/lib/grafana/dashboards/topolvm-volumegroup
+            - name: dashboard-local-pv-provisioner-volume
+              mountPath: /var/lib/grafana/dashboards/local-pv-provisioner
             - name: dashboard-all-nodes-volume
               mountPath: /var/lib/grafana/dashboards/all-nodes
             - name: dashboard-node-exporter-volume
@@ -187,6 +189,9 @@ spec:
         - name: dashboard-topolvm-volumegroup-volume
           configMap:
             name: dashboard-topolvm-volumegroup
+        - name: dashboard-local-pv-provisioner-volume
+          configMap:
+            name: dashboard-local-pv-provisioner
         - name: dashboard-all-nodes-volume
           configMap:
             name: dashboard-all-nodes

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -84,6 +84,9 @@ configMapGenerator:
   - name: dashboard-topolvm-volumegroup
     files:
       - grafana/dashboards/topolvm_volumegroup.json
+  - name: dashboard-local-pv-provisioner
+    files:
+      - grafana/dashboards/local-pv-provisioner.json
   - name: dashboard-all-nodes
     files:
       - grafana/dashboards/all_nodes.json

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -452,3 +452,22 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}
         target_label: instance
+  - job_name: "local-pv-provisioner"
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ["kube-system"]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: local-pv-provisioner$
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: ${1}:${2}
+        target_label: __address__
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance

--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -291,7 +291,7 @@ func testGrafana() {
 
 			// NOTE: expectedNum is the number of JSON files under monitoring/base/grafana/dashboards + 1(Node Exporter Full).
 			// Node Exporter Full is downloaded every time from the Internet because too large to store into configMap.
-			expectedNum := 16
+			expectedNum := 17
 			if len(dashboards) != expectedNum {
 				return fmt.Errorf("len(dashboards) should be %d: %d", expectedNum, len(dashboards))
 			}


### PR DESCRIPTION
Add a dashboard for local-pv-provisioner for watching the following metrics.

- `local_pv_provisioner_available_devices`
- `local_pv_provisioner_error_devices`

https://github.com/cybozu/neco-containers/tree/master/local-pv-provisioner#prometheus-metrics