### PR TITLE
monitoring: fix alert rules for DaemonSets

### DIFF
--- a/monitoring/base/prometheus/alert_rules/metallb.yaml
+++ b/monitoring/base/prometheus/alert_rules/metallb.yaml
@@ -13,7 +13,7 @@ groups:
       - alert: MetalLBSpeakerDown
         expr: |
           up{job="metallb-speaker"}==0
-            unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute"}
+            unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable"}
         labels:
           severity: error
         for: 10m

--- a/monitoring/base/prometheus/alert_rules/network-policy.yaml
+++ b/monitoring/base/prometheus/alert_rules/network-policy.yaml
@@ -4,7 +4,7 @@ groups:
       - alert: CalicoNodeDown
         expr: |
           up{job="calico-node"}==0
-            unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute"}
+            unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable"}
         labels:
           severity: critical
         for: 10m

--- a/monitoring/base/victoriametrics/rules/metallb-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/metallb-alertrule.yaml
@@ -19,7 +19,7 @@ spec:
         - alert: MetalLBSpeakerDown
           expr: |
             up{job="metallb-speaker"}==0
-              unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute"}
+              unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable"}
           labels:
             severity: error
           for: 10m

--- a/monitoring/base/victoriametrics/rules/network-policy-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/network-policy-alertrule.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: CalicoNodeDown
           expr: |
             up{job="calico-node"}==0
-              unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute"}
+              unless on(node) kube_node_spec_taint{key="node.kubernetes.io/unreachable"}
           labels:
             severity: critical
           for: 10m

--- a/test/alert_test/metallb.yaml
+++ b/test/alert_test/metallb.yaml
@@ -35,7 +35,7 @@ tests:
     input_series:
       - series: 'up{job="metallb-speaker",instance="10.0.0.1",node="10.0.0.1"}'
         values: '0+0x10'
-      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute",node="10.0.0.1"}'
+      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoSchedule",node="10.0.0.1"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 10m

--- a/test/alert_test/network-policy.yaml
+++ b/test/alert_test/network-policy.yaml
@@ -22,7 +22,7 @@ tests:
     input_series:
       - series: 'up{job="calico-node",instance="10.0.0.1",node="10.0.0.1"}'
         values: '0+0x10'
-      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute",node="10.0.0.1"}'
+      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoSchedule",node="10.0.0.1"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 10m

--- a/test/vmalert_test/metallb.yaml
+++ b/test/vmalert_test/metallb.yaml
@@ -35,7 +35,7 @@ tests:
     input_series:
       - series: 'up{job="metallb-speaker",instance="10.0.0.1:7472",node="10.0.0.1"}'
         values: '0+0x10'
-      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute",node="10.0.0.1"}'
+      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoSchedule",node="10.0.0.1"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 10m

--- a/test/vmalert_test/network-policy.yaml
+++ b/test/vmalert_test/network-policy.yaml
@@ -22,7 +22,7 @@ tests:
     input_series:
       - series: 'up{job="calico-node",instance="10.0.0.1:9091",node="10.0.0.1"}'
         values: '0+0x10'
-      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoExecute",node="10.0.0.1"}'
+      - series: 'kube_node_spec_taint{key="node.kubernetes.io/unreachable",effect="NoSchedule",node="10.0.0.1"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 10m


### PR DESCRIPTION
Unreachable nodes can be tainted with "NoSchedule" effect
instead of "NoExecute".