### PR TITLE
do not make VictoriaMetrics operator create self VMServiceScrape

### DIFF
--- a/monitoring/base/victoriametrics/operator.yaml
+++ b/monitoring/base/victoriametrics/operator.yaml
@@ -35,6 +35,16 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: victoriametrics-operator
+        - name: VM_DISABLESELFSERVICESCRAPECREATION
+          value: "true"
+        - name: VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR
+          value: "false"
+        - name: VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE
+          value: "false"
+        - name: VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE
+          value: "false"
+        - name: VM_ENABLEDPROMETHEUSCONVERTER_PROBE
+          value: "false"
         image: quay.io/cybozu/victoriametrics-operator:0.7.1.1
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
- we don't use VMServiceScrape which is created by the operator for VMAgent, VMAlert etc.
- we never require Prometheus operator CR conversion

see also: https://github.com/VictoriaMetrics/operator/blob/v0.7.1/vars.MD

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>