### PR TITLE
monitoring: fix to allow signout from GUI

### DIFF
--- a/monitoring/base/grafana-operator/grafana.yaml
+++ b/monitoring/base/grafana-operator/grafana.yaml
@@ -19,7 +19,7 @@ spec:
       level: "warn"
     auth:
       disable_login_form: false
-      disable_signout_menu: true
+      disable_signout_menu: false
     auth.anonymous:
       enabled: false
     auth.github:


### PR DESCRIPTION
This PR fixes `disable_signout_menu` unexpectedly introduced in
https://github.com/cybozu-go/neco-apps/pull/510

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>