### PR TITLE
[Rook/Ceph] stabilize neco-apps CI

### DIFF
--- a/argocd-config/base/maneki-apps.yaml
+++ b/argocd-config/base/maneki-apps.yaml
@@ -4,7 +4,7 @@ metadata:
   name: maneki-apps
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-wave: "12"
   labels:
     is-tenant: "true"
 spec:

--- a/argocd-config/base/rook.yaml
+++ b/argocd-config/base/rook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rook
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "6"
+    argocd.argoproj.io/sync-wave: "11"
 spec:
   project: default
   source:

--- a/rook/overlays/gcp/ceph-ssd/cluster.yaml
+++ b/rook/overlays/gcp/ceph-ssd/cluster.yaml
@@ -1,7 +1,0 @@
-apiVersion: ceph.rook.io/v1
-kind: CephCluster
-metadata:
-  name: ceph-ssd
-  namespace: ceph-ssd
-  labels:
-    neco-apps.cybozu.com/raw-mode: "true"

--- a/rook/overlays/gcp/kustomization.yaml
+++ b/rook/overlays/gcp/kustomization.yaml
@@ -2,8 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-patches:
-  - ceph-ssd/cluster.yaml
 patchesJSON6902:
 - target:
     group: ceph.rook.io

--- a/teleport/base/statefulset.yaml
+++ b/teleport/base/statefulset.yaml
@@ -92,4 +92,4 @@ spec:
       resources:
         requests:
           storage: 10Gi
-      storageClassName: ceph-ssd-block
+      storageClassName: topolvm-provisioner

--- a/teleport/overlays/gcp/statefulset.yaml
+++ b/teleport/overlays/gcp/statefulset.yaml
@@ -13,4 +13,4 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: ceph-ssd-block
+      storageClassName: topolvm-provisioner

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -369,6 +369,15 @@ func applyAndWaitForApplications(commitID string) {
 			if doUpgrade {
 				for _, cond := range app.Status.Conditions {
 					if cond.Type == argocd.ApplicationConditionSyncError {
+						// TODO: this block should be deleted after https://github.com/cybozu-go/neco-apps/pull/765 is deployed on prod
+						if appName == "teleport" {
+							stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", appName, "--force")
+							if err != nil {
+								return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+							}
+							continue
+						}
+
 						stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", appName)
 						if err != nil {
 							return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -336,6 +336,11 @@ func applyAndWaitForApplications(commitID string) {
 			continue
 		}
 
+		// TODO: skip rook app until the app is stabilized
+		if !doCeph && app.Name == "rook" {
+			continue
+		}
+
 		appList = append(appList, app.Name)
 	}
 	fmt.Printf("application list: %v\n", appList)

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -183,30 +183,6 @@ func testSetup() {
 		})
 	}
 
-	// This block is to delete lv mode Ceph cluster
-	// TODO: Once raw mode Ceph cluster is constructed, this block should be deleted
-	// Also the label neco-apps.cybozu.com/raw-mode in manifest should be deleted
-	if doUpgrade {
-		It("should delete CephCluster ceph-ssd if it isn't raw-mode", func() {
-			By("checking neco-apps.cybozu.com/raw-mode annotation")
-			stdout, stderr, err := ExecAt(boot0, "kubectl", "-nceph-ssd", "get", "cephcluster", "-lneco-apps.cybozu.com/raw-mode=true")
-			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-			if strings.Contains(string(stderr), "No resources found") {
-				By("deleting ceph-ssd cluster because it was created with lv mode")
-				ExecSafeAt(boot0, "argocd", "app", "set", "rook", "--sync-policy=none")
-				ExecSafeAt(boot0, "argocd", "app", "set", "teleport", "--sync-policy=none")
-				ExecSafeAt(boot0, "kubectl", "-nteleport", "delete", "sts", "teleport-auth")
-				ExecSafeAt(boot0, "kubectl", "-nteleport", "delete", "pvc", "teleport-storage-teleport-auth-0")
-				ExecSafeAt(boot0, "kubectl", "delete", "storageclasses", "ceph-ssd-block")
-				ExecSafeAt(boot0, "kubectl", "-nceph-ssd", "annotate", "cephblockpool", "ceph-ssd-block-pool", "i-am-sure-to-delete=ceph-ssd-block-pool")
-				ExecSafeAt(boot0, "kubectl", "-nceph-ssd", "annotate", "cephcluster", "ceph-ssd", "i-am-sure-to-delete=ceph-ssd")
-				ExecSafeAt(boot0, "kubectl", "-nceph-ssd", "delete", "cephblockpool", "ceph-ssd-block-pool")
-				ExecSafeAt(boot0, "kubectl", "-nceph-ssd", "delete", "cephcluster", "ceph-ssd")
-				ExecSafeAt(boot0, "kubectl", "-nceph-ssd", "delete", "pvc", "--all")
-			}
-		})
-	}
-
 	It("should checkout neco-apps repository@"+commitID, func() {
 		ExecSafeAt(boot0, "rm", "-rf", "neco-apps")
 
@@ -221,12 +197,6 @@ func testSetup() {
 		}
 		ExecSafeAt(boot0, "sed", "-i", "s/release/"+commitID+"/", "./neco-apps/argocd-config/base/*.yaml")
 		applyAndWaitForApplications(commitID)
-	})
-
-	// This block is for workaround to avoid tls handshake error due to deletion ceph-ssd-block-pool
-	// TODO: Delete this block after Rook 1.4 is applied
-	It("should restart teleport-proxy Pod", func() {
-		ExecSafeAt(boot0, "kubectl", "-nteleport", "delete", "pod", "-lapp.kubernetes.io/component=proxy")
 	})
 
 	It("should set DNS", func() {

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -73,7 +73,6 @@ func testApplicationResources(t *testing.T) {
 		"topolvm":              "5",
 		"unbound":              "5",
 		"elastic":              "6",
-		"rook":                 "6",
 		"monitoring":           "7",
 		"sandbox":              "7",
 		"teleport":             "7",
@@ -83,7 +82,8 @@ func testApplicationResources(t *testing.T) {
 		"neco-admission":       "9",
 		"team-management":      "9",
 		"network-policy":       "10",
-		"maneki-apps":          "11",
+		"rook":                 "11",
+		"maneki-apps":          "12",
 	}
 
 	// Getting overlays list


### PR DESCRIPTION
- Change Teleport's storage to TopoLVM instead of RBD.
- Move Rook to last of syncWeve.
- Ignore Rook on eventually loop to wait for sync of ArgoCD.
- Move test for Rook to Ceph test job.
