### PR TITLE
local-pv-provisioner: allow emptyDir in PSP.

### DIFF
--- a/local-pv-provisioner/base/podsecuritypolicy.yaml
+++ b/local-pv-provisioner/base/podsecuritypolicy.yaml
@@ -8,6 +8,8 @@ spec:
   volumes:
     - 'secret'
     - 'hostPath'
+    # emptyDir is not used in DaemonSet manifest, but added by neco-admission webhook
+    - 'emptyDir'
   allowedHostPaths:
   - pathPrefix: "/dev"
     readOnly: true


### PR DESCRIPTION
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>