### PR TITLE
monitoring: backport KubePodCrashLooping alert rule

### DIFF
--- a/monitoring/base/prometheus/alert_rules/kubernetes.yaml
+++ b/monitoring/base/prometheus/alert_rules/kubernetes.yaml
@@ -258,7 +258,7 @@ groups:
             }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
           runbook: TBD
         expr: |
-          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace!~"app-.+|maneki|sandbox"}[15m]) * 60 * 5 > 0
+          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace!~"app-.+|maneki|sandbox"}[5m]) * 60 * 5 > 0
         for: 15m
         labels:
           severity: minor


### PR DESCRIPTION
The `KubePodCrashLooping` alert rule in neco-apps is too sensitive.
The upstream rule is fixed, backport it.

Please check the following rule.
https://github.com/prometheus-operator/kube-prometheus/blob/v0.6.0/manifests/prometheus-rules.yaml#L1031

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>