### PR TITLE
CI: remove upgrade-master job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,20 +165,6 @@ jobs:
           no_output_timeout: 31m
       - delete-instance
 
-  upgrade-master:
-    docker:
-      - image: google/cloud-sdk
-    steps:
-      - checkout
-      - boot-dctest
-      - run:
-          name: Bootstrap neco-apps at master
-          command: |
-            export NECO_DIR=$(pwd)/neco
-            TARGET=dctest-upgrade ./bin/run-test.sh
-          no_output_timeout: 31m
-      - delete-instance
-
   upgrade-stage:
     docker:
       - image: google/cloud-sdk
@@ -314,12 +300,6 @@ workflows:
           name: bootstrap
           requires:
             - hold
-      - upgrade-master:
-          requires:
-            - hold
-          filters:
-            branches:
-              ignore: ["master", "stage", "release", /^op-(stage|release)-.*/]
       - upgrade-release:
           requires:
             - hold

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -22,7 +22,7 @@ The GCP instance name is `neco-apps-<CircleCI Build Number>`. If the job succeed
 CircleCI Workflow
 -----------------
 
-This repository has 4 CircleCI workflows, `main`, `daily`, `manual-dctest` and `production-release`.
+This repository has 4 CircleCI workflows: `main`, `daily`, `manual-dctest` and `manual-dctest-with-neco-feature-branch`.
 
 ### `main` workflow
 
@@ -50,15 +50,13 @@ This repository has 4 CircleCI workflows, `main`, `daily`, `manual-dctest` and `
 
 `manual-dctest` workflow is not executed automatically.  This provides full-scale test for all branches, which can be triggered from Web UI.
 
-This consists of the following 6 jobs.
+This consists of the following 3 jobs.
 
 | job name                    | description                                                                            | target branch                                                                     |
 | --------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | `bootstrap`                 | Bootstrap test on GCP instances                                                        | all branches                                                                      |
-| `upgrade-master`            | Upgrade test from `master` branch                                                      | all branches except `master`, `stage`, `release`, `op-release-*` and `op-stage-*` |
 | `upgrade-stage`             | Upgrade test from `stage` branch (staging env)                                         | all branches                                                                      |
 | `upgrade-release`           | Upgrade test from `release` branch (production env)                                    | all branches                                                                      |
-| `create-pull-request-stage` | Create PR to stage, then trigger `create-pull-request-stage` of the secret repository. | `master`                                                                          |
 
 ### `manual-dctest-with-neco-feature-branch` workflow
 


### PR DESCRIPTION
Because there are no environments running at master branch.