### PR TITLE
Add read other applications permission to Neco

### DIFF
--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -59,6 +59,7 @@ metadata:
 data:
   policy.csv: |
     p, cybozu-private:Neco, repositories, *, *, allow
+    p, cybozu-private:Neco, applications, *, *, allow
     p, cybozu-private:neco-readonly, projects, get, *, allow
     p, cybozu-private:neco-readonly, applications, get, *, allow
     p, cybozu-private:maneki, repositories, *, https://github.com/cybozu-private/maneki-apps.git, allow

--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -58,14 +58,8 @@ metadata:
   name: argocd-rbac-cm
 data:
   policy.csv: |
-    p, cybozu-private:Neco, repositories, *, *, allow
-    p, cybozu-private:Neco, applications, *, */*, allow
-    p, cybozu-private:Neco, certificates, *, *, allow
-    p, cybozu-private:Neco, clusters, *, *, allow
-    p, cybozu-private:Neco, projects, *, *, allow
-    p, cybozu-private:Neco, accounts, *, *, allow
-    p, cybozu-private:neco-readonly, projects, get, *, allow
-    p, cybozu-private:neco-readonly, applications, get, */*, allow
+    g, cybozu-private:Neco, role:admin
+    g, cybozu-private:neco-readonly, role:readonly
     p, cybozu-private:maneki, repositories, *, https://github.com/cybozu-private/maneki-apps.git, allow
     p, cybozu-private:maneki, clusters, get, *, allow
   # unauthenticated users cannot see the app, projects, etc...

--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -59,9 +59,13 @@ metadata:
 data:
   policy.csv: |
     p, cybozu-private:Neco, repositories, *, *, allow
-    p, cybozu-private:Neco, applications, *, *, allow
+    p, cybozu-private:Neco, applications, *, */*, allow
+    p, cybozu-private:Neco, certificates, *, *, allow
+    p, cybozu-private:Neco, clusters, *, *, allow
+    p, cybozu-private:Neco, projects, *, *, allow
+    p, cybozu-private:Neco, accounts, *, *, allow
     p, cybozu-private:neco-readonly, projects, get, *, allow
-    p, cybozu-private:neco-readonly, applications, get, *, allow
+    p, cybozu-private:neco-readonly, applications, get, */*, allow
     p, cybozu-private:maneki, repositories, *, https://github.com/cybozu-private/maneki-apps.git, allow
     p, cybozu-private:maneki, clusters, get, *, allow
   # unauthenticated users cannot see the app, projects, etc...

--- a/team-management/base/neco/project.yaml
+++ b/team-management/base/neco/project.yaml
@@ -12,9 +12,3 @@ spec:
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'
-  roles:
-  - name: admin
-    groups:
-    - cybozu-private:Neco
-    policies:
-    - p, proj:default:admin, applications, *, default/*, allow


### PR DESCRIPTION
This PR adds permission to read other applications to Neco team using embed role such as `role:admin`, `role:readonly`. 