### PR TITLE
fix scraping CR for VM smallset

### DIFF
--- a/monitoring/base/victoriametrics/rules/monitoring-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/monitoring-scrape.yaml
@@ -32,6 +32,7 @@ spec:
     matchNames: [monitoring]
   selector:
     matchLabels:
+      app.kubernetes.io/component: monitoring
       app.kubernetes.io/instance: vmalertmanager
       app.kubernetes.io/name: vmalertmanager
       managed-by: vm-operator
@@ -42,7 +43,7 @@ spec:
         targetLabel: job
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
-kind: VMPodScrape
+kind: VMServiceScrape
 metadata:
   name: vmagent-smallset
   namespace: monitoring
@@ -53,19 +54,18 @@ spec:
     matchNames: [monitoring]
   selector:
     matchLabels:
+      app.kubernetes.io/component: monitoring
       app.kubernetes.io/instance: vmagent-smallset
       app.kubernetes.io/name: vmagent
       managed-by: vm-operator
-  podMetricsEndpoints:
-  - relabelConfigs:
+  endpoints:
+  - port: http
+    relabelConfigs:
       - replacement: vmagent-smallset
         targetLabel: job
-      - sourceLabels: [__meta_kubernetes_pod_container_name]
-        regex: vmagent
-        action: keep
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
-kind: VMPodScrape
+kind: VMServiceScrape
 metadata:
   name: vmalert-smallset
   namespace: monitoring
@@ -76,16 +76,15 @@ spec:
     matchNames: [monitoring]
   selector:
     matchLabels:
+      app.kubernetes.io/component: monitoring
       app.kubernetes.io/instance: vmalert-smallset
       app.kubernetes.io/name: vmalert
       managed-by: vm-operator
-  podMetricsEndpoints:
-  - relabelConfigs:
+  endpoints:
+  - port: http
+    relabelConfigs:
       - replacement: vmalert-smallset
         targetLabel: job
-      - sourceLabels: [__meta_kubernetes_pod_container_name]
-        regex: vmalert
-        action: keep
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
@@ -99,6 +98,7 @@ spec:
     matchNames: [monitoring]
   selector:
     matchLabels:
+      app.kubernetes.io/component: monitoring
       app.kubernetes.io/instance: vmsingle-smallset
       app.kubernetes.io/name: vmsingle
       managed-by: vm-operator

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -518,14 +518,14 @@ func testVMCustomResources(t *testing.T) {
 		"kube-state-metrics",
 		"kubernetes",
 		"rook",
+		"vmagent-smallset",
+		"vmalert-smallset",
 		"vmalertmanager",
 		"vmsingle-smallset",
 	}
 	expectedSmallsetPodScrapes := []string{
 		"topolvm",
 		"victoriametrics-operator",
-		"vmagent-smallset",
-		"vmalert-smallset",
 	}
 	expectedSmallsetNodeScrapes := []string{
 		"kubernetes-cadvisor",


### PR DESCRIPTION
- use VMServiceScrape instead of VMPodScrape for vmagent/vmalert
- add `app.k8s.io/component` label

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>