### PR TITLE
Change boot server names for Ubuntu 20.04 dctest

### DIFF
--- a/test/teleport_test.go
+++ b/test/teleport_test.go
@@ -164,7 +164,7 @@ func testTeleport() {
 		By("accessing boot servers using tsh command")
 		for _, n := range []string{"boot-0", "boot-1", "boot-2"} {
 			Eventually(func() error {
-				cmd := exec.Command("tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "ssh", "cybozu@"+n, "date")
+				cmd := exec.Command("tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "ssh", "cybozu@gcp0-"+n, "date")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("tsh ssh failed for %s: %s", n, string(output))


### PR DESCRIPTION
The names of boot servers are now prefixed with "gcp0-".