### PR TITLE
Add kube-metrics-adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
 # Makefile to update manifests
 
+HELM_VERSION = 3.5.2
 
+.PHONY: update-kube-metrics-adapter
+update-kube-metrics-adapter:
+	$(call get-latest-tag,kube-metrics-adapter)
+	rm -rf /tmp/kube-metrics-adapter
+	cd /tmp; git clone -b $(call upstream-tag,$(latest_tag)) --depth 1 https://github.com/zalando-incubator/kube-metrics-adapter
+	helm template \
+		--set namespace=kube-metrics-adapter \
+		--set enableExternalMetricsApi=true \
+		--set service.internalPort=6443 \
+		--set replicas=2 \
+		/tmp/kube-metrics-adapter/docs/helm > kube-metrics-adapter/base/upstream/manifest.yaml
+	rm -rf /tmp/kube-metrics-adapter
+	sed -i 's/newTag: .*/newTag: $(latest_tag)/' kube-metrics-adapter/base/kustomization.yaml
 
 .PHONY: update-prometheus-adapter
 update-prometheus-adapter:
 	$(call get-latest-tag,prometheus-adapter)
-	echo $(latest_tag)
 	sed -i -E \
 		-e 's/^(          tag:).*$$/\1 $(latest_tag)/' \
 		-e 's/^(    targetRevision:).*$$/\1 $(CHART_VERSION)/' \
@@ -21,3 +34,10 @@ endef
 define upstream-tag
 	$(shell echo $1 | sed -E 's/^(.*)\.[[:digit:]]+$$/v\1/')
 endef
+
+.PHONY: setup
+setup:
+	curl -o /tmp/helm.tgz -fsL https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz
+	mkdir -p $$(go env GOPATH)/bin
+	tar --strip-components=1 -C $$(go env GOPATH)/bin -xzf /tmp/helm.tgz linux-amd64/helm
+	rm -f /tmp/helm.tgz

--- a/argocd-config/base/kube-metrics-adapter.yaml
+++ b/argocd-config/base/kube-metrics-adapter.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-metrics-adapter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: ..
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
+    targetRevision: release
+    path: kube-metrics-adapter/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-metrics-adapter
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd-config/base/kustomization.yaml
+++ b/argocd-config/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - elastic.yaml
 - external-dns.yaml
 - ingress.yaml
+- kube-metrics-adapter.yaml
 - local-pv-provisioner.yaml
 - logging.yaml
 - metallb.yaml

--- a/argocd-config/overlays/stage0/kube-metrics-adapter.yaml
+++ b/argocd-config/overlays/stage0/kube-metrics-adapter.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-metrics-adapter
+  namespace: argocd
+spec:
+  source:
+    targetRevision: stage

--- a/argocd-config/overlays/stage0/kustomization.yaml
+++ b/argocd-config/overlays/stage0/kustomization.yaml
@@ -16,6 +16,7 @@ patchesStrategicMerge:
 - elastic.yaml
 - external-dns.yaml
 - ingress.yaml
+- kube-metrics-adapter.yaml
 - local-pv-provisioner.yaml
 - logging.yaml
 - metallb.yaml

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -7,6 +7,7 @@ How to maintain neco-apps
 - [dex](#dex)
 - [elastic (ECK)](#elastic-eck)
 - [external-dns](#external-dns)
+- [kube-metrics-adapter](#kube-metrics-adapter)
 - [ingress (Contour & Envoy)](#ingress-contour--envoy)
 - [logging](#logging)
   - [loki, promtail](#loki-promtail)
@@ -98,6 +99,18 @@ $ curl -sLf -o external-dns/base/common.yaml https://github.com/kubernetes-sigs/
 ```
 
 Then check the diffs by `git diff`.
+
+## kube-metrics-adapter
+
+Check [releases](https://github.com/zalando-incubator/kube-metrics-adapter/releases).
+
+Update the manifests as follows:
+
+```console
+$ make setup   # for the first time to install Helm
+$ make update-kube-metrics-adapter
+$ git diff kube-metrics-adapter
+```
 
 ## ingress (Contour & Envoy)
 

--- a/kube-metrics-adapter/base/apiservice.yaml
+++ b/kube-metrics-adapter/base/apiservice.yaml
@@ -1,0 +1,9 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    cert-manager.io/inject-ca-from: kube-metrics-adapter/kube-metrics-adapter-root-cert
+spec:
+  insecureSkipTLSVerify: null

--- a/kube-metrics-adapter/base/cert.yaml
+++ b/kube-metrics-adapter/base/cert.yaml
@@ -1,0 +1,53 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kube-metrics-adapter-self-signed-issuer
+  namespace: kube-metrics-adapter
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kube-metrics-adapter-root-cert
+  namespace: kube-metrics-adapter
+spec:
+  commonName: ca.webhook.kube-metrics-adapter
+  duration: 438000h0m0s
+  isCA: true
+  usages:
+  - digital signature
+  - key encipherment
+  - cert sign
+  issuerRef:
+    name: kube-metrics-adapter-self-signed-issuer
+  secretName: kube-metrics-adapter-root-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kube-metrics-adapter-root-issuer
+  namespace: kube-metrics-adapter
+spec:
+  ca:
+    secretName: kube-metrics-adapter-root-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kube-metrics-adapter-cert
+  namespace: kube-metrics-adapter
+spec:
+  dnsNames:
+  - kube-metrics-adapter
+  - kube-metrics-adapter.kube-metrics-adapter
+  - kube-metrics-adapter.kube-metrics-adapter.svc
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
+  duration: 87600h0m0s
+  issuerRef:
+    name: kube-metrics-adapter-root-issuer
+  secretName: kube-metrics-adapter

--- a/kube-metrics-adapter/base/deployment.yaml
+++ b/kube-metrics-adapter/base/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+  labels: null
+spec:
+  template:
+    metadata:
+      labels:
+        version: null
+    spec:
+      containers:
+      - name: kube-metrics-adapter
+        imagePullPolicy: IfNotPresent
+        args:
+        - --prometheus-server=http://vmselect-vmcluster-largeset.monitoring.svc:8481/select/0/prometheus
+        - --enable-custom-metrics-api=false
+        - --secure-port=6443
+        - --tls-cert-file=/certs/tls.crt
+        - --tls-private-key-file=/certs/tls.key
+        resources:
+          limits: null
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /certs
+          name: volume-serving-cert
+          readOnly: true
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: volume-serving-cert
+        secret:
+          defaultMode: 420
+          secretName: kube-metrics-adapter

--- a/kube-metrics-adapter/base/kustomization.yaml
+++ b/kube-metrics-adapter/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./upstream/manifest.yaml
+- ./namespace.yaml
+- ./cert.yaml
+patchesStrategicMerge:
+- ./apiservice.yaml
+- ./deployment.yaml
+images:
+- name: registry.opensource.zalan.do/teapot/kube-metrics-adapter
+  newName: quay.io/cybozu/kube-metrics-adapter
+  newTag: 0.1.10.1

--- a/kube-metrics-adapter/base/namespace.yaml
+++ b/kube-metrics-adapter/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-metrics-adapter
+  labels:
+    team: neco

--- a/kube-metrics-adapter/base/upstream/manifest.yaml
+++ b/kube-metrics-adapter/base/upstream/manifest.yaml
@@ -1,0 +1,236 @@
+---
+# Source: kube-metrics-adapter/templates/service-account.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-metrics-adapter-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-metrics-server-resources
+rules:
+- apiGroups:
+  - external.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-metrics-adapter-resource-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-metrics-adapter-resource-collector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-metrics-adapter-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-metrics-adapter-resource-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-metrics-adapter-resource-collector
+subjects:
+- kind: ServiceAccount
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-metrics-adapter-resource-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-metrics-adapter-resource-reader
+subjects:
+- kind: ServiceAccount
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+---
+# Source: kube-metrics-adapter/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-metrics-adapter-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+---
+# Source: kube-metrics-adapter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+spec:
+  ports:
+    - port: 443
+      targetPort: 6443
+  selector:
+    application: kube-metrics-adapter
+---
+# Source: kube-metrics-adapter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-metrics-adapter
+  labels:
+    application: kube-metrics-adapter
+    version: v0.1.9
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      application: kube-metrics-adapter
+  template:
+    metadata:
+      labels:
+        application: kube-metrics-adapter
+        version: v0.1.9
+    spec:
+      serviceAccountName: kube-metrics-adapter
+      containers:
+        - name: kube-metrics-adapter
+          image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.9
+          args:
+            - --enable-external-metrics-api=true
+            - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
+            - --secure-port=6443
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+---
+# Source: kube-metrics-adapter/templates/external-metrics-apiservice.yaml
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: kube-metrics-adapter
+    namespace: kube-metrics-adapter
+  group: external.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/test/hpa_test.go
+++ b/test/hpa_test.go
@@ -102,6 +102,54 @@ spec:
       target:
         type: AverageValue
         averageValue: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hpa-external
+  namespace: sandbox
+spec:
+  selector:
+    matchLabels:
+      run: hpa-external
+  template:
+    metadata:
+      labels:
+        run: hpa-external
+    spec:
+      containers:
+      - name: testhttpd
+        image: quay.io/cybozu/testhttpd:0
+        resources:
+          requests:
+            cpu: 100m
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-external
+  namespace: sandbox
+  annotations:
+    metric-config.external.processed-events-per-second.prometheus/query: |
+      scalar(test_hpa_external)
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hpa-external
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: processed-events-per-second
+        selector:
+          matchLabels:
+            type: prometheus
+      target:
+        type: AverageValue
+        averageValue: 10
 `
 
 	It("should prepare resources for HPA tests", func() {
@@ -126,10 +174,12 @@ func testHPA() {
 			}
 			return nil
 		}).Should(Succeed())
+
+		ExecSafeAt(boot0, "kubectl", "-n", "sandbox", "delete", "deployments", "hpa-resource")
 	})
 
 	It("should work for custom resources provided by prometheus-adapter", func() {
-		By("setting custom metrics via push gateway")
+		By("waiting for the test Pod to be created")
 		var pod *corev1.Pod
 		Eventually(func() error {
 			pods := &corev1.PodList{}
@@ -169,5 +219,32 @@ func testHPA() {
 			}
 			return nil
 		}).Should(Succeed())
+
+		ExecSafeAt(boot0, "kubectl", "-n", "sandbox", "delete", "deployments", "hpa-custom")
+	})
+
+	It("should work for external resources provided by kube-metrics-adapter", func() {
+		metric := "test_hpa_external 23\n"
+		url := fmt.Sprintf("http://%s/metrics/job/some_job", bastionPushgatewayFQDN)
+		Eventually(func() error {
+			_, stderr, err := ExecAtWithInput(boot0, []byte(metric), "curl", "-sf", "--data-binary", "@-", url)
+			if err != nil {
+				return fmt.Errorf("failed to push a metrics to pushgateway: %s: %w", stderr, err)
+			}
+			stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "sandbox", "get", "deployments", "hpa-external", "-o", "json")
+			if err != nil {
+				return fmt.Errorf("failed to get hpa-external deployment: %s: %w", stderr, err)
+			}
+			dpl := &appsv1.Deployment{}
+			if err := json.Unmarshal(stdout, dpl); err != nil {
+				return err
+			}
+			if dpl.Spec.Replicas == nil || *dpl.Spec.Replicas != 3 {
+				return errors.New("replicas of hpa-external is not 3")
+			}
+			return nil
+		}).Should(Succeed())
+
+		ExecSafeAt(boot0, "kubectl", "-n", "sandbox", "delete", "deployments", "hpa-external")
 	})
 }

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -352,11 +352,14 @@ func applyAndWaitForApplications(commitID string) {
 	// TODO: remove the following block after #1268 is merged and released
 	if doUpgrade {
 		By("removing metrics-server")
-		ExecSafeAt(boot0, "kubectl", "-n", "argocd", "patch", "applications", "metrics-server",
-			"-p", `'{"metadata": {"finalizers": ["resources-finalizer.argocd.argoproj.io"]}}'`, "--type=merge")
+		_, _, err := ExecAt(boot0, "kubectl", "-n", "argocd", "get", "applications", "metrics-server")
+		if err == nil {
+			ExecSafeAt(boot0, "kubectl", "-n", "argocd", "patch", "applications", "metrics-server",
+				"-p", `'{"metadata": {"finalizers": ["resources-finalizer.argocd.argoproj.io"]}}'`, "--type=merge")
 
-		// this is only for test because auto-pruning is not enabled for argocd-config app in tests.
-		ExecSafeAt(boot0, "kubectl", "-n", "argocd", "delete", "applications", "metrics-server")
+			// this is only for test because auto-pruning is not enabled for argocd-config app in tests.
+			ExecSafeAt(boot0, "kubectl", "-n", "argocd", "delete", "applications", "metrics-server")
+		}
 
 		// this is necessary to accept prometheus-adapter app as it references a new Helm repository.
 		ExecSafeAt(boot0, "argocd", "app", "set", "--sync-policy=none", "neco-admission")


### PR DESCRIPTION
The manifest is based on the upstream Helm chart with the following kustomizations:

- Use cert-manager to generate TLS certificates
- Adjust command-line arguments