### PR TITLE
mackerel-agent: store stateful data in Ceph RBD volume

### DIFF
--- a/monitoring/overlays/osaka0/mackerel-agent.yaml
+++ b/monitoring/overlays/osaka0/mackerel-agent.yaml
@@ -54,5 +54,12 @@ spec:
           secretName: mackerel-agent
       - name: run
         emptyDir: {}
-      - name: var-lib-mackerel-agent
-        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: var-lib-mackerel-agent
+    spec:
+      storageClassName: ceph-ssd-block
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 100Mi

--- a/monitoring/overlays/stage0/mackerel-agent.yaml
+++ b/monitoring/overlays/stage0/mackerel-agent.yaml
@@ -54,5 +54,12 @@ spec:
           secretName: mackerel-agent
       - name: run
         emptyDir: {}
-      - name: var-lib-mackerel-agent
-        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: var-lib-mackerel-agent
+    spec:
+      storageClassName: ceph-ssd-block
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 100Mi

--- a/monitoring/overlays/tokyo0/mackerel-agent.yaml
+++ b/monitoring/overlays/tokyo0/mackerel-agent.yaml
@@ -54,5 +54,12 @@ spec:
           secretName: mackerel-agent
       - name: run
         emptyDir: {}
-      - name: var-lib-mackerel-agent
-        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: var-lib-mackerel-agent
+    spec:
+      storageClassName: ceph-ssd-block
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 100Mi


### PR DESCRIPTION
`mackerel-agent` stores its host ID under `/var/lib/mackerel-agent` directory.
To keep the host ID between Pod recreation, the volume for the directory should be persistent.