### PR TITLE
add PVC to vmalertmanager

### DIFF
--- a/monitoring/base/victoriametrics/alertmanager.yaml
+++ b/monitoring/base/victoriametrics/alertmanager.yaml
@@ -30,3 +30,12 @@ spec:
     requests:
       cpu: 100m
       memory: 200Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: topolvm-provisioner


### PR DESCRIPTION
Add PVC to vmalertmanager.
STS should be deleted manually after this PR is applied to stage/prod because STSs cannot be modified except  'replicas', 'template', and 'updateStrategy'.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>