### PR TITLE
fix inter-It dependency in network-policy test

### DIFF
--- a/test/network-policy_test.go
+++ b/test/network-policy_test.go
@@ -19,13 +19,12 @@ import (
 )
 
 func prepareNetworkPolicy() {
-	It("should create test-netpol namespace", func() {
+	It("should prepare test pods in test-netpol namespace", func() {
+		By("preparing namespace")
 		ExecSafeAt(boot0, "kubectl", "delete", "namespace", "test-netpol", "--ignore-not-found=true")
 		createNamespaceIfNotExists("test-netpol")
 		ExecSafeAt(boot0, "kubectl", "annotate", "namespaces", "test-netpol", "admission.cybozu.com/i-am-sure-to-delete=test-netpol")
-	})
 
-	It("should prepare test pods", func() {
 		By("deploying testhttpd pods")
 		deployYAML := `
 apiVersion: apps/v1


### PR DESCRIPTION
`It("should prepare test pods")` depends on `It("should create test-netpol namespace")`. (the former creates a resource in the namepsace the latter created)

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>