### PR TITLE
ingress: update envoy to v1.12.3

### DIFF
--- a/ingress/base/template/deployment.yaml
+++ b/ingress/base/template/deployment.yaml
@@ -160,7 +160,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: quay.io/cybozu/envoy:1.12.2.2
+        image: quay.io/cybozu/envoy:1.12.3.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:


### PR DESCRIPTION
- Update envoy to v1.12.3 as the vulnerability response.
ref: https://www.envoyproxy.io/docs/envoy/v1.12.3/intro/version_history