### PR TITLE
refine Grafana dashboards

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
+++ b/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
@@ -612,7 +612,7 @@ spec:
             "list": []
         },
         "time": {
-            "from": "now-5m",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/calico.yaml
+++ b/monitoring/base/grafana-operator/dashboards/calico.yaml
@@ -1152,7 +1152,7 @@ spec:
             "list": []
         },
         "time": {
-            "from": "now-30m",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/ceph-clusters.yaml
+++ b/monitoring/base/grafana-operator/dashboards/ceph-clusters.yaml
@@ -4556,7 +4556,6 @@ spec:
         }
         }
     ],
-    "refresh": "1m",
     "schemaVersion": 25,
     "style": "dark",
     "tags": [
@@ -4687,7 +4686,7 @@ spec:
         ]
     },
     "time": {
-        "from": "now-12h",
+        "from": "now-1h",
         "to": "now"
     },
     "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/ceph-osd.yaml
+++ b/monitoring/base/grafana-operator/dashboards/ceph-osd.yaml
@@ -1185,7 +1185,6 @@ spec:
             "type": "row"
         }
         ],
-        "refresh": "5m",
         "schemaVersion": 25,
         "style": "dark",
         "tags": [
@@ -1348,7 +1347,7 @@ spec:
         ]
         },
         "time": {
-        "from": "now-3h",
+        "from": "now-1h",
         "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/cert-manager.yaml
+++ b/monitoring/base/grafana-operator/dashboards/cert-manager.yaml
@@ -1265,7 +1265,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-24h",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/coil.yaml
+++ b/monitoring/base/grafana-operator/dashboards/coil.yaml
@@ -848,7 +848,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-6h",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/contour.yaml
+++ b/monitoring/base/grafana-operator/dashboards/contour.yaml
@@ -809,7 +809,6 @@ spec:
                 }
             }
         ],
-        "refresh": "10s",
         "schemaVersion": 19,
         "style": "dark",
         "tags": [
@@ -874,7 +873,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-30m",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/cpu-usage.yaml
+++ b/monitoring/base/grafana-operator/dashboards/cpu-usage.yaml
@@ -6,346 +6,271 @@ spec:
   name: cpu-usage.json
   json: >
     {
-        "annotations": {
-            "list": [
-                {
-                    "builtIn": 1,
-                    "datasource": "-- Grafana --",
-                    "enable": true,
-                    "hide": true,
-                    "iconColor": "rgba(0, 211, 255, 1)",
-                    "name": "Annotations & Alerts",
-                    "type": "dashboard"
-                }
-            ]
-        },
-        "editable": true,
-        "gnetId": null,
-        "graphTooltip": 0,
-        "id": null,
-        "iteration": 1570083853267,
-        "links": [],
-        "panels": [
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": null,
+      "iteration": 1570083853267,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 15,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "repeat": "namespace",
+          "repeatDirection": "v",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 20,
-                    "w": 12,
-                    "x": 0,
-                    "y": 0
-                },
-                "id": 2,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[10m])",
-                        "legendFormat": "{{pod}}",
-                        "refId": "B"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "CPU time average 10m ($namespace)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": 2,
-                        "format": "s",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "none",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"$namespace\"}[10m])",
+              "legendFormat": "{{pod}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU time average 10m ($namespace)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 2,
+              "format": "s",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             },
             {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 20,
-                    "w": 12,
-                    "x": 12,
-                    "y": 0
-                },
-                "id": 3,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_cpu_load_average_10s{namespace=\"$namespace\"}",
-                        "legendFormat": "{{pod}}",
-                        "refId": "B"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "CPU load average 10s ($namespace)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": 0,
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": "0",
-                        "show": true
-                    },
-                    {
-                        "format": "none",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
-        ],
-        "refresh": false,
-        "schemaVersion": 19,
-        "style": "dark",
-        "tags": [
-            "node"
-        ],
-        "templating": {
-            "list": [
-                {
-                    "allValue": null,
-                    "current": {
-                        "tags": [],
-                        "text": "argocd",
-                        "value": "argocd"
-                    },
-                    "datasource": "vmcluster-largeset",
-                    "definition": "label_values(kube_namespace_created,namespace)",
-                    "hide": 0,
-                    "includeAll": false,
-                    "label": null,
-                    "multi": false,
-                    "name": "namespace",
-                    "options": [
-                        {
-                            "selected": true,
-                            "text": "argocd",
-                            "value": "argocd"
-                        },
-                        {
-                            "selected": false,
-                            "text": "default",
-                            "value": "default"
-                        },
-                        {
-                            "selected": false,
-                            "text": "demo",
-                            "value": "demo"
-                        },
-                        {
-                            "selected": false,
-                            "text": "elastic-system",
-                            "value": "elastic-system"
-                        },
-                        {
-                            "selected": false,
-                            "text": "external-dns",
-                            "value": "external-dns"
-                        },
-                        {
-                            "selected": false,
-                            "text": "ingress-global",
-                            "value": "ingress-global"
-                        },
-                        {
-                            "selected": false,
-                            "text": "ingress-forest",
-                            "value": "ingress-forest"
-                        },
-                        {
-                            "selected": false,
-                            "text": "ingress-bastion",
-                            "value": "ingress-bastion"
-                        },
-                        {
-                            "selected": false,
-                            "text": "internet-egress",
-                            "value": "internet-egress"
-                        },
-                        {
-                            "selected": false,
-                            "text": "kube-node-lease",
-                            "value": "kube-node-lease"
-                        },
-                        {
-                            "selected": false,
-                            "text": "kube-public",
-                            "value": "kube-public"
-                        },
-                        {
-                            "selected": false,
-                            "text": "kube-system",
-                            "value": "kube-system"
-                        },
-                        {
-                            "selected": false,
-                            "text": "maneki",
-                            "value": "maneki"
-                        },
-                        {
-                            "selected": false,
-                            "text": "metallb-system",
-                            "value": "metallb-system"
-                        },
-                        {
-                            "selected": false,
-                            "text": "monitoring",
-                            "value": "monitoring"
-                        },
-                        {
-                            "selected": false,
-                            "text": "sandbox",
-                            "value": "sandbox"
-                        },
-                        {
-                            "selected": false,
-                            "text": "teleport",
-                            "value": "teleport"
-                        },
-                        {
-                            "selected": false,
-                            "text": "topolvm-system",
-                            "value": "topolvm-system"
-                        }
-                    ],
-                    "query": "label_values(kube_namespace_created,namespace)",
-                    "refresh": 0,
-                    "regex": "",
-                    "skipUrlSync": false,
-                    "sort": 1,
-                    "tagValuesQuery": "",
-                    "tags": [],
-                    "tagsQuery": "",
-                    "type": "query",
-                    "useTags": false
-                }
-            ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
-        "time": {
-            "from": "now-15m",
-            "to": "now"
-        },
-        "timepicker": {
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ]
-        },
-        "timezone": "",
-        "title": "CPU Usage Per Pod",
-        "uid": "llj9rd2Wk",
-        "version": 5
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "vmcluster-largeset",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 15,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "repeat": "namespace",
+          "repeatDirection": "v",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "container_cpu_load_average_10s{namespace=\"$namespace\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU load average 10s ($namespace)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 27,
+      "style": "dark",
+      "tags": [
+        "node"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "tags": [],
+              "text": [
+                "argocd"
+              ],
+              "value": [
+                "argocd"
+              ]
+            },
+            "definition": "label_values(kube_namespace_created, namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_namespace_created, namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "CPU Usage Per Pod",
+      "uid": "llj9rd2Wk",
+      "version": 4
     }

--- a/monitoring/base/grafana-operator/dashboards/envoy.yaml
+++ b/monitoring/base/grafana-operator/dashboards/envoy.yaml
@@ -1451,7 +1451,6 @@ spec:
                 ]
             }
         ],
-        "refresh": "10s",
         "schemaVersion": 16,
         "style": "dark",
         "tags": [
@@ -1503,7 +1502,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-30m",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/etcd.yaml
+++ b/monitoring/base/grafana-operator/dashboards/etcd.yaml
@@ -1782,7 +1782,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-6h",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/ingress-watcher.yaml
+++ b/monitoring/base/grafana-operator/dashboards/ingress-watcher.yaml
@@ -221,7 +221,7 @@ spec:
             "list": []
         },
         "time": {
-            "from": "now-6h",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/kube-controller-manager.yaml
+++ b/monitoring/base/grafana-operator/dashboards/kube-controller-manager.yaml
@@ -153,28 +153,28 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"10\\\\.69\\\\.0\\\\.201|10\\\\.69\\\\.0\\\\.21|10\\\\.69\\\\.1\\\\.149\",code=~\"2..\"}[5m]))",
+                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\",code=~\"2..\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "2xx",
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"10\\\\.69\\\\.0\\\\.201|10\\\\.69\\\\.0\\\\.21|10\\\\.69\\\\.1\\\\.149\",code=~\"3..\"}[5m]))",
+                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\",code=~\"3..\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "3xx",
                 "refId": "B"
               },
               {
-                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"10\\\\.69\\\\.0\\\\.201|10\\\\.69\\\\.0\\\\.21|10\\\\.69\\\\.1\\\\.149\",code=~\"4..\"}[5m]))",
+                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\",code=~\"4..\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "4xx",
                 "refId": "C"
               },
               {
-                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"10\\\\.69\\\\.0\\\\.201|10\\\\.69\\\\.0\\\\.21|10\\\\.69\\\\.1\\\\.149\",code=~\"5..\"}[5m]))",
+                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\",code=~\"5..\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "5xx",

--- a/monitoring/base/grafana-operator/dashboards/kubernetes-cluster.yaml
+++ b/monitoring/base/grafana-operator/dashboards/kubernetes-cluster.yaml
@@ -1366,7 +1366,6 @@ spec:
                 }
             }
         ],
-        "refresh": "30s",
         "schemaVersion": 16,
         "style": "dark",
         "tags": [
@@ -1376,7 +1375,7 @@ spec:
             "list": []
         },
         "time": {
-            "from": "now-30m",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/kubernetes-persistence-volumes.yaml
+++ b/monitoring/base/grafana-operator/dashboards/kubernetes-persistence-volumes.yaml
@@ -498,7 +498,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-7d",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/local-pv-provisioner.yaml
+++ b/monitoring/base/grafana-operator/dashboards/local-pv-provisioner.yaml
@@ -241,7 +241,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-6h",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/memory-usage.yaml
+++ b/monitoring/base/grafana-operator/dashboards/memory-usage.yaml
@@ -6,1487 +6,184 @@ spec:
   name: memory-usage.json
   json: >
     {
-        "annotations": {
-            "list": [
-                {
-                    "builtIn": 1,
-                    "datasource": "-- Grafana --",
-                    "enable": true,
-                    "hide": true,
-                    "iconColor": "rgba(0, 211, 255, 1)",
-                    "name": "Annotations & Alerts",
-                    "type": "dashboard"
-                }
-            ]
-        },
-        "editable": true,
-        "gnetId": null,
-        "graphTooltip": 0,
-        "id": 7,
-        "links": [],
-        "panels": [
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 7,
+      "iteration": 1615364270940,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "decimals": null,
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "maxPerRow": 4,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "repeat": "namespace",
+          "repeatDirection": "h",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 0,
-                    "y": 0
-                },
-                "id": 3,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"argocd\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (argocd)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 6,
-                    "y": 0
-                },
-                "id": 9,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"elastic-system\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (elastic-system)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 18,
-                    "y": 0
-                },
-                "id": 18,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"maneki\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (maneki)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 0,
-                    "y": 9
-                },
-                "id": 5,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"external-dns\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (external-dns)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 6,
-                    "y": 9
-                },
-                "id": 2,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"monitoring\", pod!~\"machines-endpoints-(.*)\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    },
-                    {
-                        "expr": "sum (container_memory_usage_bytes{namespace=\"monitoring\", pod=~\"machines-endpoints-(.*)\"})/1024/1024",
-                        "legendFormat": "machines-endpoints",
-                        "refId": "B"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (monitoring)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "decimals": null,
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 12,
-                    "y": 9
-                },
-                "id": 12,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"internet-egress\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (internet-egress)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 18,
-                    "y": 9
-                },
-                "id": 11,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=~\"ingress-.*\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (ingress)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 0,
-                    "y": 18
-                },
-                "id": 16,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"teleport\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (teleport)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "decimals": null,
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 6,
-                    "y": 18
-                },
-                "id": 13,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"kube-system\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (kube-system)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 12,
-                    "y": 18
-                },
-                "id": 4,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"metallb-system\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (metallb-system)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 18,
-                    "y": 18
-                },
-                "id": 17,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"topolvm-system\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (topolvm-system)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "decimals": null,
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 0,
-                    "y": 27
-                },
-                "id": 7,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"demo\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (demo)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 6,
-                    "y": 27
-                },
-                "id": 8,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"default\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (default)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 12,
-                    "y": 27
-                },
-                "id": 14,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"kube-public\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (kube-public)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 18,
-                    "y": 27
-                },
-                "id": 6,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"kube-node-lease\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (kube-node-lease)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
-            },
-            {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "decimals": null,
-                "description": "",
-                "fill": 1,
-                "fillGradient": 0,
-                "gridPos": {
-                    "h": 9,
-                    "w": 6,
-                    "x": 0,
-                    "y": 36
-                },
-                "id": 15,
-                "legend": {
-                    "avg": false,
-                    "current": false,
-                    "max": false,
-                    "min": false,
-                    "show": true,
-                    "total": false,
-                    "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
-                "nullPointMode": "null",
-                "options": {
-                    "dataLinks": []
-                },
-                "percentage": false,
-                "pointradius": 2,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                    {
-                        "expr": "container_memory_usage_bytes{namespace=\"sandbox\"}/1024/1024",
-                        "interval": "",
-                        "legendFormat": "{{pod}}",
-                        "refId": "A"
-                    }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Memory Usage (sandbox)",
-                "tooltip": {
-                    "shared": true,
-                    "sort": 0,
-                    "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                    "buckets": null,
-                    "mode": "time",
-                    "name": null,
-                    "show": true,
-                    "values": []
-                },
-                "yaxes": [
-                    {
-                        "decimals": null,
-                        "format": "decmbytes",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    },
-                    {
-                        "decimals": null,
-                        "format": "short",
-                        "label": "",
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": true
-                    }
-                ],
-                "yaxis": {
-                    "align": false,
-                    "alignLevel": null
-                }
+              "expr": "container_memory_usage_bytes{namespace=\"$namespace\"}/1024/1024",
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
             }
-        ],
-        "schemaVersion": 19,
-        "style": "dark",
-        "tags": [
-            "node"
-        ],
-        "templating": {
-            "list": []
-        },
-        "time": {
-            "from": "now-30m",
-            "to": "now"
-        },
-        "timepicker": {
-            "refresh_intervals": [
-                "5s",
-                "10s",
-                "30s",
-                "1m",
-                "5m",
-                "15m",
-                "30m",
-                "1h",
-                "2h",
-                "1d"
-            ]
-        },
-        "timezone": "",
-        "title": "Memory Usage",
-        "uid": "XtmQfd2Zk",
-        "version": 4
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage ($namespace)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "decmbytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "schemaVersion": 27,
+      "style": "dark",
+      "tags": [
+        "node"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "tags": [],
+              "text": [
+                "argocd"
+              ],
+              "value": [
+                "argocd"
+              ]
+            },
+            "datasource": null,
+            "definition": "label_values(kube_namespace_created, namespace)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_namespace_created, namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Memory Usage",
+      "uid": "XtmQfd2Zk",
+      "version": 1
     }

--- a/monitoring/base/grafana-operator/dashboards/neco-admission.yaml
+++ b/monitoring/base/grafana-operator/dashboards/neco-admission.yaml
@@ -357,7 +357,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-6h",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/sabakan.yaml
+++ b/monitoring/base/grafana-operator/dashboards/sabakan.yaml
@@ -727,7 +727,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-6h",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/sabakan.yaml
+++ b/monitoring/base/grafana-operator/dashboards/sabakan.yaml
@@ -67,7 +67,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(sabakan_machine_status{status=\"healthy\", instance=\"10.69.0.3:10081\"})",
+              "expr": "max(sum(sabakan_machine_status{status=\"healthy\"}) by (instance))",
               "refId": "A"
             }
           ],
@@ -155,7 +155,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(sabakan_machine_status{status!=\"healthy\", instance=\"10.69.0.3:10081\"}) by (status)",
+              "expr": "max(sum(sabakan_machine_status{status!=\"healthy\"}) by (status,instance)) by (status)",
               "refId": "A"
             }
           ],
@@ -268,7 +268,7 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "100 * sum(max(sabakan_machine_status{status=\"healthy\"}) by (address, serial)) / sum(sabakan_machine_status{instance=\"10.69.0.3:10081\"})",
+              "expr": "100 * max(sum(max(sabakan_machine_status{status=\"healthy\"}) by (address, serial,instance)) by (instance) / sum(sabakan_machine_status) by (instance))",
               "refId": "A"
             }
           ],
@@ -423,7 +423,7 @@ spec:
           ],
           "targets": [
             {
-              "expr": "avg(sabakan_machine_status{instance=\"10.69.0.3:10081\", status=\"unhealthy\"})by(address, role, rack, serial) > 0",
+              "expr": "avg(sabakan_machine_status{status=\"unhealthy\"})by(address, role, rack, serial) > 0",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -489,7 +489,7 @@ spec:
           ],
           "targets": [
             {
-              "expr": "avg(sabakan_machine_status{instance=\"10.69.0.3:10081\", status=\"unreachable\"})by(address, role, rack, serial) > 0",
+              "expr": "avg(sabakan_machine_status{status=\"unreachable\"})by(address, role, rack, serial) > 0",
               "interval": "",
               "legendFormat": "",
               "refId": "A"

--- a/monitoring/base/grafana-operator/dashboards/topolvm-volumegroup.yaml
+++ b/monitoring/base/grafana-operator/dashboards/topolvm-volumegroup.yaml
@@ -317,7 +317,7 @@ spec:
             ]
         },
         "time": {
-            "from": "now-6h",
+            "from": "now-1h",
             "to": "now"
         },
         "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/victoriametrics-vmcluster.yaml
+++ b/monitoring/base/grafana-operator/dashboards/victoriametrics-vmcluster.yaml
@@ -5272,7 +5272,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {

--- a/monitoring/base/grafana-operator/dashboards/victoriametrics-vmsingle.yaml
+++ b/monitoring/base/grafana-operator/dashboards/victoriametrics-vmsingle.yaml
@@ -3284,7 +3284,6 @@ spec:
           "type": "row"
         }
       ],
-      "refresh": "30s",
       "schemaVersion": 26,
       "style": "dark",
       "tags": [],
@@ -3378,7 +3377,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-30m",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {


### PR DESCRIPTION
- do not specify concrete instance value to query
- show all namespaces using templating
- use same timerange across dashboards and don't refresh by default
  - note: "Node Exporter Full" dashboard is not modified because its definition is not included in neco-apps but is downloaded from grafana.com

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>