### PR TITLE
neco-admission: Use upstream

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -177,6 +177,14 @@ $ cp -r deploy/* $GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/graf
 
 Update version following [this link](https://github.com/cybozu/neco-containers/blob/master/admission/TAG)
 
+Download the upstream manifest as follows:
+
+```console
+$ git clone https://github.com/cybozu/neco-containers
+$ cd neco-containers
+$ cp admission/config/webhook/manifests.yaml $GOPATH/src/github.com/cybozu-go/neco-apps/neco-admission/base/upstream
+```
+
 ## network-policy (Calico)
 
 Check [the release notes](https://docs.projectcalico.org/release-notes/).

--- a/neco-admission/base/kustomization.yaml
+++ b/neco-admission/base/kustomization.yaml
@@ -6,9 +6,26 @@ resources:
 - role.yaml
 - rolebinding.yaml
 - serviceaccount.yaml
-- webhook.yaml
+- upstream/manifests.yaml
 configMapGenerator:
   - name: neco-admission-config
     files:
       - config.yaml
 namespace: kube-system
+patchesStrategicMerge:
+  - webhook.yaml
+patches:
+- target:
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: neco-admission
+- target:
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: neco-admission

--- a/neco-admission/base/upstream/manifests.yaml
+++ b/neco-admission/base/upstream/manifests.yaml
@@ -1,0 +1,140 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-projectcontour-io-httpproxy
+  failurePolicy: Fail
+  name: mhttpproxy.kb.io
+  rules:
+  - apiGroups:
+    - projectcontour.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - httpproxies
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-pod
+  failurePolicy: Fail
+  name: mpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-argoproj-io-application
+  failurePolicy: Fail
+  name: vapplication.kb.io
+  rules:
+  - apiGroups:
+    - argoproj.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - applications
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-delete
+  failurePolicy: Fail
+  name: vdelete.kb.io
+  rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    apiVersions:
+    - v1
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - customresourcedefinitions
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-integreatly-org-grafanadashboard
+  failurePolicy: Fail
+  name: vgrafanadashboard.kb.io
+  rules:
+  - apiGroups:
+    - integreatly.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - grafanadashboards
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-projectcontour-io-httpproxy
+  failurePolicy: Fail
+  name: vhttpproxy.kb.io
+  rules:
+  - apiGroups:
+    - projectcontour.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - httpproxies
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-projectcalico-org-networkpolicy
+  failurePolicy: Fail
+  name: vnetworkpolicy.kb.io
+  rules:
+  - apiGroups:
+    - crd.projectcalico.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies

--- a/neco-admission/base/webhook.yaml
+++ b/neco-admission/base/webhook.yaml
@@ -1,135 +1,89 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: neco-admission
+  name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: kube-system/neco-admission
+  creationTimestamp: null
 webhooks:
+- name: mhttpproxy.kb.io
+  clientConfig:
+    caBundle: null
+    service:
+      name: neco-admission
+      namespace: kube-system
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: NotIn
+      values:
+      - "true"
 - name: mpod.kb.io
   clientConfig:
+    caBundle: null
     service:
       name: neco-admission
       namespace: kube-system
-      path: /mutate-pod
-  failurePolicy: Fail
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: NotIn
+      values:
+      - "true"
   objectSelector:
     matchExpressions:
-      - key: app.kubernetes.io/name
-        operator: NotIn
-        values:
-          - neco-admission
-  namespaceSelector:
-    matchExpressions:
-    - key: control-plane
+    - key: app.kubernetes.io/name
       operator: NotIn
-      values: ["true"]
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-- name: mhttpproxy.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: control-plane
-      operator: NotIn
-      values: ["true"]
-  clientConfig:
-    service:
-      name: neco-admission
-      namespace: kube-system
-      path: /mutate-projectcontour-io-httpproxy
-  failurePolicy: Fail
-  rules:
-  - apiGroups:
-    - projectcontour.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - httpproxies
+      values:
+      - neco-admission
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: neco-admission
+  name: validating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: kube-system/neco-admission
+  creationTimestamp: null
 webhooks:
 - name: vhttpproxy.kb.io
+  clientConfig:
+    caBundle: null
+    service:
+      name: neco-admission
+      namespace: kube-system
   namespaceSelector:
     matchExpressions:
     - key: control-plane
       operator: NotIn
-      values: ["true"]
-  clientConfig:
-    service:
-      name: neco-admission
-      namespace: kube-system
-      path: /validate-projectcontour-io-httpproxy
-  failurePolicy: Fail
-  rules:
-  - apiGroups:
-    - projectcontour.io
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - httpproxies
+      values:
+      - "true"
 - name: vnetworkpolicy.kb.io
+  clientConfig:
+    caBundle: null
+    service:
+      name: neco-admission
+      namespace: kube-system
   namespaceSelector:
     matchExpressions:
     - key: control-plane
       operator: NotIn
-      values: ["true"]
-  clientConfig:
-    service:
-      name: neco-admission
-      namespace: kube-system
-      path: /validate-projectcalico-org-networkpolicy
-  failurePolicy: Fail
-  rules:
-  - apiGroups:
-    - crd.projectcalico.org
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - networkpolicies
+      values:
+      - "true"
 - name: vapplication.kb.io
   clientConfig:
+    caBundle: null
     service:
       name: neco-admission
       namespace: kube-system
-      path: /validate-argoproj-io-application
-  failurePolicy: Fail
-  rules:
-  - apiGroups:
-    - argoproj.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - applications
 - name: vdelete.kb.io
   clientConfig:
+    caBundle: null
     service:
       name: neco-admission
       namespace: kube-system
-      path: /validate-delete
-  failurePolicy: Fail
   matchPolicy: Equivalent
+  # According to this code https://github.com/kubernetes-sigs/controller-tools/blob/master/pkg/webhook/parser.go#L183,
+  # `rules` cannot be generated with multiple GVK, so we should add new GVK manually here.
   rules:
   - apiGroups:
     - apiextensions.k8s.io
@@ -158,3 +112,10 @@ webhooks:
     - cephblockpools
     - cephclusters
     - cephobjectstores
+- name: vgrafanadashboard.kb.io
+  clientConfig:
+    caBundle: null
+    service:
+      name: neco-admission
+      namespace: kube-system
+  matchPolicy: Equivalent


### PR DESCRIPTION
ValidatingWehbhookConfiguration for GrafanaDashboard is left unconfigured by mistake.
This PR adds the config to the manifest.
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>