### PR TITLE
monitoring: Add scrape job for audit log

### DIFF
--- a/logging/base/promtail.yaml
+++ b/logging/base/promtail.yaml
@@ -27,6 +27,9 @@ spec:
             - "-config.file=/etc/promtail/promtail.yaml"
             - "-config.expand-env=true"
           volumeMounts:
+            - name: audit
+              mountPath: /var/log/audit
+              readOnly: true
             - name: journal
               mountPath: /var/log/journal
               readOnly: true
@@ -35,6 +38,9 @@ spec:
           configMap:
             name: loki-promtail
           secret: null
+        - hostPath:
+            path: /var/log/audit
+          name: audit
         - hostPath:
             path: /run/log/journal
           name: journal

--- a/logging/base/promtail/configmap.yaml
+++ b/logging/base/promtail/configmap.yaml
@@ -290,6 +290,25 @@ data:
       #
       # Added by neco
       #
+      - job_name: kubernetes-apiservers
+        static_configs:
+          - targets:
+              - localhost
+            labels:
+              job: kubernetes-apiservers
+              __path__: /var/log/audit/*.log
+        relabel_configs:
+          - target_label: type
+            replacement: audit
+          - target_label: instance
+            replacement: ${HOSTNAME}
+        pipeline_stages:
+          - json:
+              expressions:
+                timestamp: stageTimestamp
+          - timestamp:
+              format: RFC3339Nano
+              source: timestamp
       - job_name: journal
         journal:
           json: false

--- a/test/logging_test.go
+++ b/test/logging_test.go
@@ -13,13 +13,16 @@ import (
 
 func testLogging() {
 	It("should be successful", func() {
-		checkLog("should be get pod logs", `'{namespace="logging", pod="logging-loki-0"}'`)
+		checkLog("should get pod logs", `'{namespace="logging", pod="logging-loki-0"}'`)
 
 		ssNodeName := getNodeName("ss")
-		checkLog("should be get journal logs by ss", fmt.Sprintf(`'{job="systemd-journal", instance="%s"}'`, ssNodeName))
+		checkLog("should get journal logs by ss", fmt.Sprintf(`'{job="systemd-journal", instance="%s"}'`, ssNodeName))
 
 		csNodeName := getNodeName("cs")
-		checkLog("should be get journal logs by cs", fmt.Sprintf(`'{job="systemd-journal", instance="%s"}'`, csNodeName))
+		checkLog("should get journal logs by cs", fmt.Sprintf(`'{job="systemd-journal", instance="%s"}'`, csNodeName))
+
+		masterNodeName := getNodeName("master")
+		checkLog("should get audit logs from master", fmt.Sprintf(`'{job="kubernetes-apiservers", type="audit", instance="%s"}'`, masterNodeName))
 	})
 }
 


### PR DESCRIPTION
This PR adds a job for promtail scraping audit logs from API servers.
It should be merged after: https://github.com/cybozu-go/neco/pull/1444

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>