### PR TITLE
ci: output junit-compatible test result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,10 @@ jobs:
             export NECO_DIR=$(pwd)/neco
             TARGET=dctest-upgrade BASE_BRANCH=stage ./bin/run-test.sh
           no_output_timeout: 31m
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit
       - delete-instance
 
   upgrade-release:
@@ -195,6 +199,10 @@ jobs:
             export NECO_DIR=$(pwd)/neco
             TARGET=dctest-upgrade BASE_BRANCH=release ./bin/run-test.sh
           no_output_timeout: 31m
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit
       - delete-instance
 
   create-pull-request-stage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,10 @@ jobs:
             export NECO_DIR=$(pwd)/neco
             ./bin/run-test.sh
           no_output_timeout: 31m
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit
       - delete-instance
 
   upgrade-stage:

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -30,5 +30,8 @@ chmod +x run.sh
 # Clean old CI files
 $GCLOUD compute scp --zone=${ZONE} run.sh account.json cybozu@${INSTANCE_NAME}:
 $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command="sudo -H /home/cybozu/run.sh"
+STATUSCODE=$?
+mkdir -p ~/test-results/junit/
+$GCLOUD compute scp --zone=${ZONE} cybozu@${INSTANCE_NAME}:/tmp/junit.xml ~/test-results/junit/
 
-exit $?
+exit ${STATUSCODE}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cybozu-go/log"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
@@ -17,7 +18,8 @@ func Test(t *testing.T) {
 	}
 
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test")
+	junitReporter := reporters.NewJUnitReporter("/tmp/junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Test", []Reporter{junitReporter})
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
To view the statistics of failed tests in each branch easily, this PR modified `neco-apps` test to generate junit-compatible test result.

With this change, you can see the statistics by following the steps below

1. Go to [this page](https://circleci.com/build-insights)
2. Click `cybozu-go/neco-apps`
3. Select `ci-metrics`branch from the pull down menu`Change branch`
4. You can see `Failed Tests` and `Slowest Failed Tests` at the bottom of the page 

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>