### PR TITLE
pushgateway: add manifests and tests for pushgateway

### DIFF
--- a/monitoring/base/alertmanager/deployment.yaml
+++ b/monitoring/base/alertmanager/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: alertmanager
-          image: quay.io/cybozu/prometheus:2.18.1.1
+          image: quay.io/cybozu/prometheus
           command: ["alertmanager"]
           args: ["--config.file=/etc/alertmanager.secret/alertmanager.yaml"]
           ports:

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -46,3 +46,6 @@ configMapGenerator:
   - name: alertmanager
     files:
       - alertmanager/neco.template
+imageTags:
+  - name: quay.io/cybozu/prometheus
+    newTag: 2.18.1.1

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
   - prometheus/statefulset.yaml
   - alertmanager/deployment.yaml
   - alertmanager/service.yaml
+  - pushgateway/deployment.yaml
+  - pushgateway/service.yaml
 configMapGenerator:
   - name: prometheus-server-conf
     files:

--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -68,6 +68,26 @@ scrape_configs:
         regex: ([^:]+)(?::\d+)?
         replacement: ${1}
         target_label: instance
+  - job_name: "pushgateway"
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ["monitoring"]
+    relabel_configs:
+      # Discovered Labels
+      #   __meta_kubernetes_pod_label_app_kubernetes_io_name="pushgateway"
+      #   __address__="10.64.11.130:9091"
+      # Expected Target Labels
+      #   job="pushgateway"
+      #   instance="10.64.11.130"
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: pushgateway
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}
+        target_label: instance
   - job_name: 'kubernetes-apiservers'
     kubernetes_sd_configs:
     - role: endpoints

--- a/monitoring/base/prometheus/statefulset.yaml
+++ b/monitoring/base/prometheus/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: quay.io/cybozu/prometheus:2.18.1.1
+          image: quay.io/cybozu/prometheus
           command: ["prometheus"]
           args:
             - --config.file=/etc/prometheus/prometheus.yaml

--- a/monitoring/base/pushgateway/deployment.yaml
+++ b/monitoring/base/pushgateway/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pushgateway
+  labels:
+     app.kubernetes.io/name: pushgateway
+  annotations:
+    prometheus.io/port: "9091"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pushgateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pushgateway
+    spec:
+      containers:
+      - name: pushgateway
+        image: quay.io/cybozu/prometheus:2.18.1.1
+        command:
+          - pushgateway
+        ports:
+        - containerPort: 9091
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9091
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9091
+          initialDelaySeconds: 10
+          timeoutSeconds: 10

--- a/monitoring/base/pushgateway/deployment.yaml
+++ b/monitoring/base/pushgateway/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: pushgateway
-        image: quay.io/cybozu/prometheus:2.18.1.1
+        image: quay.io/cybozu/prometheus
         command:
           - pushgateway
         ports:

--- a/monitoring/base/pushgateway/service.yaml
+++ b/monitoring/base/pushgateway/service.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: pushgateway
+spec:
+  selector:
+    app.kubernetes.io/name: pushgateway
+  ports:
+  - name: pushgateway
+    port: 9091
+    targetPort: 9091

--- a/monitoring/overlays/osaka0/kustomization.yaml
+++ b/monitoring/overlays/osaka0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - grafana-operator/httpproxy.yaml
+  - pushgateway/httpproxy.yaml
 patchesStrategicMerge:
   - prometheus/statefulset.yaml
   - grafana-operator/grafana.yaml

--- a/monitoring/overlays/osaka0/pushgateway/httpproxy.yaml
+++ b/monitoring/overlays/osaka0/pushgateway/httpproxy.yaml
@@ -1,0 +1,39 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pushgateway-bastion
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: pushgateway-bastion.monitoring.osaka0.cybozu-ne.co
+    tls:
+      secretName: pushgateway-bastion-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: pushgateway
+          port: 9091
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pushgateway-forest
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: forest
+spec:
+  virtualhost:
+    fqdn: pushgateway-forest.monitoring.osaka0.cybozu-ne.co
+    tls:
+      secretName: pushgateway-forest-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: pushgateway
+          port: 9091

--- a/monitoring/overlays/stage0/kustomization.yaml
+++ b/monitoring/overlays/stage0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - grafana-operator/httpproxy.yaml
+  - pushgateway/httpproxy.yaml
 patchesStrategicMerge:
   - prometheus/statefulset.yaml
   - grafana-operator/grafana.yaml

--- a/monitoring/overlays/stage0/pushgateway/httpproxy.yaml
+++ b/monitoring/overlays/stage0/pushgateway/httpproxy.yaml
@@ -1,0 +1,39 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pushgateway-bastion
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: pushgateway-bastion.monitoring.stage0.cybozu-ne.co
+    tls:
+      secretName: pushgateway-bastion-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: pushgateway
+          port: 9091
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pushgateway-forest
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: forest
+spec:
+  virtualhost:
+    fqdn: pushgateway-forest.monitoring.stage0.cybozu-ne.co
+    tls:
+      secretName: pushgateway-forest-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: pushgateway
+          port: 9091

--- a/monitoring/overlays/tokyo0/kustomization.yaml
+++ b/monitoring/overlays/tokyo0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - grafana-operator/httpproxy.yaml
+  - pushgateway/httpproxy.yaml
 patchesStrategicMerge:
   - prometheus/statefulset.yaml
   - grafana-operator/grafana.yaml

--- a/monitoring/overlays/tokyo0/pushgateway/httpproxy.yaml
+++ b/monitoring/overlays/tokyo0/pushgateway/httpproxy.yaml
@@ -1,0 +1,39 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pushgateway-bastion
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: pushgateway-bastion.monitoring.tokyo0.cybozu-ne.co
+    tls:
+      secretName: pushgateway-bastion-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: pushgateway
+          port: 9091
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pushgateway-forest
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: forest
+spec:
+  virtualhost:
+    fqdn: pushgateway-forest.monitoring.tokyo0.cybozu-ne.co
+    tls:
+      secretName: pushgateway-forest-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: pushgateway
+          port: 9091

--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -291,10 +291,20 @@ spec:
 	})
 
 	if !withKind {
+
 		It("should be accessed from Bastion", func() {
+			By("getting the IP address of the contour LoadBalancer")
+			stdout, _, err := ExecAt(boot0, "kubectl", "-n=ingress-bastion", "get", "service/envoy", "-o=json")
+			Expect(err).ShouldNot(HaveOccurred())
+			svc := new(corev1.Service)
+			err = json.Unmarshal(stdout, svc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(len(svc.Status.LoadBalancer.Ingress)).To(Equal(1))
+			bastionIP := svc.Status.LoadBalancer.Ingress[0].IP
+
 			Eventually(func() error {
 				stdout, stderr, err := ExecAt(boot0,
-					"curl", "-sL", "http://"+bastionFQDN,
+					"curl", "-sL", "--resolve", bastionFQDN+":80:"+bastionIP, "http://"+bastionFQDN+"/-/healthy",
 					"-o", "/dev/null",
 				)
 				if err != nil {
@@ -305,8 +315,15 @@ spec:
 		})
 
 		It("should be accessed from Forest", func() {
+			stdout, _, err := ExecAt(boot0, "kubectl", "-n=ingress-forest", "get", "service/envoy", "-o=json")
+			Expect(err).ShouldNot(HaveOccurred())
+			svc := new(corev1.Service)
+			err = json.Unmarshal(stdout, svc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(len(svc.Status.LoadBalancer.Ingress)).To(Equal(1))
+			forestIP := svc.Status.LoadBalancer.Ingress[0].IP
 			Eventually(func() error {
-				return exec.Command("sudo", "nsenter", "-n", "-t", externalPID, "curl", "http://"+forestFQDN, "-m", "5").Run()
+				return exec.Command("sudo", "nsenter", "-n", "-t", externalPID, "curl", "--resolve", forestFQDN+":80:"+forestIP, forestFQDN+"/-/healthy", "-m", "5").Run()
 			}).Should(Succeed())
 		})
 	}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Test applications", func() {
 	Context("grafana-operator", testGrafanaOperator)
 	Context("sandbox-grafana", testSandboxGrafana)
 	Context("alertmanager", testAlertmanager)
+	Context("pushgateway", testPushgateway)
 	Context("prometheus-metrics", testPrometheusMetrics)
 	Context("metrics-server", testMetricsServer)
 	if !withKind {


### PR DESCRIPTION
- Add manifests of Pushgateway
   - Deployment/Service/HTTPProxy
- Configure Prometheus to scrape Pushgateway
- Add test to confirm that Pushgateway is accessible from each network
- Refactor to manage image versions by imageTags