### PR TITLE
bmc-reverse-proxy: fix osaka0 overlay

### DIFF
--- a/bmc-reverse-proxy/overlays/osaka0/kustomization.yaml
+++ b/bmc-reverse-proxy/overlays/osaka0/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-resources:
   - bmc-reverse-proxy/certificate.yaml


### PR DESCRIPTION
bmc-reverse-proxy was not deployed on osaka0 due to the incorrect kustomize manifests.
Fix this problem.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>