### PR TITLE
test: use "cp" instead of "ln -s" in preparation for overwriting.

### DIFF
--- a/test/Makefile.dctest
+++ b/test/Makefile.dctest
@@ -7,12 +7,11 @@ dctest-reboot: install.yaml
 	REBOOT=1 ./test.sh
 
 dctest-upgrade:
-	rm -f ./argocd-password.txt
 	-git worktree remove /tmp/neco-apps
 	git worktree add /tmp/neco-apps $(BASE_BRANCH)
 	cp account.json /tmp/neco-apps/test
 	cd /tmp/neco-apps/test; make test-apps BOOTSTRAP=1 COMMIT_ID=$(BASE_BRANCH)
-	ln -s /tmp/neco-apps/test/argocd-password.txt
+	cp /tmp/neco-apps/test/argocd-password.txt ./
 	UPGRADE=1 ./test.sh
 
 .PHONY: dctest dctest-reboot dctest-upgrade


### PR DESCRIPTION
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>