### PR TITLE
Remove unnecessary webhook ignore labels

### DIFF
--- a/customer-egress/base/namespace.yaml
+++ b/customer-egress/base/namespace.yaml
@@ -4,6 +4,6 @@ metadata:
   name: customer-egress
   annotations:
     coil.cybozu.com/pool: customer-egress
-    admission.cybozu.com/min-policy-order: "99"
+    admission.cybozu.com/min-policy-order: "100"
   labels:
     team: neco

--- a/customer-egress/base/namespace.yaml
+++ b/customer-egress/base/namespace.yaml
@@ -4,6 +4,6 @@ metadata:
   name: customer-egress
   annotations:
     coil.cybozu.com/pool: customer-egress
-    admission.cybozu.com/min-policy-order: 101
+    admission.cybozu.com/min-policy-order: "101"
   labels:
     team: neco

--- a/customer-egress/base/namespace.yaml
+++ b/customer-egress/base/namespace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: customer-egress
   annotations:
     coil.cybozu.com/pool: customer-egress
+    admission.cybozu.com/min-policy-order: 101
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
     team: neco

--- a/customer-egress/base/namespace.yaml
+++ b/customer-egress/base/namespace.yaml
@@ -4,6 +4,6 @@ metadata:
   name: customer-egress
   annotations:
     coil.cybozu.com/pool: customer-egress
-    admission.cybozu.com/min-policy-order: "101"
+    admission.cybozu.com/min-policy-order: "99"
   labels:
     team: neco

--- a/customer-egress/base/namespace.yaml
+++ b/customer-egress/base/namespace.yaml
@@ -6,5 +6,4 @@ metadata:
     coil.cybozu.com/pool: customer-egress
     admission.cybozu.com/min-policy-order: 101
   labels:
-    topolvm.cybozu.com/webhook: ignore
     team: neco

--- a/namespaces/base/argocd.yaml
+++ b/namespaces/base/argocd.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   name: argocd
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/argocd.yaml
+++ b/namespaces/base/argocd.yaml
@@ -5,4 +5,3 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/argocd.yaml
+++ b/namespaces/base/argocd.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: argocd
-  labels:
-    topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/bmc-reverse-proxy.yaml
+++ b/namespaces/base/bmc-reverse-proxy.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: bmc-reverse-proxy
-  labels:
-    vnetworkpolicy.kb.io/ignore: "true"
+  annotations:
+    admission.cybozu.com/min-policy-order: 501

--- a/namespaces/base/bmc-reverse-proxy.yaml
+++ b/namespaces/base/bmc-reverse-proxy.yaml
@@ -4,4 +4,3 @@ metadata:
   name: bmc-reverse-proxy
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/bmc-reverse-proxy.yaml
+++ b/namespaces/base/bmc-reverse-proxy.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bmc-reverse-proxy
   annotations:
-    admission.cybozu.com/min-policy-order: 501
+    admission.cybozu.com/min-policy-order: "501"

--- a/namespaces/base/bmc-reverse-proxy.yaml
+++ b/namespaces/base/bmc-reverse-proxy.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bmc-reverse-proxy
   annotations:
-    admission.cybozu.com/min-policy-order: "501"
+    admission.cybozu.com/min-policy-order: "499"

--- a/namespaces/base/bmc-reverse-proxy.yaml
+++ b/namespaces/base/bmc-reverse-proxy.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bmc-reverse-proxy
   annotations:
-    admission.cybozu.com/min-policy-order: "499"
+    admission.cybozu.com/min-policy-order: "500"

--- a/namespaces/base/cert-manager.yaml
+++ b/namespaces/base/cert-manager.yaml
@@ -4,6 +4,5 @@ metadata:
   name: cert-manager
   labels:
     cert-manager.io/disable-validation: "true"
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"

--- a/namespaces/base/domestic-egress.yaml
+++ b/namespaces/base/domestic-egress.yaml
@@ -4,5 +4,3 @@ metadata:
   name: domestic-egress
   annotations:
     coil.cybozu.com/pool: domestic-egress
-  labels:
-    topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/domestic-egress.yaml
+++ b/namespaces/base/domestic-egress.yaml
@@ -7,4 +7,3 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/domestic-egress.yaml
+++ b/namespaces/base/domestic-egress.yaml
@@ -5,5 +5,4 @@ metadata:
   annotations:
     coil.cybozu.com/pool: domestic-egress
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/elastic.yaml
+++ b/namespaces/base/elastic.yaml
@@ -5,4 +5,3 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/elastic.yaml
+++ b/namespaces/base/elastic.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: elastic-system
-  labels:
-    topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/elastic.yaml
+++ b/namespaces/base/elastic.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   name: elastic-system
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/external-dns.yaml
+++ b/namespaces/base/external-dns.yaml
@@ -4,4 +4,3 @@ metadata:
   name: external-dns
   labels:
     cert-manager.io/disable-validation: "true"
-    topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/external-dns.yaml
+++ b/namespaces/base/external-dns.yaml
@@ -4,5 +4,4 @@ metadata:
   name: external-dns
   labels:
     cert-manager.io/disable-validation: "true"
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/external-dns.yaml
+++ b/namespaces/base/external-dns.yaml
@@ -6,4 +6,3 @@ metadata:
     cert-manager.io/disable-validation: "true"
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/ingress.yaml
+++ b/namespaces/base/ingress.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-global
-  labels:
-    topolvm.cybozu.com/webhook: ignore
   annotations:
     admission.cybozu.com/min-policy-order: 1001
 ---
@@ -11,8 +9,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-bastion
-  labels:
-    topolvm.cybozu.com/webhook: ignore
   annotations:
     admission.cybozu.com/min-policy-order: 1001
 ---
@@ -20,7 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-forest
-  labels:
-    topolvm.cybozu.com/webhook: ignore
   annotations:
     admission.cybozu.com/min-policy-order: 1001

--- a/namespaces/base/ingress.yaml
+++ b/namespaces/base/ingress.yaml
@@ -3,18 +3,18 @@ kind: Namespace
 metadata:
   name: ingress-global
   annotations:
-    admission.cybozu.com/min-policy-order: "999"
+    admission.cybozu.com/min-policy-order: "900"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-bastion
   annotations:
-    admission.cybozu.com/min-policy-order: "999"
+    admission.cybozu.com/min-policy-order: "900"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-forest
   annotations:
-    admission.cybozu.com/min-policy-order: "999"
+    admission.cybozu.com/min-policy-order: "900"

--- a/namespaces/base/ingress.yaml
+++ b/namespaces/base/ingress.yaml
@@ -3,23 +3,24 @@ kind: Namespace
 metadata:
   name: ingress-global
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-
+  annotations:
+    admission.cybozu.com/min-policy-order: 1001
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-bastion
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-
+  annotations:
+    admission.cybozu.com/min-policy-order: 1001
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-forest
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
+  annotations:
+    admission.cybozu.com/min-policy-order: 1001

--- a/namespaces/base/ingress.yaml
+++ b/namespaces/base/ingress.yaml
@@ -3,18 +3,18 @@ kind: Namespace
 metadata:
   name: ingress-global
   annotations:
-    admission.cybozu.com/min-policy-order: 1001
+    admission.cybozu.com/min-policy-order: "1001"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-bastion
   annotations:
-    admission.cybozu.com/min-policy-order: 1001
+    admission.cybozu.com/min-policy-order: "1001"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-forest
   annotations:
-    admission.cybozu.com/min-policy-order: 1001
+    admission.cybozu.com/min-policy-order: "1001"

--- a/namespaces/base/ingress.yaml
+++ b/namespaces/base/ingress.yaml
@@ -3,18 +3,18 @@ kind: Namespace
 metadata:
   name: ingress-global
   annotations:
-    admission.cybozu.com/min-policy-order: "1001"
+    admission.cybozu.com/min-policy-order: "999"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-bastion
   annotations:
-    admission.cybozu.com/min-policy-order: "1001"
+    admission.cybozu.com/min-policy-order: "999"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-forest
   annotations:
-    admission.cybozu.com/min-policy-order: "1001"
+    admission.cybozu.com/min-policy-order: "999"

--- a/namespaces/base/ingress.yaml
+++ b/namespaces/base/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"
 
 ---
 apiVersion: v1
@@ -15,7 +14,6 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"
 
 ---
 apiVersion: v1
@@ -25,4 +23,3 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: internet-egress
   annotations:
     coil.cybozu.com/pool: internet-egress
-    admission.cybozu.com/min-policy-order: "99"
+    admission.cybozu.com/min-policy-order: "100"
   labels:
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"

--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: internet-egress
   annotations:
     coil.cybozu.com/pool: internet-egress
-    admission.cybozu.com/min-policy-order: 101
+    admission.cybozu.com/min-policy-order: "101"
   labels:
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"

--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: internet-egress
   annotations:
     coil.cybozu.com/pool: internet-egress
-    admission.cybozu.com/min-policy-order: "101"
+    admission.cybozu.com/min-policy-order: "99"
   labels:
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"

--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: internet-egress
   annotations:
     coil.cybozu.com/pool: internet-egress
+    admission.cybozu.com/min-policy-order: 101
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"

--- a/namespaces/base/kube-system.yaml
+++ b/namespaces/base/kube-system.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: kube-system
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"
+  annotations:
+    admission.cybozu.com/min-policy-order: 501

--- a/namespaces/base/kube-system.yaml
+++ b/namespaces/base/kube-system.yaml
@@ -6,4 +6,4 @@ metadata:
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"
   annotations:
-    admission.cybozu.com/min-policy-order: 501
+    admission.cybozu.com/min-policy-order: "501"

--- a/namespaces/base/kube-system.yaml
+++ b/namespaces/base/kube-system.yaml
@@ -6,4 +6,4 @@ metadata:
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"
   annotations:
-    admission.cybozu.com/min-policy-order: "499"
+    admission.cybozu.com/min-policy-order: "500"

--- a/namespaces/base/kube-system.yaml
+++ b/namespaces/base/kube-system.yaml
@@ -6,4 +6,4 @@ metadata:
     topolvm.cybozu.com/webhook: ignore
     mpod.kb.io/ignore: "true"
   annotations:
-    admission.cybozu.com/min-policy-order: "501"
+    admission.cybozu.com/min-policy-order: "499"

--- a/namespaces/base/metallb.yaml
+++ b/namespaces/base/metallb.yaml
@@ -5,4 +5,3 @@ metadata:
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/metallb.yaml
+++ b/namespaces/base/metallb.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   name: metallb-system
   labels:
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/metallb.yaml
+++ b/namespaces/base/metallb.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: metallb-system
-  labels:
-    topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/monitoring.yaml
+++ b/namespaces/base/monitoring.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: monitoring
   annotations:
-    admission.cybozu.com/min-policy-order: "499"
+    admission.cybozu.com/min-policy-order: "500"

--- a/namespaces/base/monitoring.yaml
+++ b/namespaces/base/monitoring.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: monitoring
   annotations:
-    admission.cybozu.com/min-policy-order: 501
+    admission.cybozu.com/min-policy-order: "501"

--- a/namespaces/base/monitoring.yaml
+++ b/namespaces/base/monitoring.yaml
@@ -4,4 +4,3 @@ metadata:
   name: monitoring
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/monitoring.yaml
+++ b/namespaces/base/monitoring.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: monitoring
   annotations:
-    admission.cybozu.com/min-policy-order: "501"
+    admission.cybozu.com/min-policy-order: "499"

--- a/namespaces/base/monitoring.yaml
+++ b/namespaces/base/monitoring.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
-  labels:
-    vnetworkpolicy.kb.io/ignore: "true"
+  annotations:
+    admission.cybozu.com/min-policy-order: 501

--- a/namespaces/base/rook-ceph.yaml
+++ b/namespaces/base/rook-ceph.yaml
@@ -2,12 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ceph-hdd
-  labels:
-    vnetworkpolicy.kb.io/ignore: "true"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ceph-ssd
-  labels:
-    vnetworkpolicy.kb.io/ignore: "true"

--- a/namespaces/base/rook-ceph.yaml
+++ b/namespaces/base/rook-ceph.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ceph-hdd
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
-    mpod.kb.io/ignore: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -12,4 +11,3 @@ metadata:
   name: ceph-ssd
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/teleport.yaml
+++ b/namespaces/base/teleport.yaml
@@ -4,4 +4,3 @@ metadata:
   name: teleport
   labels:
     vnetworkpolicy.kb.io/ignore: "true"
-    mpod.kb.io/ignore: "true"

--- a/namespaces/base/teleport.yaml
+++ b/namespaces/base/teleport.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: teleport
-  labels:
-    vnetworkpolicy.kb.io/ignore: "true"
+  annotations:
+    admission.cybozu.com/min-policy-order: 501

--- a/namespaces/base/teleport.yaml
+++ b/namespaces/base/teleport.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: teleport
   annotations:
-    admission.cybozu.com/min-policy-order: "501"
+    admission.cybozu.com/min-policy-order: "499"

--- a/namespaces/base/teleport.yaml
+++ b/namespaces/base/teleport.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: teleport
   annotations:
-    admission.cybozu.com/min-policy-order: "499"
+    admission.cybozu.com/min-policy-order: "500"

--- a/namespaces/base/teleport.yaml
+++ b/namespaces/base/teleport.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: teleport
   annotations:
-    admission.cybozu.com/min-policy-order: 501
+    admission.cybozu.com/min-policy-order: "501"

--- a/namespaces/base/topolvm.yaml
+++ b/namespaces/base/topolvm.yaml
@@ -4,5 +4,4 @@ metadata:
   name: topolvm-system
   labels:
     app.kubernetes.io/name: topolvm-system
-    vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore

--- a/namespaces/base/topolvm.yaml
+++ b/namespaces/base/topolvm.yaml
@@ -6,4 +6,3 @@ metadata:
     app.kubernetes.io/name: topolvm-system
     vnetworkpolicy.kb.io/ignore: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"

--- a/neco-admission/base/deployment.yaml
+++ b/neco-admission/base/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         args:
         - --cert-dir=/certs
         - --httpproxy-default-class=forest
-        image: quay.io/cybozu/neco-admission:0.7.2
+        image: quay.io/cybozu/neco-admission
         resources:
           requests:
             cpu: 100m

--- a/neco-admission/base/kustomization.yaml
+++ b/neco-admission/base/kustomization.yaml
@@ -29,3 +29,6 @@ patches:
     - op: replace
       path: /metadata/name
       value: neco-admission
+images:
+  - name: quay.io/cybozu/neco-admission
+    newTag: 0.7.2

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -398,23 +398,6 @@ func applyAndWaitForApplications(commitID string) {
 				}
 			}
 
-			// Temporary code for upgrading neco-admission and NetworkPolicy simultaneously
-			// TODO: Remove this code after neco-apps#1042 is merged
-			if doUpgrade &&
-				target.name == "network-policy" &&
-				app.Status.Sync.Status == SyncStatusCodeOutOfSync {
-				if app.Operation != nil && app.Status.OperationState.Phase == "Running" {
-					stdout, stderr, err := ExecAt(boot0, "argocd", "app", "terminate-op", target.name)
-					if err != nil {
-						return fmt.Errorf("failed to terminate operation. app: %s, stdout: %s, stderr: %s, err: %v", target.name, stdout, stderr, err)
-					}
-				}
-				stdout, stderr, err = ExecAt(boot0, "argocd", "app", "sync", target.name)
-				if err != nil {
-					return fmt.Errorf("failed to sync application. app: %s, stdout: %s, stderr: %s, err: %v", target.name, stdout, stderr, err)
-				}
-			}
-
 			return fmt.Errorf("%s is not initialized. argocd app get %s -o json: %s", target.name, target.name, appStdout)
 		}
 		return nil


### PR DESCRIPTION
This PR removes unnecessary webhook ignore labels.
Note that `vnetworkpolicy` rejects less than `admission.cybozu.com/min-policy-order` annotation value, not including "equal" value (default is `1000.0`).
See: https://github.com/cybozu/neco-containers/pull/497