### PR TITLE
Add teleport proxy test which confirms that teleport client can access kube-apiserver

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -33,8 +33,10 @@ PROMTOOL_DLPATH := $(DOWNLOAD_DIR)/prometheus-v$(PROMTOOL_VERSION).tar.gz
 TELEPORT_DLPATH := $(DOWNLOAD_DIR)/teleport-v$(TELEPORT_VERSION).tar.gz
 
 BINDIR := $(abspath $(CURDIR)/bin)
+KUBECTL := $(BINDIR)/kubectl
 KUSTOMIZE := $(BINDIR)/kustomize
 PROMTOOL := $(BINDIR)/promtool
+TSH := $(BINDIR)/tsh
 
 install.yaml: $(shell find ../argocd/base)
 	$(KUSTOMIZE) build ../argocd/base/ > install.yaml
@@ -72,33 +74,38 @@ dctest-upgrade:
 	cp /tmp/neco-apps/test/argocd-password.txt ./
 	PATH=$(BINDIR):$$PATH CEPH=$(CEPH) OVERLAY=$(OVERLAY) UPGRADE=1 ./test.sh
 
+$(KUBECTL):
+	mkdir -p $(BINDIR)
+	$(MAKE) setup-download
+	$(WGET) -O $@ https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
+	chmod +x $@
+
 setup-download:
 	if [ -z "$$(which wget)" ]; then \
 		$(SUDO) apt-get update && $(SUDO) apt-get -y install wget; \
 	fi
 	mkdir -p $(DOWNLOAD_DIR)
 
-$(KUSTOMIZE_DLPATH):
+$(KUSTOMIZE):
+	mkdir -p $(BINDIR)
 	$(MAKE) setup-download
 	$(WGET) -O $(KUSTOMIZE_DLPATH) https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz
+	tar zxf $(KUSTOMIZE_DLPATH) -C $(BINDIR)
+	chmod +x $@
 
-$(PROMTOOL_DLPATH):
+$(PROMTOOL):
+	mkdir -p $(BINDIR)
 	$(MAKE) setup-download
 	$(WGET) -O $(PROMTOOL_DLPATH) https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).linux-amd64.tar.gz
+	tar zxf $(PROMTOOL_DLPATH) -C $(BINDIR) --strip-components=1 prometheus-$(PROMTOOL_VERSION).linux-amd64/promtool
 
-$(TELEPORT_DLPATH):
+$(TSH):
+	mkdir -p $(BINDIR)
 	$(MAKE) setup-download
 	$(WGET) -O $(TELEPORT_DLPATH) https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-linux-amd64-bin.tar.gz
+	tar zxf $(TELEPORT_DLPATH) -C $(BINDIR) --strip-component=1 teleport/tsh
 
-setup: $(KUSTOMIZE_DLPATH) $(PROMTOOL_DLPATH) $(TELEPORT_DLPATH)
-	mkdir -p $(BINDIR)
-	tar zxf $(KUSTOMIZE_DLPATH) -C /tmp
-	cp /tmp/kustomize $(BINDIR)/kustomize
-	chmod +x $(BINDIR)/kustomize
-	tar zxf $(PROMTOOL_DLPATH) -C /tmp --strip-components=1 prometheus-$(PROMTOOL_VERSION).linux-amd64/promtool
-	cp /tmp/promtool $(BINDIR)/promtool
-	tar zxf $(TELEPORT_DLPATH) -C /tmp --strip-component=1 teleport/tsh
-	cp /tmp/tsh $(BINDIR)/tsh
+setup: $(KUBECTL) $(KUSTOMIZE) $(PROMTOOL) $(TSH)
 	go install github.com/onsi/ginkgo/ginkgo
 
 .PHONY: test-tools

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -67,6 +67,7 @@ stringData:
       kubernetes:
         enabled: true
         listen_addr: 0.0.0.0:3026
+        public_addr: [ "teleport.gcp0.dev-ne.co:3026" ]
       listen_addr: 0.0.0.0:3023
       public_addr: [ "teleport.gcp0.dev-ne.co:443" ]
       web_listen_addr: 0.0.0.0:3080

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -185,6 +185,41 @@ func testSetup() {
 		})
 	}
 
+	// TODO: remove this block after this code is released.
+	if doUpgrade {
+		It("should recreate teleport secrets", func() {
+			stdout, stderr, err := ExecAt(boot0, "env", "ETCDCTL_API=3", "etcdctl", "--cert=/etc/etcd/backup.crt", "--key=/etc/etcd/backup.key",
+				"get", "--print-value-only", "/neco/teleport/auth-token")
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+			teleportToken := strings.TrimSpace(string(stdout))
+			teleportTmpl := template.Must(template.New("").Parse(teleportSecret))
+			buf := bytes.NewBuffer(nil)
+			err = teleportTmpl.Execute(buf, struct {
+				Token string
+			}{
+				Token: teleportToken,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			stdout, stderr, err = ExecAtWithInput(boot0, buf.Bytes(), "kubectl", "apply", "-n", "teleport", "-f", "-")
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+
+			stdout, stderr, err = ExecAt(boot0,
+				"kubectl", "get", "po",
+				"-n=teleport",
+				"--selector app.kubernetes.io/component=proxy,app.kubernetes.io/name=teleport",
+				"-o", "json",
+			)
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+			var podList corev1.PodList
+			err = json.Unmarshal(stdout, &podList)
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s", stdout)
+			Expect(podList.Items).To(HaveLen(1))
+			stdout, stderr, err = ExecAt(boot0, "kubectl", "delete", "pod", "-n", "teleport", podList.Items[0].Name)
+			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+		})
+	}
+
 	It("should checkout neco-apps repository@"+commitID, func() {
 		ExecSafeAt(boot0, "rm", "-rf", "neco-apps")
 

--- a/test/teleport_test.go
+++ b/test/teleport_test.go
@@ -155,15 +155,10 @@ func testTeleport() {
 			go func() { io.Copy(os.Stdout, ptmx) }()
 			return cmd.Wait()
 		}).Should(Succeed())
-		cmd = exec.Command("tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "login")
-		ptmx, err := pty.Start(cmd)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer ptmx.Close()
-		_, err = ptmx.Write([]byte("dummypass\n"))
-		Expect(err).ShouldNot(HaveOccurred())
-		go func() { io.Copy(os.Stdout, ptmx) }()
-		err = cmd.Wait()
-		Expect(err).ShouldNot(HaveOccurred())
+
+		By("getting node resources with kubectl via teleport proxy")
+		output, err = exec.Command("kubectl", "get", "nodes").CombinedOutput()
+		Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
 
 		By("accessing boot servers using tsh command")
 		for _, n := range []string{"boot-0", "boot-1", "boot-2"} {


### PR DESCRIPTION
Update of teleport from v4.1 to v4.2 caused a degradation that the URL of kube-apiserver is given like 0.0.0.0:3206.
This PR contains a new test case to prevent this behavior from occurring again.

Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>