### PR TITLE
ingress: add dummy HTTPProxies

### DIFF
--- a/ingress/base/bastion/httpproxy.yaml
+++ b/ingress/base/bastion/httpproxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dummy
+  namespace: ingress
+  annotations:
+    contour-plus.cybozu.com/exclude: "true"
+    kubernetes.io/ingress.class: bastion

--- a/ingress/base/bastion/kustomization.yaml
+++ b/ingress/base/bastion/kustomization.yaml
@@ -10,3 +10,4 @@ patchesStrategicMerge:
   - rbac_contour-plus.yaml
   - service.yaml
   - certificate.yaml
+  - httpproxy.yaml

--- a/ingress/base/forest/httpproxy.yaml
+++ b/ingress/base/forest/httpproxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dummy
+  namespace: ingress
+  annotations:
+    contour-plus.cybozu.com/exclude: "true"
+    kubernetes.io/ingress.class: forest

--- a/ingress/base/forest/kustomization.yaml
+++ b/ingress/base/forest/kustomization.yaml
@@ -9,3 +9,4 @@ patchesStrategicMerge:
   - deployment.yaml
   - rbac_contour-plus.yaml
   - certificate.yaml
+  - httpproxy.yaml

--- a/ingress/base/global/httpproxy.yaml
+++ b/ingress/base/global/httpproxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dummy
+  namespace: ingress
+  annotations:
+    contour-plus.cybozu.com/exclude: "true"
+    kubernetes.io/ingress.class: global

--- a/ingress/base/global/kustomization.yaml
+++ b/ingress/base/global/kustomization.yaml
@@ -10,3 +10,4 @@ patchesStrategicMerge:
   - rbac_contour-plus.yaml
   - service.yaml
   - certificate.yaml
+  - httpproxy.yaml

--- a/ingress/base/template/httpproxy.yaml
+++ b/ingress/base/template/httpproxy.yaml
@@ -1,0 +1,59 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dummy
+  namespace: ingress
+  annotations:
+    contour-plus.cybozu.com/exclude: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: dummy.ingress.dummy
+    tls:
+      secretName: dummy-httpproxy-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: dummy
+          port: 80
+        - name: dummy
+          port: 443
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: dummy-httpproxy
+  namespace: ingress
+spec:
+  secretName: dummy-httpproxy-tls
+  duration: 87600h0m0s # 10y
+  issuerRef:
+    name: contour-selfsign
+  commonName: "dummy.ingress.dummy"
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dummy
+  namespace: ingress
+  annotations:
+    projectcontour.io/upstream-protocol.tls: "443"
+    projectcontour.io/upstream-protocol.h2: "80"
+spec:
+  ports:
+  - port: 80
+    name: http
+    protocol: TCP
+    targetPort: 8080
+  - port: 443
+    name: https
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: dummy

--- a/ingress/base/template/kustomization.yaml
+++ b/ingress/base/template/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - pdb.yaml
   - rbac_contour-plus.yaml
   - service.yaml
+  - httpproxy.yaml


### PR DESCRIPTION
This PR is to prevent envoy crush loop.
See: https://github.com/cybozu-go/neco/issues/1002