### PR TITLE
fix NodeExporterDown alert on Prometheus

### DIFF
--- a/monitoring/base/prometheus/alert_rules/node.yaml
+++ b/monitoring/base/prometheus/alert_rules/node.yaml
@@ -7,7 +7,7 @@ groups:
           runbook: Please consider to find root causes, and solve the problems.
         expr: |
           (up{job="node-exporter"} == 0) * on (instance)
-          label_replace(sum(sabakan_machine_status{status!="retired"} == 1) by (address), "instance", "$1", "address" , "(.+)")
+          label_replace(sum(sabakan_machine_status{status!="retired"} == 1) by (address), "instance", "$1:9100", "address" , "(.+)")
         for: 30m
         labels:
           severity: minor

--- a/test/alert_test/node.yaml
+++ b/test/alert_test/node.yaml
@@ -4,13 +4,13 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{job="node-exporter", instance="192.168.0.1"}'
+      - series: 'up{job="node-exporter", instance="192.168.0.1:9100"}'
         values: '0+0x30'
-      - series: 'up{job="node-exporter", instance="192.168.0.2"}'
+      - series: 'up{job="node-exporter", instance="192.168.0.2:9100"}'
         values: '0+0x30'
-      - series: 'up{job="node-exporter", instance="192.168.0.3"}'
+      - series: 'up{job="node-exporter", instance="192.168.0.3:9100"}'
         values: '1+0x30'
-      - series: 'up{job="node-exporter", instance="192.168.0.4"}'
+      - series: 'up{job="node-exporter", instance="192.168.0.4:9100"}'
         values: '1+0x30'
       - series: 'sabakan_machine_status{status="healthy", address="192.168.0.1"}'
         values: '1+0x30'
@@ -33,17 +33,17 @@ tests:
         alertname: NodeExporterDown
         exp_alerts:
           - exp_labels:
-              instance: "192.168.0.1"
+              instance: "192.168.0.1:9100"
               severity: minor
             exp_annotations:
               runbook: Please consider to find root causes, and solve the problems.
-              summary: NodeExporter has disappeared at `192.168.0.1`.
+              summary: NodeExporter has disappeared at `192.168.0.1:9100`.
 
   - interval: 1m
     input_series:
-      - series: 'up{job="node-exporter", instance="192.168.0.1"}'
+      - series: 'up{job="node-exporter", instance="192.168.0.1:9100"}'
         values: '1+0x30'
-      - series: 'up{job="node-exporter", instance="192.168.0.2"}'
+      - series: 'up{job="node-exporter", instance="192.168.0.2:9100"}'
         values: '0+0x29 1'
       - series: 'sabakan_machine_status{status="healthy", address="192.168.0.1"}'
         values: '1+0x30'


### PR DESCRIPTION
`job="node-exporter"` metrics have port number in `instance` label (i.e. `instance="10.0.0.1:9100"`, not `instance="10.0.0.1"`), even on Prometheus.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>