### PR TITLE
upgrade TopoLVM to v0.5.2

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -190,7 +190,8 @@ Check [releases](https://github.com/cybozu-go/topolvm/releases) for changes.
 Download the upstream manifest as follows:
 
 ```console
-$ git clone https://github.com/cybozu-go/topolvm
+$ cd $GOPATH/src/github.com/topolvm
+$ git clone https://github.com/topolvm/topolvm
 $ cd topolvm
 $ git checkout vX.Y.Z
 $ cp -r deploy/manifests/* $GOPATH/src/github.com/cybozu-go/neco-apps/topolvm/base/upstream

--- a/monitoring/base/prometheus/statefulset.yaml
+++ b/monitoring/base/prometheus/statefulset.yaml
@@ -48,7 +48,6 @@ spec:
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
-        fsGroup: 10000
       volumes:
         - name: prometheus-config-volume
           configMap:

--- a/sandbox/overlays/gcp/grafana/statefulset.yaml
+++ b/sandbox/overlays/gcp/grafana/statefulset.yaml
@@ -68,7 +68,6 @@ spec:
               mountPath: /etc/grafana/provisioning/datasources
       priorityClassName: node-bound
       securityContext:
-        fsGroup: 10000
         runAsUser: 10000
       volumes:
         - configMap:

--- a/teleport/base/statefulset.yaml
+++ b/teleport/base/statefulset.yaml
@@ -70,7 +70,6 @@ spec:
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000
-        fsGroup: 10000
       volumes:
       - name: teleport-auth-secret
         secret:

--- a/test/elastic_test.go
+++ b/test/elastic_test.go
@@ -42,7 +42,6 @@ spec:
         serviceAccountName: elastic
         securityContext:
           runAsUser: 1000
-          fsGroup: 1000
         containers:
           - name: elasticsearch
             env:

--- a/topolvm/base/kustomization.yaml
+++ b/topolvm/base/kustomization.yaml
@@ -25,8 +25,8 @@ configMapGenerator:
       - ./upstream/base/scheduler-options.yaml
 
 imageTags:
-  - name: quay.io/cybozu/topolvm
-    newTag: 0.5.0
+  - name: quay.io/topolvm/topolvm
+    newTag: 0.5.2
 
 patchesJSON6902:
 - target:

--- a/topolvm/base/upstream/base/controller.yaml
+++ b/topolvm/base/upstream/base/controller.yaml
@@ -303,7 +303,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: topolvm-controller
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /topolvm-controller
             - --cert-dir=/certs
@@ -331,7 +331,7 @@ spec:
               mountPath: /certs
 
         - name: csi-provisioner
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /csi-provisioner
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -344,7 +344,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-attacher
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /csi-attacher
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -355,7 +355,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-resizer
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /csi-resizer
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -366,7 +366,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: liveness-probe
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /livenessprobe
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/topolvm/base/upstream/base/node.yaml
+++ b/topolvm/base/upstream/base/node.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: node
       containers:
         - name: topolvm-node
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           securityContext:
             privileged: true
           command:
@@ -92,7 +92,7 @@ spec:
               mountPropagation: "Bidirectional"
 
         - name: csi-registrar
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /csi-node-driver-registrar
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -108,7 +108,7 @@ spec:
               mountPath: /registration
 
         - name: liveness-probe
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /livenessprobe
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/topolvm/base/upstream/overlays/daemonset-scheduler/kustomization.yaml
+++ b/topolvm/base/upstream/overlays/daemonset-scheduler/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - ../../base
   - scheduler.yaml
 imageTags:
-  - name: quay.io/cybozu/topolvm
-    newTag: 0.5.0
+  - name: quay.io/topolvm/topolvm
+    newTag: 0.5.2

--- a/topolvm/base/upstream/overlays/daemonset-scheduler/scheduler.yaml
+++ b/topolvm/base/upstream/overlays/daemonset-scheduler/scheduler.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: topolvm-scheduler
       containers:
         - name: topolvm-scheduler
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /topolvm-scheduler
             - --config=/etc/topolvm/scheduler-options.yaml

--- a/topolvm/base/upstream/overlays/deployment-scheduler/kustomization.yaml
+++ b/topolvm/base/upstream/overlays/deployment-scheduler/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - ../../base
   - scheduler.yaml
 imageTags:
-  - name: quay.io/cybozu/topolvm
-    newTag: 0.5.0
+  - name: quay.io/topolvm/topolvm
+    newTag: 0.5.2

--- a/topolvm/base/upstream/overlays/deployment-scheduler/scheduler.yaml
+++ b/topolvm/base/upstream/overlays/deployment-scheduler/scheduler.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: topolvm-scheduler
       containers:
         - name: topolvm-scheduler
-          image: quay.io/cybozu/topolvm:latest
+          image: quay.io/topolvm/topolvm:latest
           command:
             - /topolvm-scheduler
             - --config=/etc/topolvm/scheduler-options.yaml


### PR DESCRIPTION
- Upgrade TopoLVM to v0.5.2.
- Remove fsGroup for topolvm provisioned volume.