### PR TITLE
test: do not prepare kubectl-moco and kubeseal

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -24,8 +24,6 @@ KUSTOMIZE_VERSION := 3.7.0
 PROMTOOL_VERSION := 2.24.1
 TELEPORT_VERSION := 5.1.2
 KUBERNETES_VERSION := 1.19.7
-MOCO_VERSION := 0.5.1
-KUBESEAL_VERSION := 0.14.1
 
 # Cache
 DOWNLOAD_DIR := $(abspath $(CURDIR)/download)
@@ -35,11 +33,9 @@ TELEPORT_DLPATH := $(DOWNLOAD_DIR)/teleport-v$(TELEPORT_VERSION).tar.gz
 
 BINDIR := $(abspath $(CURDIR)/bin)
 KUBECTL := $(BINDIR)/kubectl
-KUBECTLMOCO := $(BINDIR)/kubectl-moco
 KUSTOMIZE := $(BINDIR)/kustomize
 PROMTOOL := $(BINDIR)/promtool
 TSH := $(BINDIR)/tsh
-KUBESEAL := $(BINDIR)/kubeseal
 
 install.yaml: $(shell find ../argocd/base)
 	$(KUSTOMIZE) build ../argocd/base/ > install.yaml
@@ -93,7 +89,7 @@ dctest-upgrade: install.yaml
 	fi
 	PATH=$(BINDIR):$$PATH OVERLAY=$(OVERLAY) UPGRADE=1 SUITE=$(SUITE) ./test.sh
 
-.PHONY: kubeseal
+.PHONY: setup-download
 setup-download:
 	if [ -z "$$(which wget)" ]; then \
 		$(SUDO) apt-get update && $(SUDO) apt-get -y install wget; \
@@ -104,11 +100,6 @@ setup-download:
 $(KUBECTL):
 	$(MAKE) setup-download
 	$(WGET) -O $@ https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
-	chmod +x $@
-
-$(KUBECTLMOCO):
-	$(MAKE) setup-download
-	$(WGET) -O $@ https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco-linux-amd64
 	chmod +x $@
 
 $(KUSTOMIZE):
@@ -126,13 +117,8 @@ $(TSH):
 	$(WGET) -O $(TELEPORT_DLPATH) https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-linux-amd64-bin.tar.gz
 	tar zxf $(TELEPORT_DLPATH) -C $(BINDIR) --strip-component=1 teleport/tsh
 
-$(KUBESEAL):
-	$(MAKE) setup-download
-	$(WGET) -O $@ https://github.com/bitnami-labs/sealed-secrets/releases/download/v$(KUBESEAL_VERSION)/kubeseal-linux-amd64
-	chmod +x $@
-
 .PHONY: setup
-setup: $(KUBECTL) $(KUBECTLMOCO) $(KUSTOMIZE) $(PROMTOOL) $(TSH) $(KUBESEAL)
+setup: $(KUBECTL) $(KUSTOMIZE) $(PROMTOOL) $(TSH)
 	go install github.com/onsi/ginkgo/ginkgo
 
 .PHONY: test-tools

--- a/test/moco_test.go
+++ b/test/moco_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -198,22 +197,8 @@ func testMoco() {
 			return nil
 		}).Should(Succeed())
 
-		//TODO: Please remove this codes ("copying kubectl-moco") when reaching the following state.
-		// - kubectl-moco is included in neco's deb package.
-		// - The MOCO v0.5.0 (or v0.6.0) is released.
-		//   The next version of MOCO will have some breaking changes. The old version of kubectl-moco cannot be used with the new MOCO.
-		By("copying kubectl-moco")
-		buf, err := ioutil.ReadFile("./bin/kubectl-moco")
-		Expect(err).NotTo(HaveOccurred())
-		stdout, stderr, err := ExecAtWithInput(boot0, buf, "dd", "of=kubectl-moco")
-		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-		stdout, stderr, err = ExecAt(boot0, "chmod", "+x", "./kubectl-moco")
-		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-		stdout, stderr, err = ExecAt(boot0, "./kubectl-moco", "--version")
-		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-
-		By("running kubectl-moco mysql")
-		stdout, stderr, err = ExecAt(boot0, "./kubectl-moco", "-n", "test-moco", "mysql", "-u", "root", "my-cluster", "--", "--version")
+		By("running kubectl moco mysql")
+		stdout, stderr, err := ExecAt(boot0, "kubectl", "moco", "-n", "test-moco", "mysql", "-u", "root", "my-cluster", "--", "--version")
 		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 		Expect(string(stdout)).Should(ContainSubstring("mysql  Ver 8"))
 	})

--- a/test/sealed-secret_test.go
+++ b/test/sealed-secret_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,15 +9,6 @@ import (
 
 func prepareSealedSecret() {
 	It("should create a Secret to be converted for SealedSecret", func() {
-		// TODO: remove this after cybozu-go/neco#1399 gets merged
-		By("copying kubeseal to boot-0")
-		buf, err := ioutil.ReadFile("./bin/kubeseal")
-		Expect(err).NotTo(HaveOccurred())
-		stdout, stderr, err := ExecAtWithInput(boot0, buf, "dd", "of=kubeseal")
-		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-		stdout, stderr, err = ExecAt(boot0, "chmod", "+x", "./kubeseal")
-		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
-
 		By("creating a SealedSecret")
 		secret := []byte(`
 apiVersion: v1
@@ -30,7 +20,7 @@ type: Opaque
 data:
   foo: YmFy
 `)
-		stdout, stderr, err = ExecAtWithInput(boot0, secret, "./kubeseal | kubectl apply -f -")
+		stdout, stderr, err := ExecAtWithInput(boot0, secret, "kubeseal | kubectl apply -f -")
 		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
 	})
 }


### PR DESCRIPTION
They are now pre-installed by neco debian package.