### PR TITLE
network-policy: Add synv-wave for bmc-reverse-proxy network-policy

### DIFF
--- a/network-policy/base/policies/bmc-reverse-proxy.yaml
+++ b/network-policy/base/policies/bmc-reverse-proxy.yaml
@@ -16,6 +16,8 @@ kind: NetworkPolicy
 metadata:
   name: egress-bmc-allow
   namespace: bmc-reverse-proxy
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   order: 500.0
   types:


### PR DESCRIPTION
Signed-off-by: Hiroshi Muraoka <h.muraoka714@gmail.com>