### PR TITLE
Specify certificate's extended key usage explicitly

### DIFF
--- a/argocd-ingress/overlays/gcp/certificate.yaml
+++ b/argocd-ingress/overlays/gcp/certificate.yaml
@@ -21,6 +21,10 @@ spec:
   issuerRef:
     name: argocd-server-selfsign
   commonName: "ca.server.argocd"
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
   isCA: true
 ---
 apiVersion: cert-manager.io/v1alpha2
@@ -49,3 +53,8 @@ spec:
   commonName: argocd.gcp0.dev-ne.co
   dnsNames:
     - argocd.gcp0.dev-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/argocd-ingress/overlays/kind/certificate.yaml
+++ b/argocd-ingress/overlays/kind/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: argocd.kind.cybozu-ne.co
   dnsNames:
     - argocd.kind.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/argocd-ingress/overlays/osaka0/certificate.yaml
+++ b/argocd-ingress/overlays/osaka0/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: argocd.osaka0.cybozu-ne.co
   dnsNames:
     - argocd.osaka0.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/argocd-ingress/overlays/stage0/certificate.yaml
+++ b/argocd-ingress/overlays/stage0/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: argocd.stage0.cybozu-ne.co
   dnsNames:
     - argocd.stage0.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/argocd-ingress/overlays/tokyo0/certificate.yaml
+++ b/argocd-ingress/overlays/tokyo0/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: argocd.tokyo0.cybozu-ne.co
   dnsNames:
     - argocd.tokyo0.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/bmc-reverse-proxy/overlays/gcp/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/gcp/bmc-reverse-proxy/certificate.yaml
@@ -19,6 +19,10 @@ spec:
   issuerRef:
     name: bmc-reverse-proxy-selfsign
   commonName: "ca.bmc-reverse-proxy"
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
   isCA: true
 ---
 apiVersion: cert-manager.io/v1alpha2
@@ -45,3 +49,8 @@ spec:
   commonName: "*.bmc.gcp0.dev-ne.co"
   dnsNames:
     - "*.bmc.gcp0.dev-ne.co"
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/bmc-reverse-proxy/overlays/osaka0/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/osaka0/bmc-reverse-proxy/certificate.yaml
@@ -10,3 +10,8 @@ spec:
   commonName: "*.bmc.osaka0.cybozu-ne.co"
   dnsNames:
     - "*.bmc.osaka0.cybozu-ne.co"
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/bmc-reverse-proxy/overlays/stage0/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/stage0/bmc-reverse-proxy/certificate.yaml
@@ -10,3 +10,8 @@ spec:
   commonName: "*.bmc.stage0.cybozu-ne.co"
   dnsNames:
     - "*.bmc.stage0.cybozu-ne.co"
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/bmc-reverse-proxy/overlays/tokyo0/bmc-reverse-proxy/certificate.yaml
+++ b/bmc-reverse-proxy/overlays/tokyo0/bmc-reverse-proxy/certificate.yaml
@@ -10,3 +10,8 @@ spec:
   commonName: "*.bmc.tokyo0.cybozu-ne.co"
   dnsNames:
     - "*.bmc.tokyo0.cybozu-ne.co"
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/ingress/base/template/certificate.yaml
+++ b/ingress/base/template/certificate.yaml
@@ -30,6 +30,7 @@ spec:
   usages:
     - digital signature
     - key encipherment
+    - cert sign
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
@@ -59,6 +60,8 @@ spec:
   usages:
     - digital signature
     - key encipherment
+    - server auth
+    - client auth
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
@@ -79,3 +82,5 @@ spec:
   usages:
     - digital signature
     - key encipherment
+    - server auth
+    - client auth

--- a/ingress/base/template/deployment.yaml
+++ b/ingress/base/template/deployment.yaml
@@ -86,7 +86,7 @@ spec:
       - env:
         - name: CP_DEFAULT_ISSUER_NAME
           value: clouddns
-        image: quay.io/cybozu/contour-plus:0.4.2
+        image: quay.io/cybozu/contour-plus:0.4.3
         name: contour-plus
       dnsPolicy: ClusterFirst
       serviceAccountName: contour

--- a/neco-admission/base/certificates.yaml
+++ b/neco-admission/base/certificates.yaml
@@ -21,6 +21,10 @@ spec:
     name: webhook-selfsign
   commonName: "ca.webhook.kube-system"
   isCA: true
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
 ---
 # Create an Issuer that uses the above generated CA certificate to issue certs
 apiVersion: cert-manager.io/v1alpha2
@@ -47,3 +51,8 @@ spec:
     - neco-admission
     - neco-admission.kube-system
     - neco-admission.kube-system.svc
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/teleport/overlays/gcp/certificate.yaml
+++ b/teleport/overlays/gcp/certificate.yaml
@@ -22,6 +22,10 @@ spec:
     name: teleport-proxy-selfsign
   commonName: "ca.proxy.teleport"
   isCA: true
+  usages:
+    - digital signature
+    - key encipherment
+    - cert sign
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
@@ -49,3 +53,8 @@ spec:
   commonName: teleport.gcp0.dev-ne.co
   dnsNames:
     - teleport.gcp0.dev-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/teleport/overlays/osaka0/certificate.yaml
+++ b/teleport/overlays/osaka0/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: teleport.osaka0.cybozu-ne.co
   dnsNames:
     - teleport.osaka0.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/teleport/overlays/stage0/certificate.yaml
+++ b/teleport/overlays/stage0/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: teleport.stage0.cybozu-ne.co
   dnsNames:
     - teleport.stage0.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/teleport/overlays/tokyo0/certificate.yaml
+++ b/teleport/overlays/tokyo0/certificate.yaml
@@ -11,3 +11,8 @@ spec:
   commonName: teleport.tokyo0.cybozu-ne.co
   dnsNames:
     - teleport.tokyo0.cybozu-ne.co
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/test/cert-manager_test.go
+++ b/test/cert-manager_test.go
@@ -58,6 +58,11 @@ spec:
   commonName: %s
   dnsNames:
     - %s
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
 `, issuerName, domainName, domainName)
 		_, stderr, err := ExecAtWithInput(boot0, []byte(certificate), "kubectl", "apply", "-f", "-")
 		Expect(err).NotTo(HaveOccurred(), "stderr: %s", stderr)

--- a/topolvm/base/upstream/certificates.yaml
+++ b/topolvm/base/upstream/certificates.yaml
@@ -21,6 +21,10 @@ spec:
     name: webhook-selfsign
   commonName: "ca.webhook.topolvm"
   isCA: true
+  usages:
+  - digital signature
+  - key encipherment
+  - cert sign
 ---
 # Create an Issuer that uses the above generated CA certificate to issue certs
 apiVersion: cert-manager.io/v1alpha3
@@ -47,3 +51,8 @@ spec:
   - controller
   - controller.topolvm-system
   - controller.topolvm-system.svc
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth

--- a/topolvm/base/upstream/controller.yaml
+++ b/topolvm/base/upstream/controller.yaml
@@ -303,7 +303,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: topolvm-controller
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /topolvm-controller
             - --cert-dir=/certs
@@ -331,7 +331,7 @@ spec:
               mountPath: /certs
 
         - name: csi-provisioner
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /csi-provisioner
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -344,7 +344,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-attacher
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /csi-attacher
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -355,7 +355,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-resizer
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /csi-resizer
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -366,7 +366,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: liveness-probe
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /livenessprobe
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/topolvm/base/upstream/node.yaml
+++ b/topolvm/base/upstream/node.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: node
       containers:
         - name: topolvm-node
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           securityContext:
             privileged: true
           command:
@@ -92,7 +92,7 @@ spec:
               mountPropagation: "Bidirectional"
 
         - name: csi-registrar
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /csi-node-driver-registrar
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -108,7 +108,7 @@ spec:
               mountPath: /registration
 
         - name: liveness-probe
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /livenessprobe
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/topolvm/base/upstream/scheduler.yaml
+++ b/topolvm/base/upstream/scheduler.yaml
@@ -50,7 +50,7 @@ spec:
       serviceAccountName: topolvm-scheduler
       containers:
         - name: topolvm-scheduler
-          image: quay.io/cybozu/topolvm:0.4.6
+          image: quay.io/cybozu/topolvm:0.4.7
           command:
             - /topolvm-scheduler
             - --listen=localhost:9251


### PR DESCRIPTION
This PR specifies certificates' extended key usages explicitly.
- updates manifests managed in neco-apps
- updates TopoLVM to reflect manifests managed in upstream

This PR also updates contour-plus to 0.4.3 to generate certificates with explicit usages.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>