### PR TITLE
monitoring: add Kubernetes labels to node/namespace metrics

### DIFF
--- a/monitoring/base/kube-state-metrics/deployment.yaml
+++ b/monitoring/base/kube-state-metrics/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     spec:
       containers:
       - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
+        args:
+        - --labels-metric-allow-list
+        - namespaces=[team],nodes=[cke.cybozu.com/rack,cke.cybozu.com/role,cke.cybozu.com/master]
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Starting with kube-state-metrics v2.0.0, labels metrics such as
`kube_namespace_labels` or `kube_node_labels` does not include
Kubernetes resource labels.

https://github.com/kubernetes/kube-state-metrics/issues/1270

Since we are using some Kubernetes labels, this commit restores them.