### PR TITLE
monitoring: add httpproxy and services for ingress-watcher

### DIFF
--- a/monitoring/base/ingress-health/deployment.yaml
+++ b/monitoring/base/ingress-health/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-health
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: ingress-health
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-health
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-health
+    spec:
+      containers:
+      - name: ingress-health
+        args:
+          - --listen=:8080
+        image: quay.io/cybozu/testhttpd:0.1.0
+        ports:
+          - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+      terminationGracePeriodSeconds: 10

--- a/monitoring/base/ingress-health/service.yaml
+++ b/monitoring/base/ingress-health/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-health-http
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: ingress-health-http
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ingress-health
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
   - alertmanager/service.yaml
   - pushgateway/deployment.yaml
   - pushgateway/service.yaml
+  - ingress-health/deployment.yaml
+  - ingress-health/service.yaml
 configMapGenerator:
   - name: prometheus-server-conf
     files:

--- a/monitoring/overlays/osaka0/ingress-health/httpproxy.yaml
+++ b/monitoring/overlays/osaka0/ingress-health/httpproxy.yaml
@@ -1,0 +1,71 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-global
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: global
+spec:
+  virtualhost:
+    fqdn: ingress-health-global.monitoring.osaka0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-global-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-bastion
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: ingress-health-bastion.monitoring.osaka0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-bastion-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-forest
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: forest
+spec:
+  virtualhost:
+    fqdn: ingress-health-forest.monitoring.osaka0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-forest-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m

--- a/monitoring/overlays/osaka0/kustomization.yaml
+++ b/monitoring/overlays/osaka0/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - grafana-operator/httpproxy.yaml
   - pushgateway/httpproxy.yaml
+  - ingress-health/httpproxy.yaml
 patchesStrategicMerge:
   - prometheus/statefulset.yaml
   - grafana-operator/grafana.yaml

--- a/monitoring/overlays/stage0/ingress-health/httpproxy.yaml
+++ b/monitoring/overlays/stage0/ingress-health/httpproxy.yaml
@@ -1,0 +1,71 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-global
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: global
+spec:
+  virtualhost:
+    fqdn: ingress-health-global.monitoring.stage0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-global-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-bastion
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: ingress-health-bastion.monitoring.stage0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-bastion-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-forest
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: forest
+spec:
+  virtualhost:
+    fqdn: ingress-health-forest.monitoring.stage0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-forest-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m

--- a/monitoring/overlays/stage0/kustomization.yaml
+++ b/monitoring/overlays/stage0/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - grafana-operator/httpproxy.yaml
   - pushgateway/httpproxy.yaml
+  - ingress-health/httpproxy.yaml
 patchesStrategicMerge:
   - prometheus/statefulset.yaml
   - grafana-operator/grafana.yaml

--- a/monitoring/overlays/tokyo0/ingress-health/httpproxy.yaml
+++ b/monitoring/overlays/tokyo0/ingress-health/httpproxy.yaml
@@ -1,0 +1,71 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-global
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: global
+spec:
+  virtualhost:
+    fqdn: ingress-health-global.monitoring.tokyo0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-global-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-bastion
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: bastion
+spec:
+  virtualhost:
+    fqdn: ingress-health-bastion.monitoring.tokyo0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-bastion-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: ingress-health-forest
+  namespace: monitoring
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: forest
+spec:
+  virtualhost:
+    fqdn: ingress-health-forest.monitoring.tokyo0.cybozu-ne.co
+    tls:
+      secretName: ingress-health-forest-tls
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: ingress-health-http
+          port: 80
+      permitInsecure: true
+      timeoutPolicy:
+        response: 2m
+        idle: 5m

--- a/monitoring/overlays/tokyo0/kustomization.yaml
+++ b/monitoring/overlays/tokyo0/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - grafana-operator/httpproxy.yaml
   - pushgateway/httpproxy.yaml
+  - ingress-health/httpproxy.yaml
 patchesStrategicMerge:
   - prometheus/statefulset.yaml
   - grafana-operator/grafana.yaml

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Test applications", func() {
 	Context("sandbox-grafana", testSandboxGrafana)
 	Context("alertmanager", testAlertmanager)
 	Context("pushgateway", testPushgateway)
+	Context("ingress-health", testIngressHealth)
 	Context("prometheus-metrics", testPrometheusMetrics)
 	Context("metrics-server", testMetricsServer)
 	if !withKind {


### PR DESCRIPTION
Deploy testhttpd and expose the endpoint to global, forest and bastion with HTTPProxy.
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>