### PR TITLE
Resize the Prometheus volume

### DIFF
--- a/monitoring/base/prometheus/statefulset.yaml
+++ b/monitoring/base/prometheus/statefulset.yaml
@@ -62,4 +62,4 @@ spec:
         storageClassName: topolvm-provisioner
         resources:
           requests:
-            storage: 450Gi
+            storage: 460Gi


### PR DESCRIPTION
The Prometheus Volume was resized to 460Gi through our operation. 
Therefore, this PR fixes the volume size of the Prometheus manifest.