### PR TITLE
grafana-operator: Upgrade to 3.7.0

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -169,9 +169,14 @@ Download the upstream manifest as follows:
 
 ```console
 $ git clone https://github.com/integr8ly/grafana-operator
-$ cd grafana-operator
+$ cd $GOPATH/src/github.com/integr8ly/grafana-operator
 $ git checkout vX.Y.Z
-$ cp -r deploy/* $GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/grafana-operator/upstream
+$ UPSTREAM_DIR=$GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/grafana-operator/upstream/
+$ rm -r $UPSTREAM_DIR/*
+$ cp -r deploy/crds $GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/grafana-operator/upstream
+$ cp -r deploy/cluster_roles $GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/grafana-operator/upstream
+$ cp -r deploy/roles $GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/grafana-operator/upstream
+$ cp deploy/operator.yaml $GOPATH/src/github.com/cybozu-go/neco-apps/monitoring/base/grafana-operator/upstream
 ```
 
 ### victoriametrics (operator)

--- a/monitoring/base/grafana-operator/upstream/cluster_roles/README.md
+++ b/monitoring/base/grafana-operator/upstream/cluster_roles/README.md
@@ -1,0 +1,25 @@
+# Grafana Operator | Cluster Roles
+
+## Grant Grafana instance RBAC to GrafanaDashboard definitions in other projects/namespaces
+
+By default a Grafana instance deployed by the Grafana Operator will only read GrafanaDashboard custom resources from the namespace/project that the Grafana instance is deployed in. If specifing the `--scan-all` or `--namespaces` flags or if your using `dashboardNamespaceSelector`, then the ServiceAccount that Grafana is running as needs view access to the GrafanaDashboard resources in other namespaces. To grant those permissions the following ClusterRole and ClusterRoleBinding need to be deployed.
+
+Create the `ClusterRole`
+```
+kubectl create -f cluster_role_grafana_operator.yaml
+```
+
+Create the `ClusterRoleBinding` for the `ServiceAccount/grafana-operator` in the given namespace
+```
+GRAFANA_NAMESPACE=grafana
+sed "s/namespace: grafana/namespace: ${GRAFANA_NAMESPACE}/g" cluster_role_binding_grafana_operator.yaml
+```
+
+## Grant non Cluster Admins permissions to deploy operator and associated Grafana instances
+
+For a cluster administrator to allow other users to be able to deploy Grafana operators and the associated Custom Resources namespace/project admins/editors need edit access to the Grafana Custom Resources.
+
+```
+kubectl create -f cluster_role_aggregate_grafana_admin_edit.yaml
+kubectl create -f cluster_role_aggregate_grafana_view.yaml
+```

--- a/monitoring/base/grafana-operator/upstream/crds/Grafana.yaml
+++ b/monitoring/base/grafana-operator/upstream/crds/Grafana.yaml
@@ -11,11 +11,11 @@ spec:
     singular: grafana
   scope: Namespaced
   subresources:
-    status: {}
+    status: { }
   version: v1alpha1
   validation:
     openAPIV3Schema:
-      required: ["spec"]
+      required: [ "spec" ]
       properties:
         spec:
           properties:
@@ -106,7 +106,7 @@ spec:
                 labels:
                   type: object
                   description: Additional labels for the service
-                nodeSelector: 
+                nodeSelector:
                   type: object
                   description: Additional labels for the running grafana pods in a labeled node.
                 tolerations:
@@ -147,3 +147,69 @@ spec:
             jsonnet:
               type: object
               description: Jsonnet library configuration
+        livenessProbeSpec:
+          type: object
+          properties:
+            initialDelaySeconds:
+              description: 'Number of seconds after the container has
+                                        started before liveness probes are initiated. More info:
+                                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+              format: int32
+              type: integer
+            timeoutSeconds:
+              description: Number of seconds after which the probe times out. Defaults to 1 second.
+                Minimum value is 1.
+              format: int32
+              type: integer
+            periodSeconds:
+              description: 'How often (in seconds) to perform the probe.
+                Default to 10 seconds. Minimum value is 1.'
+              format: int32
+              type: integer
+            successThreshold:
+              description: 'Minimum consecutive successes for the probe
+                to be considered successful after having failed. Defaults
+                to 1. Must be 1 for liveness and startup. Minimum value
+                is 1.'
+              format: int32
+              type: integer
+            failureThreshold:
+              description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
+              Giving up in case of liveness probe means restarting the container.
+              In case of readiness probe the Pod will be marked Unready.
+              Defaults to 3. Minimum value is 1.'
+              format: int32
+              type: integer
+          readinessProbeSpec:
+            type: object
+            properties:
+              initialDelaySeconds:
+                description: 'Number of seconds after the container has
+                                                 started before liveness probes are initiated. More info:
+                                                 https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                format: int32
+                type: integer
+              timeoutSeconds:
+                description: 'Number of seconds after which the probe times out. Defaults to 1 second.
+                  Minimum value is 1.'
+                format: int32
+                type: integer
+              periodSeconds:
+                description: 'How often (in seconds) to perform the probe.
+                  Default to 10 seconds. Minimum value is 1.'
+                format: int32
+                type: integer
+              successThreshold:
+                description: 'Minimum consecutive successes for the probe
+                  to be considered successful after having failed. Defaults
+                  to 1. Must be 1 for liveness and startup. Minimum value
+                  is 1.'
+                format: int32
+                type: integer
+              failureThreshold:
+                description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                Giving up in case of liveness probe means restarting the container.
+                In case of readiness probe the Pod will be marked Unready.
+                Defaults to 3. Minimum value is 1.'
+                format: int32
+                type: integer

--- a/monitoring/base/grafana-operator/upstream/crds/Grafana.yaml
+++ b/monitoring/base/grafana-operator/upstream/crds/Grafana.yaml
@@ -180,36 +180,36 @@ spec:
               Defaults to 3. Minimum value is 1.'
               format: int32
               type: integer
-          readinessProbeSpec:
-            type: object
-            properties:
-              initialDelaySeconds:
-                description: 'Number of seconds after the container has
-                                                 started before liveness probes are initiated. More info:
-                                                 https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                format: int32
-                type: integer
-              timeoutSeconds:
-                description: 'Number of seconds after which the probe times out. Defaults to 1 second.
-                  Minimum value is 1.'
-                format: int32
-                type: integer
-              periodSeconds:
-                description: 'How often (in seconds) to perform the probe.
-                  Default to 10 seconds. Minimum value is 1.'
-                format: int32
-                type: integer
-              successThreshold:
-                description: 'Minimum consecutive successes for the probe
-                  to be considered successful after having failed. Defaults
-                  to 1. Must be 1 for liveness and startup. Minimum value
-                  is 1.'
-                format: int32
-                type: integer
-              failureThreshold:
-                description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
-                Giving up in case of liveness probe means restarting the container.
-                In case of readiness probe the Pod will be marked Unready.
-                Defaults to 3. Minimum value is 1.'
-                format: int32
-                type: integer
+        readinessProbeSpec:
+          type: object
+          properties:
+            initialDelaySeconds:
+              description: 'Number of seconds after the container has
+                                               started before liveness probes are initiated. More info:
+                                               https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+              format: int32
+              type: integer
+            timeoutSeconds:
+              description: 'Number of seconds after which the probe times out. Defaults to 1 second.
+                Minimum value is 1.'
+              format: int32
+              type: integer
+            periodSeconds:
+              description: 'How often (in seconds) to perform the probe.
+                Default to 10 seconds. Minimum value is 1.'
+              format: int32
+              type: integer
+            successThreshold:
+              description: 'Minimum consecutive successes for the probe
+                to be considered successful after having failed. Defaults
+                to 1. Must be 1 for liveness and startup. Minimum value
+                is 1.'
+              format: int32
+              type: integer
+            failureThreshold:
+              description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
+              Giving up in case of liveness probe means restarting the container.
+              In case of readiness probe the Pod will be marked Unready.
+              Defaults to 3. Minimum value is 1.'
+              format: int32
+              type: integer

--- a/monitoring/base/grafana-operator/upstream/crds/Grafana.yaml
+++ b/monitoring/base/grafana-operator/upstream/crds/Grafana.yaml
@@ -147,69 +147,78 @@ spec:
             jsonnet:
               type: object
               description: Jsonnet library configuration
-        livenessProbeSpec:
-          type: object
-          properties:
-            initialDelaySeconds:
-              description: 'Number of seconds after the container has
-                                        started before liveness probes are initiated. More info:
-                                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-              format: int32
-              type: integer
-            timeoutSeconds:
-              description: Number of seconds after which the probe times out. Defaults to 1 second.
-                Minimum value is 1.
-              format: int32
-              type: integer
-            periodSeconds:
-              description: 'How often (in seconds) to perform the probe.
-                Default to 10 seconds. Minimum value is 1.'
-              format: int32
-              type: integer
-            successThreshold:
-              description: 'Minimum consecutive successes for the probe
-                to be considered successful after having failed. Defaults
-                to 1. Must be 1 for liveness and startup. Minimum value
-                is 1.'
-              format: int32
-              type: integer
-            failureThreshold:
-              description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
-              Giving up in case of liveness probe means restarting the container.
-              In case of readiness probe the Pod will be marked Unready.
-              Defaults to 3. Minimum value is 1.'
-              format: int32
-              type: integer
-        readinessProbeSpec:
-          type: object
-          properties:
-            initialDelaySeconds:
-              description: 'Number of seconds after the container has
-                                               started before liveness probes are initiated. More info:
-                                               https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-              format: int32
-              type: integer
-            timeoutSeconds:
-              description: 'Number of seconds after which the probe times out. Defaults to 1 second.
-                Minimum value is 1.'
-              format: int32
-              type: integer
-            periodSeconds:
-              description: 'How often (in seconds) to perform the probe.
-                Default to 10 seconds. Minimum value is 1.'
-              format: int32
-              type: integer
-            successThreshold:
-              description: 'Minimum consecutive successes for the probe
-                to be considered successful after having failed. Defaults
-                to 1. Must be 1 for liveness and startup. Minimum value
-                is 1.'
-              format: int32
-              type: integer
-            failureThreshold:
-              description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
-              Giving up in case of liveness probe means restarting the container.
-              In case of readiness probe the Pod will be marked Unready.
-              Defaults to 3. Minimum value is 1.'
-              format: int32
-              type: integer
+            livenessProbeSpec:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  description: >-
+                    Number of seconds after the container has
+                    started before liveness probes are initiated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                  format: int32
+                  type: integer
+                timeoutSeconds:
+                  description: Number of seconds after which the probe times out. Defaults to 1 second.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: >-
+                    How often (in seconds) to perform the probe.
+                    Default to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: >-
+                    Minimum consecutive successes for the probe
+                    to be considered successful after having failed. Defaults
+                    to 1. Must be 1 for liveness and startup. Minimum value
+                    is 1.
+                  format: int32
+                  type: integer
+                failureThreshold:
+                  description: >-
+                    When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                    Giving up in case of liveness probe means restarting the container.
+                    In case of readiness probe the Pod will be marked Unready.
+                    Defaults to 3. Minimum value is 1.
+                  format: int32
+                  type: integer
+            readinessProbeSpec:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  description: >-
+                    Number of seconds after the container has
+                    started before liveness probes are initiated. More info
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                  format: int32
+                  type: integer
+                timeoutSeconds:
+                  description: >-
+                    Number of seconds after which the probe times out. Defaults to 1 second.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: >-
+                    How often (in seconds) to perform the probe.
+                    Default to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: >-
+                    Minimum consecutive successes for the probe
+                    to be considered successful after having failed. Defaults
+                    to 1. Must be 1 for liveness and startup. Minimum value
+                    is 1.
+                  format: int32
+                  type: integer
+                failureThreshold:
+                  description: >-
+                    When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                    Giving up in case of liveness probe means restarting the container.
+                    In case of readiness probe the Pod will be marked Unready.
+                    Defaults to 3. Minimum value is 1.
+                  format: int32
+                  type: integer

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -61,4 +61,4 @@ images:
     newTag: 1.9.7.1
   - name: quay.io/integreatly/grafana-operator
     newName: quay.io/cybozu/grafana-operator
-    newTag: 3.6.0.1
+    newTag: 3.7.0.1


### PR DESCRIPTION
I confirmed that there is only the difference that I recognize should be according to the release note by executing `kustomize build .` before and after the update.

Ref https://github.com/cybozu/neco-containers/pull/475
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>