### PR TITLE
team-management: remove default limits for sandbox and app-misc

### DIFF
--- a/team-management/base/maneki/app-misc.yaml
+++ b/team-management/base/maneki/app-misc.yaml
@@ -13,9 +13,6 @@ spec:
       defaultRequest:
         cpu: 100m
         memory: 10Mi
-      default:
-        cpu: 200m
-        memory: 100Mi
       max:
         cpu: 20
         memory: 100Gi

--- a/team-management/base/sandbox/sandbox.yaml
+++ b/team-management/base/sandbox/sandbox.yaml
@@ -13,9 +13,6 @@ spec:
       defaultRequest:
         cpu: 100m
         memory: 10Mi
-      default:
-        cpu: 200m
-        memory: 100Mi
       max:
         cpu: 8
         memory: 16Gi


### PR DESCRIPTION
Remove default `resources.limit` because it is annoyed when expanding `resources.request`.
If the default settings are deleted, the max limit is used.