### PR TITLE
rook: remove rook app from gcp CI to stabilize CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
           name: Test neco-apps
           command: |
             export NECO_DIR=$(pwd)/neco
-            TARGET=dctest-ceph ./bin/run-test.sh
+            OVERLAY=gcp-rook TARGET=dctest-ceph ./bin/run-test.sh
           no_output_timeout: 31m
       - delete-instance
 

--- a/argocd-config/base/kustomization.yaml
+++ b/argocd-config/base/kustomization.yaml
@@ -17,7 +17,6 @@ resources:
 - neco-admission.yaml
 - network-policy.yaml
 - pvc-autoresizer.yaml
-- rook.yaml
 - sandbox.yaml
 - secrets.yaml
 - team-management.yaml

--- a/argocd-config/overlays/gcp-rook/kustomization.yaml
+++ b/argocd-config/overlays/gcp-rook/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../gcp
+- rook.yaml

--- a/argocd-config/overlays/gcp-rook/rook.yaml
+++ b/argocd-config/overlays/gcp-rook/rook.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/cybozu-go/neco-apps.git
     targetRevision: release
-    path: rook/base
+    path: rook/overlays/gcp
   destination:
     server: https://kubernetes.default.svc
     namespace: ceph-hdd

--- a/argocd-config/overlays/gcp/kustomization.yaml
+++ b/argocd-config/overlays/gcp/kustomization.yaml
@@ -13,4 +13,3 @@ patchesStrategicMerge:
 - sandbox.yaml
 - secrets.yaml
 - teleport.yaml
-- rook.yaml

--- a/argocd-config/overlays/gcp/rook.yaml
+++ b/argocd-config/overlays/gcp/rook.yaml
@@ -1,8 +1,0 @@
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: rook
-  namespace: argocd
-spec:
-  source:
-    path: rook/overlays/gcp

--- a/argocd-config/overlays/osaka0/kustomization.yaml
+++ b/argocd-config/overlays/osaka0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - maneki-apps.yaml
+- rook.yaml
 patchesStrategicMerge:
 - argocd-ingress.yaml
 - argocd.yaml
@@ -14,4 +15,3 @@ patchesStrategicMerge:
 - monitoring.yaml
 - secrets.yaml
 - teleport.yaml
-- rook.yaml

--- a/argocd-config/overlays/osaka0/rook.yaml
+++ b/argocd-config/overlays/osaka0/rook.yaml
@@ -3,6 +3,32 @@ kind: Application
 metadata:
   name: rook
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
 spec:
+  project: default
   source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
+    targetRevision: release
     path: rook/overlays/osaka0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ceph-hdd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  ignoreDifferences:
+    # count may be changed manually
+    - group: ceph.rook.io
+      kind: CephCluster
+      name: ceph-ssd
+      namespace: ceph-ssd
+      jsonPointers:
+        - /spec/storage/storageClassDeviceSets/0/count
+    - group: ceph.rook.io
+      kind: CephCluster
+      name: ceph-hdd
+      namespace: ceph-hdd
+      jsonPointers:
+        - /spec/storage/storageClassDeviceSets/0/count

--- a/argocd-config/overlays/stage0/kustomization.yaml
+++ b/argocd-config/overlays/stage0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - maneki-apps.yaml
+- rook.yaml
 patchesStrategicMerge:
 - argocd-ingress.yaml
 - argocd.yaml
@@ -25,5 +26,4 @@ patchesStrategicMerge:
 - team-management.yaml
 - teleport.yaml
 - topolvm.yaml
-- rook.yaml
 - unbound.yaml

--- a/argocd-config/overlays/stage0/rook.yaml
+++ b/argocd-config/overlays/stage0/rook.yaml
@@ -3,7 +3,32 @@ kind: Application
 metadata:
   name: rook
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
 spec:
+  project: default
   source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
     targetRevision: stage
     path: rook/overlays/stage0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ceph-hdd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  ignoreDifferences:
+    # count may be changed manually
+    - group: ceph.rook.io
+      kind: CephCluster
+      name: ceph-ssd
+      namespace: ceph-ssd
+      jsonPointers:
+        - /spec/storage/storageClassDeviceSets/0/count
+    - group: ceph.rook.io
+      kind: CephCluster
+      name: ceph-hdd
+      namespace: ceph-hdd
+      jsonPointers:
+        - /spec/storage/storageClassDeviceSets/0/count

--- a/argocd-config/overlays/tokyo0/kustomization.yaml
+++ b/argocd-config/overlays/tokyo0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - maneki-apps.yaml
+- rook.yaml
 patchesStrategicMerge:
 - argocd-ingress.yaml
 - argocd.yaml
@@ -14,4 +15,3 @@ patchesStrategicMerge:
 - monitoring.yaml
 - secrets.yaml
 - teleport.yaml
-- rook.yaml

--- a/argocd-config/overlays/tokyo0/rook.yaml
+++ b/argocd-config/overlays/tokyo0/rook.yaml
@@ -3,6 +3,32 @@ kind: Application
 metadata:
   name: rook
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
 spec:
+  project: default
   source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
+    targetRevision: release
     path: rook/overlays/tokyo0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ceph-hdd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  ignoreDifferences:
+    # count may be changed manually
+    - group: ceph.rook.io
+      kind: CephCluster
+      name: ceph-ssd
+      namespace: ceph-ssd
+      jsonPointers:
+        - /spec/storage/storageClassDeviceSets/0/count
+    - group: ceph.rook.io
+      kind: CephCluster
+      name: ceph-hdd
+      namespace: ceph-hdd
+      jsonPointers:
+        - /spec/storage/storageClassDeviceSets/0/count

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -4,6 +4,7 @@
 
 TARGET=${TARGET:-dctest}
 BASE_BRANCH=${BASE_BRANCH:-master}
+OVERLAY=${OVERLAY:-gcp}
 
 cat >run.sh <<EOF
 #!/bin/sh -ex
@@ -24,7 +25,7 @@ git checkout -qf ${CIRCLE_SHA1}
 cd test
 cp /home/cybozu/account.json ./
 make setup
-make $TARGET COMMIT_ID=${CIRCLE_SHA1} BASE_BRANCH=${BASE_BRANCH}
+make $TARGET COMMIT_ID=${CIRCLE_SHA1} BASE_BRANCH=${BASE_BRANCH} OVERLAY=${OVERLAY}
 EOF
 chmod +x run.sh
 

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -196,6 +196,7 @@ func testSetup() {
 			setupArgoCD()
 		}
 		ExecSafeAt(boot0, "sed", "-i", "s/release/"+commitID+"/", "./neco-apps/argocd-config/base/*.yaml")
+		ExecSafeAt(boot0, "sed", "-i", "s/release/"+commitID+"/", "./neco-apps/argocd-config/overlays/"+overlayName+"/*.yaml")
 		applyAndWaitForApplications(commitID)
 	})
 
@@ -312,11 +313,6 @@ func applyAndWaitForApplications(commitID string) {
 			continue
 		}
 
-		// TODO: skip rook app until the app is stabilized
-		if !doCeph && app.Name == "rook" {
-			continue
-		}
-
 		appList = append(appList, app.Name)
 	}
 	fmt.Printf("application list: %v\n", appList)
@@ -350,15 +346,6 @@ func applyAndWaitForApplications(commitID string) {
 			if doUpgrade {
 				for _, cond := range app.Status.Conditions {
 					if cond.Type == argocd.ApplicationConditionSyncError {
-						// TODO: this block should be deleted after https://github.com/cybozu-go/neco-apps/pull/765 is deployed on prod
-						if appName == "teleport" {
-							stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", appName, "--force")
-							if err != nil {
-								return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
-							}
-							continue
-						}
-
 						stdout, stderr, err := ExecAt(boot0, "argocd", "app", "sync", appName)
 						if err != nil {
 							return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -55,6 +55,7 @@ func kustomizeBuild(dir string) ([]byte, []byte, error) {
 func testApplicationResources(t *testing.T) {
 	targetRevisions := map[string]string{
 		"gcp":      "release",
+		"gcp-rook": "release",
 		"neco-dev": "release",
 		"osaka0":   "release",
 		"stage0":   "stage",


### PR DESCRIPTION
- remove rook app from circle-ci on gcp
- create gcp-rook folder and apply it when CI of ceph

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>