### PR TITLE
test: Cleanup temporary code.

### DIFF
--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -186,30 +186,6 @@ func testSetup() {
 		})
 	}
 
-	// This block is for enabling Teleport Application feature
-	// After neco-apps#883 is merged, please delete this block
-	if doUpgrade {
-		It("should prepare secrets", func() {
-			By("creating upgraded secrets for teleport and reboot teleport-auth")
-			stdout, stderr, err := ExecAt(boot0, "env", "ETCDCTL_API=3", "etcdctl", "--cert=/etc/etcd/backup.crt", "--key=/etc/etcd/backup.key",
-				"get", "--print-value-only", "/neco/teleport/auth-token")
-			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-			teleportToken := strings.TrimSpace(string(stdout))
-			teleportTmpl := template.Must(template.New("").Parse(teleportSecret))
-			buf := bytes.NewBuffer(nil)
-			err = teleportTmpl.Execute(buf, struct {
-				Token string
-			}{
-				Token: teleportToken,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			stdout, stderr, err = ExecAtWithInput(boot0, buf.Bytes(), "kubectl", "apply", "-n", "teleport", "-f", "-")
-			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-			stdout, stderr, err = ExecAtWithInput(boot0, buf.Bytes(), "kubectl", "delete", "-n", "teleport", "pod", "teleport-auth-0")
-			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-		})
-	}
-
 	It("should checkout neco-apps repository@"+commitID, func() {
 		ExecSafeAt(boot0, "rm", "-rf", "neco-apps")
 


### PR DESCRIPTION
This PR cleans the  temporal code introduced [here](https://github.com/cybozu-go/neco-apps/pull/883).
Signed-off-by: Kazuhito MATSUDA <kazuhito.matuda@gmail.com>