### PR TITLE
cert-manager: Fix ZeroSSL EAB key.

### DIFF
--- a/cert-manager/overlays/stage0/clusterissuer.yaml
+++ b/cert-manager/overlays/stage0/clusterissuer.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   acme:
     externalAccountBinding:
-      keyID: wwxKZVO5df00sc1950lnjQ
+      keyID: DPHXf32ALIr3ppIZoEgqNw
       keySecretRef:
-        name: zero-ssl-eabsecret-20201221
+        name: zero-ssl-eabsecret-20201223
         key: eab-hmac-key
       keyAlgorithm: HS256
     email: neco@cybozu.com


### PR DESCRIPTION
After this PR is merged and released, we should set auto-sync for `cert-manager` ArgoCD app.