### PR TITLE
monitoring: fix metrics name for Argo CD >= 1.5.0.

### DIFF
--- a/monitoring/base/prometheus/alert_rules/argocd.yaml
+++ b/monitoring/base/prometheus/alert_rules/argocd.yaml
@@ -2,7 +2,7 @@ groups:
   - name: argocd-config
     rules:
       - alert: AppOutOfSync
-        expr: argocd_app_sync_status{sync_status="Synced",project="default"} == 0
+        expr: argocd_app_info{sync_status="Synced",project="default"} == 0
         for: 20m
         labels:
           severity: minor

--- a/monitoring/base/prometheus/alert_rules/argocd.yaml
+++ b/monitoring/base/prometheus/alert_rules/argocd.yaml
@@ -2,12 +2,20 @@ groups:
   - name: argocd-config
     rules:
       - alert: AppOutOfSync
-        expr: argocd_app_info{sync_status="Synced",project="default"} == 0
+        expr: argocd_app_info{sync_status!="Synced",project="default"} == 1
         for: 20m
         labels:
           severity: minor
         annotations:
-          summary: "{{ $labels.exported_name }} is out-of-sync."
+          summary: "{{ $labels.name }} is out-of-sync."
+          runbook: "See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync"
+      - alert: AllAppMissing
+        expr: absent(argocd_app_info{sync_status="Synced",project="default"})
+        for: 20m
+        labels:
+          severity: minor
+        annotations:
+          summary: "no application is synced."
           runbook: "See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync"
       - alert: ArgoCDDown
         expr: |

--- a/test/alert_test/argocd.yaml
+++ b/test/alert_test/argocd.yaml
@@ -4,31 +4,56 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'argocd_app_info{exported_name="monitoring",sync_status="Synced",project="default"}'
+      - series: 'argocd_app_info{name="monitoring",sync_status="Synced",project="default"}'
         values: 0+0x20
-      - series: 'argocd_app_info{exported_name="metallb",sync_status="Synced",project="default"}'
+      - series: 'argocd_app_info{name="metallb",sync_status="Synced",project="default"}'
         values: 0+0x20
-      - series: 'argocd_app_info{exported_name="argocd",sync_status="Synced",project="default"}'
+      - series: 'argocd_app_info{name="argocd",sync_status="Synced",project="default"}'
         values: '0+0x10 1+0x10'
+      - series: 'argocd_app_info{name="monitoring",sync_status="Unknown",project="default"}'
+        values: 1+0x20
+      - series: 'argocd_app_info{name="metallb",sync_status="Unknown",project="default"}'
+        values: 1+0x20
+      - series: 'argocd_app_info{name="argocd",sync_status="Unknown",project="default"}'
+        values: '1+0x10 0+0x10'
     alert_rule_test:
       - eval_time: 20m
         alertname: AppOutOfSync
         exp_alerts:
           - exp_labels:
-              exported_name: monitoring
+              name: monitoring
               severity: minor
-              sync_status: Synced
+              sync_status: Unknown
               project: default
             exp_annotations:
               summary: monitoring is out-of-sync.
               runbook: See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync
           - exp_labels:
-              exported_name: metallb
+              name: metallb
+              severity: minor
+              sync_status: Unknown
+              project: default
+            exp_annotations:
+              summary: metallb is out-of-sync.
+              runbook: See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync
+  - interval: 1m
+    input_series:
+      - series: 'argocd_app_info{name="monitoring",sync_status="Unknown",project="default"}'
+        values: 1+0x20
+      - series: 'argocd_app_info{name="metallb",sync_status="Unknown",project="default"}'
+        values: 1+0x20
+      - series: 'argocd_app_info{name="argocd",sync_status="Unknown",project="default"}'
+        values: 1+0x20
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: AllAppMissing
+        exp_alerts:
+          - exp_labels:
               severity: minor
               sync_status: Synced
               project: default
             exp_annotations:
-              summary: metallb is out-of-sync.
+              summary: no application is synced.
               runbook: See https://github.com/cybozu-go/neco-apps/blob/master/DEVELOPMENT.md#out-of-sync
   - interval: 1m
     input_series:

--- a/test/alert_test/argocd.yaml
+++ b/test/alert_test/argocd.yaml
@@ -4,11 +4,11 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'argocd_app_sync_status{exported_name="monitoring",sync_status="Synced",project="default"}'
+      - series: 'argocd_app_info{exported_name="monitoring",sync_status="Synced",project="default"}'
         values: 0+0x20
-      - series: 'argocd_app_sync_status{exported_name="metallb",sync_status="Synced",project="default"}'
+      - series: 'argocd_app_info{exported_name="metallb",sync_status="Synced",project="default"}'
         values: 0+0x20
-      - series: 'argocd_app_sync_status{exported_name="argocd",sync_status="Synced",project="default"}'
+      - series: 'argocd_app_info{exported_name="argocd",sync_status="Synced",project="default"}'
         values: '0+0x10 1+0x10'
     alert_rule_test:
       - eval_time: 20m


### PR DESCRIPTION
Follow metrics name change in Argo CD 1.5 and add monitoring alert AllAppMissing