### PR TITLE
reboot: alert if nodes are unschedulable

### DIFF
--- a/monitoring/base/prometheus/alert_rules/kubernetes.yaml
+++ b/monitoring/base/prometheus/alert_rules/kubernetes.yaml
@@ -432,6 +432,15 @@ groups:
         for: 15m
         labels:
           severity: minor
+      - alert: KubeNodeUnschedulable
+        annotations:
+          summary: '{{ $labels.node }} has been unschedulable for more than 15 minutes.'
+          runbook: TBD
+        expr: |
+          kube_node_spec_unschedulable{job="kube-state-metrics"} == 1
+        for: 15m
+        labels:
+          severity: minor
       - alert: KubeVersionMismatch
         annotations:
           summary: There are {{ $value }} different semantic versions of Kubernetes

--- a/test/alert_test/kubernetes.yaml
+++ b/test/alert_test/kubernetes.yaml
@@ -415,6 +415,21 @@ tests:
               summary: 10.0.0.1 has been unready for more than 15 minutes.
   - interval: 1m
     input_series:
+      - series: 'kube_node_spec_unschedulable{job="kube-state-metrics", node="10.0.0.1"}'
+        values: '1+0x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: KubeNodeUnschedulable
+        exp_alerts:
+          - exp_labels:
+              severity: minor
+              job: kube-state-metrics
+              node: 10.0.0.1
+            exp_annotations:
+              runbook: TBD
+              summary: 10.0.0.1 has been unschedulable for more than 15 minutes.
+  - interval: 1m
+    input_series:
       - series: 'kubernetes_build_info{job="kubernetes-nodes", gitVersion="v1.99.9", instance="10.0.0.1"}'
         values: '1+0x15'
       - series: 'kubernetes_build_info{job="kubernetes-nodes", gitVersion="v1.99.9", instance="10.0.0.2"}'


### PR DESCRIPTION
This PR adds `KubeNodeUnschedulable` alert to monitor cordoned nodes.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>