### PR TITLE
circleci: skip kindtest if op-* branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,11 @@ workflows:
       - kindtest:
           filters:
             branches:
-              ignore: ["master", "stage", "release"]
+              ignore:
+                - master
+                - stage
+                - release
+                - /^op-(stage|release)-.*/
 
   manual-dctest:
     jobs:

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -28,10 +28,10 @@ This repository has 4 CircleCI workflows, `main`, `daily`, `manual-dctest` and `
 
 `main` workflow is used for testing feature branch of `neco-apps`. This consists of the following 2 jobs.
 
-| job name   | description              | target branch                                        |
-| ---------- | ------------------------ | ---------------------------------------------------- |
-| `test`     | Syntax check for go lang | all branches                                         |
-| `kindtest` | Bootstrap test on kind   | all branches except `master`, `stage`, and `release` |
+| job name   | description              | target branch                                                                     |
+| ---------- | ------------------------ | --------------------------------------------------------------------------------- |
+| `test`     | Syntax check for go lang | all branches                                                                      |
+| `kindtest` | Bootstrap test on kind   | all branches except `master`, `stage`, `release`, `op-release-*` and `op-stage-*` |
 
 ### `daily` workflow
 


### PR DESCRIPTION
`op-stage-*` and `op-release-*` branches are created by `create-pull-request` jobs.
Always they passed `manual-dctest` and `kindtest`, so they can skip `kindtest` in `main` workflow.