### PR TITLE
Add async flag

### DIFF
--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -272,7 +272,7 @@ func applyAndWaitForApplications(overlay string) {
 		return nil
 	}).Should(Succeed())
 
-	ExecSafeAt(boot0, "cd", "./neco-apps", "&&", "argocd", "app", "sync", "argocd-config", "--local", "argocd-config/overlays/"+overlay)
+	ExecSafeAt(boot0, "cd", "./neco-apps", "&&", "argocd", "app", "sync", "argocd-config", "--local", "argocd-config/overlays/"+overlay, "--async")
 
 	By("getting application list")
 	stdout, _, err := kustomizeBuild("../argocd-config/overlays/" + overlay)


### PR DESCRIPTION
`argocd app sync argocd-config --local argocd-config/overlays/gcp` takes a lot of time as `app sync` blocks until the sync process is complete.
Therefore, executing the command above with `ExecSafeAt()` function often causes  timeout error like [this](https://circleci.com/gh/cybozu-go/neco-apps/8401).

To avoid this problem,  add `async` flag for the command to return as soon as the sync request was received by the API server.

Application statuses eventually become healthy [here](https://github.com/cybozu-go/neco-apps/blob/master/test/setup_test.go#L308-L351), so this change will not have side effects.   
