### PR TITLE
Fix egress nat to mount `/run`

### DIFF
--- a/coil/base/egress.yaml
+++ b/coil/base/egress.yaml
@@ -11,6 +11,16 @@ spec:
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: 43200  # 12 hours
+  template:
+    spec:
+      containers:
+      - name: egress
+        volumeMounts:
+        - mountPath: /run
+          name: run
+      volumes:
+      - emptyDir: {}
+        name: run
 ---
 apiVersion: coil.cybozu.com/v2
 kind: Egress
@@ -25,3 +35,13 @@ spec:
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: 43200  # 12 hours
+  template:
+    spec:
+      containers:
+      - name: egress
+        volumeMounts:
+        - mountPath: /run
+          name: run
+      volumes:
+      - emptyDir: {}
+        name: run

--- a/customer-egress/base/egress.yaml
+++ b/customer-egress/base/egress.yaml
@@ -11,3 +11,13 @@ spec:
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: 43200  # 12 hours
+  template:
+    spec:
+      containers:
+      - name: egress
+        volumeMounts:
+        - mountPath: /run
+          name: run
+      volumes:
+      - emptyDir: {}
+        name: run


### PR DESCRIPTION
iptables fails to lock `/run/xtables.lock` on Ubuntu 20.04.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>