### PR TITLE
Revert "argocd: Upgrade dex to v2.27.0"

### DIFF
--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -11,6 +11,6 @@ images:
   - name: quay.io/cybozu/argocd
     newTag: 1.7.7.3
   - name: quay.io/cybozu/dex
-    newTag: 2.27.0.1
+    newTag: 2.22.0.2
   - name: quay.io/cybozu/redis
     newTag: 5.0.8.3


### PR DESCRIPTION
After upgrading dex from v2.22.0 to v2.27.0, argocd login via cli does not work,
Therefore, this PR revert the dex upgrade.