### PR TITLE
topolvm: upgrade to 0.3.0

### DIFF
--- a/test/Makefile.kindtest
+++ b/test/Makefile.kindtest
@@ -1,7 +1,7 @@
 include Makefile
 
 KIND_NODE_VERSION = 1.16
-TOPOLVM_VERSION = 0.2.2
+TOPOLVM_VERSION = 0.3.0
 TOPOLVM_STORAGE_SIZE = 20G
 
 /tmp/kindtest/scheduler/scheduler-config.yaml: kind/scheduler-config.yaml

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -272,15 +272,6 @@ func applyAndWaitForApplications(overlay string) {
 		return nil
 	}).Should(Succeed())
 
-	// TODO: remove this block after merging commit where neco-developer is deleted
-	if doUpgrade {
-		_, _, err := ExecAt(boot0, "kubectl", "get", "clusterrole", "neco-developer")
-		if err == nil {
-			ExecSafeAt(boot0, "argocd", "app", "set", "team-management", "--sync-policy", "none")
-			ExecSafeAt(boot0, "kubectl", "delete", "clusterrole", "neco-developer")
-		}
-	}
-
 	ExecSafeAt(boot0, "cd", "./neco-apps", "&&", "argocd", "app", "sync", "argocd-config", "--local", "argocd-config/overlays/"+overlay)
 
 	By("getting application list")
@@ -314,10 +305,9 @@ func applyAndWaitForApplications(overlay string) {
 	fmt.Printf("application list: %v\n", appList)
 	Expect(appList).ShouldNot(HaveLen(0))
 
-	// TODO: Remove this block after `maneki-apps` project have been pruned
+	// TODO: Remove this block after CSIDriver is updated on release branch.
 	if doUpgrade {
-		stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", "--prune", "team-management")
-		Expect(err).ShouldNot(HaveOccurred(), "stdout:%s, stderr:%s", stdout, stderr)
+		ExecSafeAt(boot0, "argocd", "app", "sync", "topolvm", "--force")
 	}
 
 	By("waiting initialization")

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -307,7 +307,13 @@ func applyAndWaitForApplications(overlay string) {
 
 	// TODO: Remove this block after CSIDriver is updated on release branch.
 	if doUpgrade {
-		ExecSafeAt(boot0, "argocd", "app", "sync", "topolvm", "--force")
+		Eventually(func() error {
+			stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", "topolvm", "--force")
+			if err != nil {
+				return fmt.Errorf("unable to sync --force topolvm; stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+			return nil
+		}).Should(Succeed())
 	}
 
 	By("waiting initialization")

--- a/topolvm/base/upstream/controller.yaml
+++ b/topolvm/base/upstream/controller.yaml
@@ -5,6 +5,10 @@ metadata:
   name: topolvm.cybozu.com
 spec:
   attachRequired: true
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
 
 ---
 apiVersion: v1

--- a/topolvm/base/upstream/controller.yaml
+++ b/topolvm/base/upstream/controller.yaml
@@ -244,7 +244,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: topolvm-controller
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /topolvm-controller
             - --cert-dir=/certs
@@ -272,7 +272,7 @@ spec:
               mountPath: /certs
 
         - name: csi-provisioner
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /csi-provisioner
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -285,7 +285,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-attacher
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /csi-attacher
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -297,7 +297,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: liveness-probe
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /livenessprobe
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/topolvm/base/upstream/node.yaml
+++ b/topolvm/base/upstream/node.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: node
       containers:
         - name: topolvm-node
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           securityContext:
             privileged: true
           command:
@@ -92,7 +92,7 @@ spec:
               mountPropagation: "Bidirectional"
 
         - name: csi-registrar
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /csi-node-driver-registrar
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -108,7 +108,7 @@ spec:
               mountPath: /registration
 
         - name: liveness-probe
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /livenessprobe
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/topolvm/base/upstream/scheduler.yaml
+++ b/topolvm/base/upstream/scheduler.yaml
@@ -50,7 +50,7 @@ spec:
       serviceAccountName: topolvm-scheduler
       containers:
         - name: topolvm-scheduler
-          image: quay.io/cybozu/topolvm:0.2.2
+          image: quay.io/cybozu/topolvm:0.3.0
           command:
             - /topolvm-scheduler
             - --listen=localhost:9251


### PR DESCRIPTION
- Upgrade topolvm to 0.3.0.
- Use force sync because `CSIDriver` cannot be patched.
- Remove some obsoleted setup code.