### PR TITLE
cert-manager: Use ZeroSSL for stage0.

### DIFF
--- a/cert-manager/overlays/stage0/clusterissuer.yaml
+++ b/cert-manager/overlays/stage0/clusterissuer.yaml
@@ -6,10 +6,16 @@ metadata:
   name: clouddns
 spec:
   acme:
+    externalAccountBinding:
+      keyID: wwxKZVO5df00sc1950lnjQ
+      keySecretRef:
+        name: zero-ssl-eabsecret-20201221
+        key: eab-hmac-key
+      keyAlgorithm: HS256
     email: neco@cybozu.com
     privateKeySecretRef:
-      name: letsencrypt-prod
-    server: https://acme-v02.api.letsencrypt.org/directory
+      name: zerossl-secret
+    server: https://acme.zerossl.com/v2/DV90
     solvers:
       - dns01:
           clouddns:

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -492,6 +492,11 @@ func testGeneratedSecretName(t *testing.T) {
 					appeared = true
 				}
 
+				// This lines tests ClusterIssuer at stage0 contains EAB HMAC Secret
+				if strings.Contains(strCondensed, "keySecretRef:name:"+es.Name+"key:eab-hmac-key") {
+					appeared = true
+				}
+
 				// This line tests VMAlertmanager.spec.configSecret
 				if strings.Contains(string(str), "configSecret: "+es.Name) {
 					appeared = true
@@ -504,6 +509,12 @@ func testGeneratedSecretName(t *testing.T) {
 			}
 			if !appeared {
 				t.Error("secret:", es.Name, "was not found in any manifests")
+			}
+
+			// Secret zero-ssl-eabsecret-yymmdd is not appeared except for stage0 manifests
+			// So, test with dummy secret doesn't make sense
+			if strings.HasPrefix(es.Name, "zero-ssl-eabsecret-") {
+				continue OUTER
 			}
 
 			for _, cs := range dummySecrets {


### PR DESCRIPTION
This PR replaces the ClusterIssuer (name: clouddns) from Let's Encrypt to ZeroSSL.
To enable the ClusterIssuer, we need the operation creating Secret that includes EAB HMAC Key.