### PR TITLE
fix vmalert rule for TopoLVM

### DIFF
--- a/monitoring/base/victoriametrics/rules/topolvm-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/topolvm-alertrule.yaml
@@ -11,7 +11,7 @@ spec:
       rules:
         - alert: AvailableBytesHighUtilizationInShortTerm
           expr: |
-            sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24)) without (instance,node) <= 0
+            sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24)) by (device_class) <= 0
           labels:
             severity: warning
           for: 10m
@@ -20,7 +20,7 @@ spec:
             runbook: Please check the disk utilization of applications and contact the developer team.
         - alert: AvailableBytesHighUtilizationInLongTerm
           expr: |
-            sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24*30)) without (instance,node) <= 0
+            sum(predict_linear(topolvm_volumegroup_available_bytes[1h], 3600*24*30)) by (device_class) <= 0
           labels:
             severity: warning
           for: 1h


### PR DESCRIPTION
kube-state-metrics-alertrule.yaml and kubernetes-alertrule.yaml don't seems to have problems.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>