### PR TITLE
Revert "Fix egress nat to mount `/run`"

### DIFF
--- a/coil/base/egress.yaml
+++ b/coil/base/egress.yaml
@@ -11,16 +11,6 @@ spec:
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: 43200  # 12 hours
-  template:
-    spec:
-      containers:
-      - name: egress
-        volumeMounts:
-        - mountPath: /run
-          name: run
-      volumes:
-      - emptyDir: {}
-        name: run
 ---
 apiVersion: coil.cybozu.com/v2
 kind: Egress
@@ -35,13 +25,3 @@ spec:
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: 43200  # 12 hours
-  template:
-    spec:
-      containers:
-      - name: egress
-        volumeMounts:
-        - mountPath: /run
-          name: run
-      volumes:
-      - emptyDir: {}
-        name: run

--- a/customer-egress/base/egress.yaml
+++ b/customer-egress/base/egress.yaml
@@ -11,13 +11,3 @@ spec:
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: 43200  # 12 hours
-  template:
-    spec:
-      containers:
-      - name: egress
-        volumeMounts:
-        - mountPath: /run
-          name: run
-      volumes:
-      - emptyDir: {}
-        name: run


### PR DESCRIPTION
This reverts commit c42ce63085cdd55769aed67bebdb766ff039bed4.

The coil bug was fixed in 2.0.5.
https://github.com/cybozu-go/coil/blob/main/CHANGELOG.md#205---2021-01-14