### PR TITLE
Update neco-admission to 0.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
                 command: |
                   cd neco
                   ./bin/run-dctest.sh bootstrap release "" menu-ss.yml
-                no_output_timeout: 41m
+                no_output_timeout: 61m
       - unless:
           condition: <<parameters.neco-release-branch>>
           steps:
@@ -83,7 +83,7 @@ commands:
                 command: |
                   cd neco
                   ./bin/run-dctest.sh bootstrap "" "" menu-ss.yml
-                no_output_timeout: 41m
+                no_output_timeout: 61m
 
   delete-instance:
     description: remove GCP instance for this test
@@ -185,7 +185,7 @@ jobs:
           command: |
             export NECO_DIR=$(pwd)/neco
             ./bin/run-test.sh
-          no_output_timeout: 41m
+          no_output_timeout: 61m
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
@@ -208,7 +208,7 @@ jobs:
           command: |
             export NECO_DIR=$(pwd)/neco
             TARGET=dctest-reboot ./bin/run-test.sh
-          no_output_timeout: 41m
+          no_output_timeout: 61m
       - delete-instance
 
   upgrade-stage:
@@ -223,7 +223,7 @@ jobs:
           command: |
             export NECO_DIR=$(pwd)/neco
             TARGET=dctest-upgrade BASE_BRANCH=stage ./bin/run-test.sh
-          no_output_timeout: 41m
+          no_output_timeout: 61m
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
@@ -242,7 +242,7 @@ jobs:
           command: |
             export NECO_DIR=$(pwd)/neco
             TARGET=dctest-upgrade BASE_BRANCH=release ./bin/run-test.sh
-          no_output_timeout: 41m
+          no_output_timeout: 61m
       - store_test_results:
           path: ~/test-results
       - store_artifacts:

--- a/argocd-config/overlays/gcp/kustomization.yaml
+++ b/argocd-config/overlays/gcp/kustomization.yaml
@@ -10,6 +10,7 @@ patchesStrategicMerge:
 - local-pv-provisioner.yaml
 - metallb.yaml
 - monitoring.yaml
+- neco-admission.yaml
 - rook.yaml
 - sandbox.yaml
 - secrets.yaml

--- a/argocd-config/overlays/gcp/neco-admission.yaml
+++ b/argocd-config/overlays/gcp/neco-admission.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: argocd
 spec:
   source:
-    targetRevision: stage
-    path: neco-admission/overlays/stage0
+    path: neco-admission/overlays/gcp

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -11,7 +11,7 @@ How to write Kubernetes application manifests
 
 - All namespaces should have `team=xxx` labels to clarify their owner.
 - To skip validation/mutation webhook, administrators can use the following special annotations
-  - `mpod.kb.io/ignore: "true"`: With this label, [PodMutator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podmutator) is ignored. This label is necessary when the pods in the namespace are required to start without neco-admission webhooks.
+  - `admission.cybozu.com/pod: ignore`: With this label, [PodMutator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podmutator) and [PodValidator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podvalidator) are ignored. This label is necessary when the pods in the namespace are required to start without neco-admission webhooks.
   - `vnetworkpolicy.kb.io/ignore: "true"`: This label enables to ignore [CalicoNetworkPolicyValidator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#caliconetworkpolicyvalidator). Using this label makes it possible for administrators to set high prioritized network policies for namespaces.
   - `topolvm.cybozu.com/webhook: ignore`: This label disables using the Topolvm webhook used for persistent volumes provided by Topolvm. Administrators should use this label for the namespaces which should be independent of Topolvm. See more details about the label [here](https://github.com/topolvm/topolvm/blob/main/deploy/README.md#protect-system-namespaces-from-topolvm-webhook).
 

--- a/namespaces/base/cert-manager.yaml
+++ b/namespaces/base/cert-manager.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     cert-manager.io/disable-validation: "true"
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"
+    admission.cybozu.com/pod: ignore

--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -7,4 +7,4 @@ metadata:
     admission.cybozu.com/min-policy-order: "100"
   labels:
     topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"
+    admission.cybozu.com/pod: ignore

--- a/namespaces/base/kube-system.yaml
+++ b/namespaces/base/kube-system.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-system
-  labels:
-    topolvm.cybozu.com/webhook: ignore
-    mpod.kb.io/ignore: "true"
   annotations:
     admission.cybozu.com/min-policy-order: "500"
+  labels:
+    topolvm.cybozu.com/webhook: ignore
+    admission.cybozu.com/pod: ignore

--- a/neco-admission/base/deployment.yaml
+++ b/neco-admission/base/deployment.yaml
@@ -35,6 +35,18 @@ spec:
         - --cert-dir=/certs
         - --httpproxy-default-class=forest
         - --zap-stacktrace-level=panic
+        - --valid-image-prefix=quay.io/cybozu/
+        - --valid-image-prefix=quay.io/topolvm/
+        - --valid-image-prefix=ghcr.io/cybozu/
+        - --valid-image-prefix=ghcr.io/cybozu-go/
+        - --valid-image-prefix=ghcr.io/cybozu-private/
+        - --valid-image-prefix=docker.elastic.co/
+        - --valid-image-prefix=quay.io/gravitational/teleport-ent/
+        - --valid-image-prefix=datadog/agent,docker.io/datadog/agent
+        # TODO: remove this after we build our own images for Rook
+        - --valid-image-prefix=k8s.gcr.io/sig-storage/,quay.io/cephcsi/
+        # TODO: remove this after https://github.com/cybozu-go/neco/issues/1408
+        - --valid-image-prefix=quay.io/integreatly/grafana_plugins_init
         image: quay.io/cybozu/neco-admission
         resources:
           requests:

--- a/neco-admission/base/kustomization.yaml
+++ b/neco-admission/base/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
       value: neco-admission
 images:
   - name: quay.io/cybozu/neco-admission
-    newTag: 0.8.1
+    newTag: 0.9.0

--- a/neco-admission/base/upstream/manifests.yaml
+++ b/neco-admission/base/upstream/manifests.yaml
@@ -165,6 +165,46 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-pod
+  failurePolicy: Fail
+  name: vpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-preventdelete
+  failurePolicy: Fail
+  name: vpreventdelete.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - persistentvolumeclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-service
   failurePolicy: Fail
   name: vservice.kb.io

--- a/neco-admission/base/webhook.yaml
+++ b/neco-admission/base/webhook.yaml
@@ -18,10 +18,10 @@ webhooks:
       namespace: kube-system
   namespaceSelector:
     matchExpressions:
-    - key: mpod.kb.io/ignore
+    - key: admission.cybozu.com/pod
       operator: NotIn
       values:
-      - "true"
+      - ignore
   objectSelector:
     matchExpressions:
     - key: app.kubernetes.io/name
@@ -106,6 +106,12 @@ webhooks:
       name: neco-admission
       namespace: kube-system
   matchPolicy: Equivalent
+  namespaceSelector:
+    matchExpressions:
+    - key: admission.cybozu.com/pod
+      operator: NotIn
+      values:
+      - ignore
 - name: vpreventdelete.kb.io
   clientConfig:
     service:

--- a/neco-admission/base/webhook.yaml
+++ b/neco-admission/base/webhook.yaml
@@ -100,6 +100,53 @@ webhooks:
       name: neco-admission
       namespace: kube-system
   matchPolicy: Equivalent
+- name: vpod.kb.io
+  clientConfig:
+    service:
+      name: neco-admission
+      namespace: kube-system
+  matchPolicy: Equivalent
+- name: vpreventdelete.kb.io
+  clientConfig:
+    service:
+      name: neco-admission
+      namespace: kube-system
+  matchPolicy: Equivalent
+  # According to this code https://github.com/kubernetes-sigs/controller-tools/blob/master/pkg/webhook/parser.go#L183,
+  # `rules` cannot be generated with multiple GVK, so we should add new GVK manually here.
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - persistentvolumeclaims
+  - apiGroups:
+    - objectbucket.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - DELETE
+    resources:
+    - objectbucketclaims
+  - apiGroups:
+    - moco.cybozu.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - DELETE
+    resources:
+    - mysqlclusters
+  - apiGroups:
+    - elasticsearch.k8s.elastic.co
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - elasticsearches
 - name: vservice.kb.io
   clientConfig:
     service:

--- a/neco-admission/overlays/gcp/deployment.yaml
+++ b/neco-admission/overlays/gcp/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neco-admission
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: neco-admission
+        env:
+        - name: VPOD_IMAGE_PERMISSIVE
+          value: "true"

--- a/neco-admission/overlays/gcp/kustomization.yaml
+++ b/neco-admission/overlays/gcp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - deployment.yaml

--- a/neco-admission/overlays/stage0/deployment.yaml
+++ b/neco-admission/overlays/stage0/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: neco-admission
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: neco-admission
+        env:
+        - name: VPOD_IMAGE_PERMISSIVE
+          value: "true"

--- a/neco-admission/overlays/stage0/kustomization.yaml
+++ b/neco-admission/overlays/stage0/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - deployment.yaml

--- a/test/contour_test.go
+++ b/test/contour_test.go
@@ -19,7 +19,7 @@ func prepareContour() {
 	It("should create test-ingress namespace", func() {
 		ExecSafeAt(boot0, "kubectl", "delete", "namespace", "test-ingress", "--ignore-not-found=true")
 		createNamespaceIfNotExists("test-ingress")
-		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-ingress", "i-am-sure-to-delete=test-ingress")
+		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-ingress", "admission.cybozu.com/i-am-sure-to-delete=test-ingress")
 	})
 
 	It("should prepare resources", func() {

--- a/test/local-pv-provisioner_test.go
+++ b/test/local-pv-provisioner_test.go
@@ -40,7 +40,7 @@ func prepareLocalPVProvisioner() {
 	It("should create test-local-pv-provisioner namespace", func() {
 		ExecSafeAt(boot0, "kubectl", "delete", "namespace", ns, "--ignore-not-found=true")
 		createNamespaceIfNotExists(ns)
-		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", ns, "i-am-sure-to-delete="+ns)
+		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", ns, "admission.cybozu.com/i-am-sure-to-delete="+ns)
 	})
 
 	It("should be used as block device", func() {

--- a/test/network-policy_test.go
+++ b/test/network-policy_test.go
@@ -22,7 +22,7 @@ func prepareNetworkPolicy() {
 	It("should create test-netpol namespace", func() {
 		ExecSafeAt(boot0, "kubectl", "delete", "namespace", "test-netpol", "--ignore-not-found=true")
 		createNamespaceIfNotExists("test-netpol")
-		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-netpol", "i-am-sure-to-delete=test-netpol")
+		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-netpol", "admission.cybozu.com/i-am-sure-to-delete=test-netpol")
 	})
 
 	It("should prepare test pods", func() {

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -404,7 +404,7 @@ func applyAndWaitForApplications(commitID string) {
 			}
 			time.Sleep(1 * time.Second)
 		}
-	}, 40*time.Minute).Should(Succeed())
+	}, 60*time.Minute).Should(Succeed())
 }
 
 // Sometimes synchronization fails when argocd applies network policies.

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -90,7 +90,7 @@ func prepareRookCeph() {
 	It("should create test-rook-rgw namespace for testRookRGW", func() {
 		ExecSafeAt(boot0, "kubectl", "delete", "namespace", "test-rook-rgw", "--ignore-not-found=true")
 		createNamespaceIfNotExists("test-rook-rgw")
-		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-rook-rgw", "i-am-sure-to-delete=test-rook-rgw")
+		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-rook-rgw", "admission.cybozu.com/i-am-sure-to-delete=test-rook-rgw")
 	})
 
 	It("should apply a OBC resource and a POD for testRookRGW", func() {
@@ -133,7 +133,7 @@ spec:
 		It("should create "+ns+" namespace for testRookRBD", func() {
 			ExecSafeAt(boot0, "kubectl", "delete", "namespace", ns, "--ignore-not-found=true")
 			createNamespaceIfNotExists(ns)
-			ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", ns, "i-am-sure-to-delete="+ns)
+			ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", ns, "admission.cybozu.com/i-am-sure-to-delete="+ns)
 		})
 
 		It("should create a POD for testRookRBD", func() {

--- a/test/topolvm_test.go
+++ b/test/topolvm_test.go
@@ -19,7 +19,7 @@ func prepareTopoLVM() {
 		By("creating test-topolvm namespace")
 		ExecSafeAt(boot0, "kubectl", "delete", "namespace", topolvmNS, "--ignore-not-found=true")
 		createNamespaceIfNotExists(topolvmNS)
-		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", topolvmNS, "i-am-sure-to-delete="+topolvmNS)
+		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", topolvmNS, "admission.cybozu.com/i-am-sure-to-delete="+topolvmNS)
 
 		By("creating Pod and a PVC")
 		manifest := `


### PR DESCRIPTION
neco-admission is configured so that it protects the following resources
if they are annotated with `admission.cybozu.com/prevent: delete`.

- PersistentVolumeClaim
- ObjectBucketClaim
- MySQLCluster
- Elasticsearch

neco-admission is also configured to deny images from untrusted sources.