### PR TITLE
monitoring: complement scrape configs for VictoriaMetrics largeset cluster.

### DIFF
--- a/local-pv-provisioner/base/daemonset.yaml
+++ b/local-pv-provisioner/base/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          ports:
+            - containerPort: 8080
+              name: metrics
           volumeMounts:
             - name: dev
               mountPath: /dev/crypt-disk/by-path

--- a/monitoring/base/victoriametrics/kustomization.yaml
+++ b/monitoring/base/victoriametrics/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - rules/cert-manager-scrape.yaml
   - rules/cke-alertrule.yaml
   - rules/cke-scrape.yaml
+  - rules/coil-scrape.yaml
   - rules/elastic-operator-alertrule.yaml
   - rules/elastic-operator-scrape.yaml
   - rules/etcd-alertrule.yaml

--- a/monitoring/base/victoriametrics/kustomization.yaml
+++ b/monitoring/base/victoriametrics/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - rules/kube-state-metrics-alertrule.yaml
   - rules/kubernetes-scrape.yaml
   - rules/kubernetes-alertrule.yaml
+  - rules/local-pv-provisioner-scrape.yaml
   - rules/metallb-alertrule.yaml
   - rules/metallb-scrape.yaml
   - rules/monitoring-scrape.yaml

--- a/monitoring/base/victoriametrics/rules/coil-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/coil-scrape.yaml
@@ -1,0 +1,53 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: coild
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    matchNames: [kube-system]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coil
+      app.kubernetes.io/component: coild
+  podMetricsEndpoints:
+  - port: metrics
+    relabelConfigs:
+    - replacement: coild
+      targetLabel: job
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: coil-controller
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    matchNames: [kube-system]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coil
+      app.kubernetes.io/component: coil-controller
+  podMetricsEndpoints:
+  - port: metrics
+    relabelConfigs:
+    - replacement: coil-controller
+      targetLabel: job
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: coil-egress
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    matchNames: [internet-egress, domestic-egress, customer-egress]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coil
+      app.kubernetes.io/component: egress
+  podMetricsEndpoints:
+  - port: metrics
+    relabelConfigs:
+    - replacement: coil-egress
+      targetLabel: job

--- a/monitoring/base/victoriametrics/rules/external-dns-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/external-dns-scrape.yaml
@@ -10,6 +10,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: external-dns
   podMetricsEndpoints:
-  - relabelConfigs:
+  - port: metrics
+    relabelConfigs:
     - replacement: external-dns
       targetLabel: job

--- a/monitoring/base/victoriametrics/rules/local-pv-provisioner-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/local-pv-provisioner-scrape.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: local-pv-provisioner
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    matchNames: [kube-system]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: local-pv-provisioner
+  podMetricsEndpoints:
+  - port: metrics
+    relabelConfigs:
+    - replacement: local-pv-provisioner
+      targetLabel: job

--- a/monitoring/base/victoriametrics/rules/neco-admission-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/neco-admission-scrape.yaml
@@ -10,6 +10,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: neco-admission
   podMetricsEndpoints:
-  - relabelConfigs:
+  - port: metrics
+    relabelConfigs:
       - replacement: neco-admission
         targetLabel: job


### PR DESCRIPTION
This PR adds scrape configs of local-pv-provisioner and coil for the VictoriaMetrics largeset cluster.
This also fixes some existing VMPodMetrics configs to specify the port names explicitly.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
