### PR TITLE
monitoring: Add scraping rule for Calico typha.

### DIFF
--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -313,6 +313,25 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}:9091
         target_label: __address__
+  - job_name: "calico-typha"
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ["kube-system"]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+        action: keep
+        regex: calico-typha
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}:9093
+        target_label: __address__
   - job_name: "monitor-hw"
     kubernetes_sd_configs:
       - role: endpoints

--- a/network-policy/base/calico/deployment.yaml
+++ b/network-policy/base/calico/deployment.yaml
@@ -19,5 +19,3 @@ spec:
             value: "veth"
           - name: TYPHA_PROMETHEUSMETRICSENABLED
             value: "true"
-          - name: TYPHA_PROMETHEUSMETRICSPORT
-            value: "9093"


### PR DESCRIPTION
This PR adds scraping config for calico typha.
Alert rules for typha are going to be written in another task.