### PR TITLE
Stabilize argocd sync

### DIFF
--- a/argocd-config/base/maneki-apps.yaml
+++ b/argocd-config/base/maneki-apps.yaml
@@ -4,7 +4,7 @@ metadata:
   name: maneki-apps
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-wave: "11"
   labels:
     is-tenant: "true"
 spec:

--- a/argocd-config/base/network-policy.yaml
+++ b/argocd-config/base/network-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: network-policy
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "8"
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   project: default
   source:

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -77,13 +77,13 @@ func testApplicationResources(t *testing.T) {
 		"monitoring":           "7",
 		"sandbox":              "7",
 		"teleport":             "7",
-		"network-policy":       "8",
+		"network-policy":       "10",
 		"argocd-ingress":       "9",
 		"bmc-reverse-proxy":    "9",
 		"metrics-server":       "9",
 		"neco-admission":       "9",
 		"team-management":      "9",
-		"maneki-apps":          "10",
+		"maneki-apps":          "11",
 	}
 
 	// Getting overlays list


### PR DESCRIPTION
This PR moves network-policy sync-wave in order to prevent the connection failure to the Kube API server.