### PR TITLE
remove useless prometheus relabel configs.

### DIFF
--- a/monitoring/base/prometheus/prometheus.yaml
+++ b/monitoring/base/prometheus/prometheus.yaml
@@ -103,12 +103,6 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
       action: keep
       regex: kubernetes;https
-    - source_labels: [__name__]
-      action: drop
-      regex: apiserver_request_duration_seconds.*
-    - source_labels: [__name__]
-      action: drop
-      regex: apiserver_request_latency_seconds.*
     - source_labels: [__address__]
       action: replace
       regex: ([^:]+)(?::\d+)?
@@ -174,9 +168,6 @@ scrape_configs:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
-      - source_labels: [__name__]
-        action: drop
-        regex: kubelet_runtime_operations_duration_seconds.*
   - job_name: 'kubernetes-cadvisor'
     scheme: https
     tls_config:
@@ -225,9 +216,6 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: kubernetes_name
-      - source_labels: [__name__]
-        action: drop
-        regex: node_cpu_seconds_total
       # CAUTION:
       # Do not remove the port number from instance label
       # because node-exporter-full dashboard expects to be in the form of `ip:port`.


### PR DESCRIPTION
prometheus.yaml have some `action: drop` relabel configs to drop some metrics. However, those configs does not work and the metrics have been already used. So, remove the useless configs.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>