### PR TITLE
pvc-autoresizer: fix to refer to VictoriaMetrics instead of Prometheus

### DIFF
--- a/monitoring/base/victoriametrics/rules/kubernetes-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/kubernetes-alertrule.yaml
@@ -1,5 +1,5 @@
 # NOTE: most of the rules are downloaded from the following link:
-# https://github.com/coreos/kube-prometheus/blob/master/manifests/prometheus-rules.yaml
+# https://github.com/prometheus-operator/kube-prometheus/blob/master/manifests/kubernetes-prometheusRule.yaml
 # The following Apache License is kube-prometheus's one.
 
 # Apache License

--- a/pvc-autoresizer/base/controller.yaml
+++ b/pvc-autoresizer/base/controller.yaml
@@ -9,4 +9,4 @@ spec:
       containers:
       - name: manager
         args:
-        - --prometheus-url=http://prometheus.monitoring.svc:9090
+        - --prometheus-url=http://vmselect-vmcluster-largeset.monitoring.svc:8481/select/0/prometheus


### PR DESCRIPTION
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>