### PR TITLE
Disable ExternalIP of sandbox grafana svc

### DIFF
--- a/sandbox/overlays/gcp/grafana/service.yaml
+++ b/sandbox/overlays/gcp/grafana/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: grafana
   name: grafana
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - name: service
     port: 3000

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Test applications", func() {
 	Context("preparing pushgateway", preparePushgateway)
 	Context("preparing ingress-health", prepareIngressHealth)
 	Context("preparing grafana-operator", prepareGrafanaOperator)
+	Context("preparing sandbox grafana", prepareSandboxGrafanaIngress)
 	Context("preparing topolvm", prepareTopoLVM)
 	Context("preparing network-policy", prepareNetworkPolicy) // this must be the last preparation.
 


### PR DESCRIPTION
Check the access to Sandbox Grafana via HTTPProxy as in stage0.

This test logic is same as the Grafana in monitoring ns.
https://github.com/cybozu-go/neco-apps/blob/c179828305a8b85a0e9ae27d1e3e75c719ff6fff/test/monitoring_test.go#L483-L563

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>