### PR TITLE
Clean up code blocks which was added only for regular container update in 2020/09

### DIFF
--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -570,27 +570,14 @@ func testGrafanaOperator() {
 			}
 			var dashboards []struct {
 				ID int `json:"id"`
-				// TODO: this field should be deleted after grafana-operator v3.6.0 is merged to release branch
-				Title string `json:"title"`
 			}
 			err = json.Unmarshal(stdout, &dashboards)
 			if err != nil {
 				return err
 			}
 
-			// TODO: this code block should be deleted after grafana-operator v3.6.0 is merged to release branch
-			offset := 0
-			for _, d := range dashboards {
-				if d.Title == "Node Exporter Full" {
-					offset++
-					break
-				}
-			}
-
 			// NOTE: expectedNum is the number of files under monitoring/base/grafana/dashboards
-			// TODO: this comparison logic should be replaced after grafana-operator v3.6.0 is merged to release branch
-			// len(dashboards) != numGrafanaDashboard
-			if len(dashboards)-offset != numGrafanaDashboard-1 {
+			if len(dashboards) != numGrafanaDashboard {
 				return fmt.Errorf("len(dashboards) should be %d: %d", numGrafanaDashboard, len(dashboards))
 			}
 			return nil


### PR DESCRIPTION
This PR cleans up some temporal code blocks which are added to emulate manual operations to be done only once for https://github.com/cybozu-go/neco-apps/pull/783.
Signed-off-by: Masayuki Ishii <masa213f@gmail.com>