### PR TITLE
monitoring: Fix the type of grafana svc

### DIFF
--- a/monitoring/base/grafana/service.yaml
+++ b/monitoring/base/grafana/service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: grafana
   namespace: monitoring
 spec:
-  type: LoadBalancer
   ports:
   - name: service
     port: 80
@@ -14,5 +13,3 @@ spec:
     targetPort: 3000
   selector:
     app.kubernetes.io/name: grafana
-status:
-  loadBalancer: {}

--- a/monitoring/overlays/gcp/grafana/service.yaml
+++ b/monitoring/overlays/gcp/grafana/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  type: LoadBalancer

--- a/monitoring/overlays/gcp/kustomization.yaml
+++ b/monitoring/overlays/gcp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
   - ../../base
 patches:
+  - grafana/service.yaml
   - prometheus/statefulset.yaml
 configMapGenerator:
   - name: alertmanager

--- a/monitoring/overlays/kind/grafana/service.yaml
+++ b/monitoring/overlays/kind/grafana/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  type: LoadBalancer

--- a/monitoring/overlays/kind/kustomization.yaml
+++ b/monitoring/overlays/kind/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
   - ../../base
 patches:
+  - grafana/service.yaml
   - grafana/statefulset.yaml
   - prometheus/statefulset.yaml
   - machines-endpoints/cronjob.yaml


### PR DESCRIPTION
The Grafana is now published using `HTTPProxy`.
So, `grafana` svc need not be `type LoadBalancer` in stage and production environments.

But in gcp and kind, it should still be `type LoadBalancer` for debugging.