### PR TITLE
coil: Enable sessionAffinity for egresses

### DIFF
--- a/coil/base/egress.yaml
+++ b/coil/base/egress.yaml
@@ -7,7 +7,10 @@ spec:
   replicas: 2
   destinations:
   - 0.0.0.0/0
-  sessionAffinity: None
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 43200  # 12 hours
 ---
 apiVersion: coil.cybozu.com/v2
 kind: Egress
@@ -18,4 +21,7 @@ spec:
   replicas: 2
   destinations:
   - 10.0.3.0/24
-  sessionAffinity: None
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 43200  # 12 hours

--- a/customer-egress/base/egress.yaml
+++ b/customer-egress/base/egress.yaml
@@ -7,4 +7,7 @@ spec:
   replicas: 2
   destinations:
   - 0.0.0.0/0
-  sessionAffinity: None
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 43200  # 12 hours


### PR DESCRIPTION
I investigated https://github.com/torvalds/linux/blob/bbe2ba04c5a92a49db8a42c850a5a2f6481e47eb/net/netfilter/ipvs/ip_vs_core.c
and found that the session affinity timeout for UDP is updated every time packets are sent or received.
This means that the source hashing option is not needed any more and we should just use `sessionAffinity` to keep long-lived sessions  alive.
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>