### PR TITLE
make vmagent/vmalert see CRs in monitoring NS only

### DIFF
--- a/monitoring/base/victoriametrics/vmagent-smallset.yaml
+++ b/monitoring/base/victoriametrics/vmagent-smallset.yaml
@@ -51,27 +51,15 @@ spec:
   containers:
     - name: config-reloader
       image: quay.io/cybozu/prometheus-config-reloader:0.43.2.1
-  serviceScrapeNamespaceSelector:
-    matchLabels:
-      team: neco
   serviceScrapeSelector:
     matchLabels:
       smallset: "true"
-  podScrapeNamespaceSelector:
-    matchLabels:
-      team: neco
   podScrapeSelector:
     matchLabels:
       smallset: "true"
-  nodeScrapeNamespaceSelector:
-    matchLabels:
-      team: neco
   nodeScrapeSelector:
     matchLabels:
       smallset: "true"
-  probeNamespaceSelector:
-    matchLabels:
-      team: neco
   probeSelector:
     matchLabels:
       smallset: "true"

--- a/monitoring/base/victoriametrics/vmalert-smallset.yaml
+++ b/monitoring/base/victoriametrics/vmalert-smallset.yaml
@@ -16,9 +16,6 @@ spec:
   notifier:
     url: "http://vmalertmanager-vmalertmanager.monitoring.svc:9093"
   evaluationInterval: "30s"
-  ruleNamespaceSelector:
-    matchLabels:
-      team: neco
   ruleSelector:
     matchLabels:
       smallset: "true"

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -632,18 +632,11 @@ func testVMCustomResources(t *testing.T) {
 	}
 
 	// check namespace label selectors
-
-	expectedNamespaceSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"team": "neco",
-		},
-	}
-
-	if !reflect.DeepEqual(smallsetVMAgent.Spec.ServiceScrapeNamespaceSelector, &expectedNamespaceSelector) ||
-		!reflect.DeepEqual(smallsetVMAgent.Spec.PodScrapeNamespaceSelector, &expectedNamespaceSelector) ||
-		!reflect.DeepEqual(smallsetVMAgent.Spec.NodeScrapeNamespaceSelector, &expectedNamespaceSelector) ||
-		!reflect.DeepEqual(smallsetVMAgent.Spec.ProbeNamespaceSelector, &expectedNamespaceSelector) ||
-		!reflect.DeepEqual(smallsetVMAlert.Spec.RuleNamespaceSelector, &expectedNamespaceSelector) {
+	if smallsetVMAgent.Spec.ServiceScrapeNamespaceSelector != nil ||
+		smallsetVMAgent.Spec.PodScrapeNamespaceSelector != nil ||
+		smallsetVMAgent.Spec.NodeScrapeNamespaceSelector != nil ||
+		smallsetVMAgent.Spec.ProbeNamespaceSelector != nil ||
+		smallsetVMAlert.Spec.RuleNamespaceSelector != nil {
 		t.Errorf("bad namespace selector")
 	}
 


### PR DESCRIPTION
To reduce load of API server, see only monitoring NS.
If namespace selector is omitted (nil), they see only the NS which they are in.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>