### PR TITLE
monitoring: fix alert rules to use neco reboot-worker

### DIFF
--- a/monitoring/base/prometheus/alert_rules/cke.yaml
+++ b/monitoring/base/prometheus/alert_rules/cke.yaml
@@ -21,7 +21,7 @@ groups:
           severity: minor
       - alert: CKEOperationTakesLongTime
         expr: |
-          sum(cke_operation_phase{phase!="completed"}) > 0
+          sum(cke_operation_phase{phase!~"completed|reboot-nodes"}) > 0
         labels:
           severity: warning
         for: 30m
@@ -39,12 +39,21 @@ groups:
           runbook: TBD
       - alert: CKEDoesNotPerformAnyOps
         expr: |
-          rate(cke_operation_phase_timestamp_seconds[1h]) == 0
+          rate(cke_operation_phase_timestamp_seconds[5m]) == 0
         labels:
           severity: warning
-        for: 15m
+        for: 1h
         annotations:
           summary: CKE does not perform any operations for more than 1 hour.
+          runbook: TBD
+      - alert: CKERebootQueueStuck
+        expr: |
+          sum(rate(cke_reboot_queue_entries[5m])) == 0 and sum(cke_reboot_queue_entries) > 0
+        labels:
+          severity: warning
+        for: 1h
+        annotations:
+          summary: CKE reboot queue is stuck for more than 1 hour.
           runbook: TBD
       - alert: CKESabakanIntegrationSeemsToBeFailed
         expr: |
@@ -57,7 +66,7 @@ groups:
           runbook: TBD
       - alert: CKESabakanIntegrationDoesNotPerformAnyOps
         expr: |
-          rate(cke_sabakan_integration_timestamp_seconds[1h]) == 0
+          sum(rate(cke_sabakan_integration_timestamp_seconds[5m])) == 0 and sum(cke_operation_phase{phase="reboot-nodes"}) == 0
         labels:
           severity: warning
         for: 60m

--- a/monitoring/base/prometheus/alert_rules/cke.yaml
+++ b/monitoring/base/prometheus/alert_rules/cke.yaml
@@ -39,7 +39,7 @@ groups:
           runbook: TBD
       - alert: CKEDoesNotPerformAnyOps
         expr: |
-          rate(cke_operation_phase_timestamp_seconds[5m]) == 0
+          (cke_operation_phase_timestamp_seconds - cke_operation_phase_timestamp_seconds offset 5m) == 0
         labels:
           severity: warning
         for: 1h
@@ -48,7 +48,7 @@ groups:
           runbook: TBD
       - alert: CKERebootQueueStuck
         expr: |
-          sum(rate(cke_reboot_queue_entries[5m])) == 0 and sum(cke_reboot_queue_entries) > 0
+          (cke_reboot_queue_entries - cke_reboot_queue_entries offset 5m) == 0 and cke_reboot_queue_entries > 0
         labels:
           severity: warning
         for: 1h
@@ -66,7 +66,7 @@ groups:
           runbook: TBD
       - alert: CKESabakanIntegrationDoesNotPerformAnyOps
         expr: |
-          sum(rate(cke_sabakan_integration_timestamp_seconds[5m])) == 0 and sum(cke_operation_phase{phase="reboot-nodes"}) == 0
+          ((cke_sabakan_integration_timestamp_seconds - cke_sabakan_integration_timestamp_seconds offset 5m) == 0) and ignoring(phase) (cke_operation_phase{phase="reboot-nodes"} == 0)
         labels:
           severity: warning
         for: 60m

--- a/monitoring/base/prometheus/alert_rules/kubernetes.yaml
+++ b/monitoring/base/prometheus/alert_rules/kubernetes.yaml
@@ -428,7 +428,7 @@ groups:
           summary: '{{ $labels.node }} has been unready for more than 15 minutes.'
           runbook: TBD
         expr: |
-          sum by(node) (kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}) == 0 and sum by(node) (kube_node_spec_unschedulable{job="kube-state-metrics"}) == 0
+          (kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0) and ignoring(condition,status) (kube_node_spec_unschedulable{job="kube-state-metrics"} == 0)
         for: 15m
         labels:
           severity: minor

--- a/monitoring/base/prometheus/alert_rules/kubernetes.yaml
+++ b/monitoring/base/prometheus/alert_rules/kubernetes.yaml
@@ -366,7 +366,7 @@ groups:
           kube_daemonset_status_number_ready{job="kube-state-metrics",namespace!~"app-.+|maneki|sandbox"}
             /
           kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics",namespace!~"app-.+|maneki|sandbox"} * 100 < 100
-        for: 15m
+        for: 30m
         labels:
           severity: minor
       - alert: KubeDaemonSetNotScheduled
@@ -428,17 +428,17 @@ groups:
           summary: '{{ $labels.node }} has been unready for more than 15 minutes.'
           runbook: TBD
         expr: |
-          kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+          sum by(node) (kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}) == 0 and sum by(node) (kube_node_spec_unschedulable{job="kube-state-metrics"}) == 0
         for: 15m
         labels:
           severity: minor
       - alert: KubeNodeUnschedulable
         annotations:
-          summary: '{{ $labels.node }} has been unschedulable for more than 15 minutes.'
+          summary: '{{ $labels.node }} has been unschedulable for more than 1 hour.'
           runbook: TBD
         expr: |
           kube_node_spec_unschedulable{job="kube-state-metrics"} == 1
-        for: 15m
+        for: 1h
         labels:
           severity: minor
       - alert: KubeVersionMismatch
@@ -561,7 +561,7 @@ groups:
         expr: count(up{job="kubernetes-apiservers"} == 1) < 3
         labels:
           severity: warning
-        for: 10m
+        for: 15m
         annotations:
           summary: The number of kube-apiserver is less than 3.
           runbook: Please consider to find root causes, and solve the problems

--- a/test/alert_test/cke.yaml
+++ b/test/alert_test/cke.yaml
@@ -86,6 +86,41 @@ tests:
               summary: CKE performs some operations.
   - interval: 1m
     input_series:
+      - series: cke_operation_phase_timestamp_seconds
+        values: '0 1+0x119'
+    alert_rule_test:
+    - eval_time: 65m
+      alertname: CKEDoesNotPerformAnyOps
+      exp_alerts: []
+    - eval_time: 66m
+      alertname: CKEDoesNotPerformAnyOps
+      exp_alerts:
+        - exp_labels:
+            severity: warning
+          exp_annotations:
+            runbook: TBD
+            summary: CKE does not perform any operations for more than 1 hour.
+  - interval: 1m
+    input_series:
+      - series: cke_reboot_queue_entries
+        values: '0+0x120 1+0x120'
+    alert_rule_test:
+    - eval_time: 90m
+      alertname: CKERebootQueueStuck
+      exp_alerts: []
+    - eval_time: 185m
+      alertname: CKERebootQueueStuck
+      exp_alerts: []
+    - eval_time: 186m
+      alertname: CKERebootQueueStuck
+      exp_alerts:
+        - exp_labels:
+            severity: warning
+          exp_annotations:
+            runbook: TBD
+            summary: CKE reboot queue is stuck for more than 1 hour.
+  - interval: 1m
+    input_series:
       - series: 'cke_sabakan_integration_successful'
         values: '0+0x59 1'
     alert_rule_test:
@@ -108,17 +143,14 @@ tests:
   - interval: 1m
     input_series:
       - series: 'cke_sabakan_integration_timestamp_seconds'
-        values: '0+0x60 1'
+        values: '0 1+0x119'
+      - series: 'cke_operation_phase{phase="reboot-nodes"}'
+        values: '0+0x120'
     alert_rule_test:
-      - eval_time: 61m
+      - eval_time: 65m
         alertname: CKESabakanIntegrationDoesNotPerformAnyOps
         exp_alerts: []
-  - interval: 1m
-    input_series:
-      - series: 'cke_sabakan_integration_timestamp_seconds'
-        values: '0+0x61'
-    alert_rule_test:
-      - eval_time: 61m
+      - eval_time: 66m
         alertname: CKESabakanIntegrationDoesNotPerformAnyOps
         exp_alerts:
           - exp_labels:
@@ -126,3 +158,13 @@ tests:
             exp_annotations:
               runbook: TBD
               summary: The timestamp of CKE-sabakan integration does not change for 1 hour.
+  - interval: 1m
+    input_series:
+      - series: 'cke_sabakan_integration_timestamp_seconds'
+        values: '0 1+0x119'
+      - series: 'cke_operation_phase{phase="reboot-nodes"}'
+        values: '1+0x120'
+    alert_rule_test:
+      - eval_time: 66m
+        alertname: CKESabakanIntegrationDoesNotPerformAnyOps
+        exp_alerts: []

--- a/test/alert_test/kubernetes.yaml
+++ b/test/alert_test/kubernetes.yaml
@@ -408,7 +408,10 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: minor
+              condition: Ready
+              job: kube-state-metrics
               node: 10.0.0.1
+              status: true
             exp_annotations:
               runbook: TBD
               summary: 10.0.0.1 has been unready for more than 15 minutes.

--- a/test/alert_test/kubernetes.yaml
+++ b/test/alert_test/kubernetes.yaml
@@ -31,7 +31,7 @@ tests:
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.3"}'
         values: 0+0x15
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 15m
         alertname: K8sAPIServersDegraded
         exp_alerts:
           - exp_labels:
@@ -48,7 +48,7 @@ tests:
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.3"}'
         values: 1+0x15
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 15m
         alertname: K8sAPIServersDegraded
         exp_alerts: []
   - interval: 1m
@@ -294,11 +294,11 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_daemonset_status_number_ready{job="kube-state-metrics", namespace="kube-system", daemonset="calico-node"}'
-        values: '8+0x15'
+        values: '8+0x30'
       - series: 'kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace="kube-system", daemonset="calico-node"}'
-        values: '10+0x15'
+        values: '10+0x30'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 30m
         alertname: KubeDaemonSetRolloutStuck
         exp_alerts:
           - exp_labels:
@@ -400,25 +400,34 @@ tests:
     input_series:
       - series: 'kube_node_status_condition{job="kube-state-metrics", condition="Ready", status="true", node="10.0.0.1"}'
         values: '0+0x15'
+      - series: 'kube_node_spec_unschedulable{job="kube-state-metrics", node="10.0.0.1"}'
+        values: '0+0x15'
     alert_rule_test:
       - eval_time: 15m
         alertname: KubeNodeNotReady
         exp_alerts:
           - exp_labels:
               severity: minor
-              condition: Ready
-              job: kube-state-metrics
               node: 10.0.0.1
-              status: true
             exp_annotations:
               runbook: TBD
               summary: 10.0.0.1 has been unready for more than 15 minutes.
   - interval: 1m
     input_series:
+      - series: 'kube_node_status_condition{job="kube-state-metrics", condition="Ready", status="true", node="10.0.0.1"}'
+        values: '0+0x15'
       - series: 'kube_node_spec_unschedulable{job="kube-state-metrics", node="10.0.0.1"}'
         values: '1+0x15'
     alert_rule_test:
       - eval_time: 15m
+        alertname: KubeNodeNotReady
+        exp_alerts: []
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_spec_unschedulable{job="kube-state-metrics", node="10.0.0.1"}'
+        values: '1+0x60'
+    alert_rule_test:
+      - eval_time: 60m
         alertname: KubeNodeUnschedulable
         exp_alerts:
           - exp_labels:
@@ -427,7 +436,7 @@ tests:
               node: 10.0.0.1
             exp_annotations:
               runbook: TBD
-              summary: 10.0.0.1 has been unschedulable for more than 15 minutes.
+              summary: 10.0.0.1 has been unschedulable for more than 1 hour.
   - interval: 1m
     input_series:
       - series: 'kubernetes_build_info{job="kubernetes-nodes", gitVersion="v1.99.9", instance="10.0.0.1"}'


### PR DESCRIPTION
This PR adds and fixes alert rules for `neco reboot-worker`.

### What this PR does: 

- `CKEOperationTakesLongTime`
  Reboot phase is removed from alert calculation.
- `CKESabakanIntegrationDoesNotPerformAnyOps`
  It is silenced when reboot operation is ongoing.
- `CKERebootQueueStuck`
  It is added to alert reboot queue being stuck for 60mins.
- `K8sAPIServersDegraded`
  Extend from 10mins to 15mins.
- `KubeDaemonSetRolloutStuck`
  Extend from 15mins to 30mins.
- `KubeNodeNotReady`
  It is silenced when the node is rebooted.
- `KubeNodeUnschedulable`
  Extend from 15mins to 60mins.

### What this PR is not for:

- `KubePodCrashLooping`
  It is already treated in #891.
- `KubeDeploymentReplicasMismatch`
- `KubePodNotReady`
  They are not treated in this PR.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>