### PR TITLE
Update VictoriaMetrics operator to v0.10.0

### DIFF
--- a/monitoring/base/victoriametrics/kustomization.yaml
+++ b/monitoring/base/victoriametrics/kustomization.yaml
@@ -17,6 +17,8 @@ resources:
   - upstream/rbac/vmrule_viewer_role.yaml
   - upstream/rbac/vmservicescrape_editor_role.yaml
   - upstream/rbac/vmservicescrape_viewer_role.yaml
+  - upstream/rbac/vmstaticscrape_editor_role.yaml
+  - upstream/rbac/vmstaticscrape_viewer_role.yaml
   - rbac
   - operator.yaml
   - configmap-settype.yaml

--- a/monitoring/base/victoriametrics/operator.yaml
+++ b/monitoring/base/victoriametrics/operator.yaml
@@ -77,7 +77,7 @@ spec:
           value: "0.21.0.2"
         - name: VM_VMALERTMANAGER_CONFIGRELOADERIMAGE
           value: quay.io/cybozu/configmap-reload:0.5.0.1
-        image: quay.io/cybozu/victoriametrics-operator:0.9.0.1
+        image: quay.io/cybozu/victoriametrics-operator:0.10.0.1
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/monitoring/base/victoriametrics/rbac/editor_aggregation.yaml
+++ b/monitoring/base/victoriametrics/rbac/editor_aggregation.yaml
@@ -53,3 +53,11 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vmstaticscrape-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/monitoring/base/victoriametrics/rbac/viewer_aggregation.yaml
+++ b/monitoring/base/victoriametrics/rbac/viewer_aggregation.yaml
@@ -46,3 +46,10 @@ metadata:
   name: vmservicescrape-viewer-role
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vmstaticscrape-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/monitoring/base/victoriametrics/remove_crd_status.yaml
+++ b/monitoring/base/victoriametrics/remove_crd_status.yaml
@@ -57,3 +57,9 @@ kind: CustomResourceDefinition
 metadata:
   name: vmsingles.operator.victoriametrics.com
 status: null
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vmstaticscrapes.operator.victoriametrics.com
+status: null

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -463,6 +463,22 @@ spec:
                 - name
                 type: object
               type: array
+            insertPorts:
+              description: InsertPorts - additional listen ports for data ingestion.
+              properties:
+                graphitePort:
+                  description: GraphitePort listen port
+                  type: string
+                influxPort:
+                  description: InfluxPort listen port
+                  type: string
+                openTSDBHTTPPort:
+                  description: OpenTSDBHTTPPort for http connections.
+                  type: string
+                openTSDBPort:
+                  description: OpenTSDBPort for tcp and udp listen
+                  type: string
+              type: object
             logFormat:
               description: LogFormat for VMAgent to be configured with.
               enum:
@@ -525,9 +541,7 @@ spec:
               type: object
             nodeScrapeSelector:
               description: NodeScrapeSelector defines VMNodeScrape to be selected
-                for scraping. if neither PodScrapeNamespaceSelector nor ProbeSelector
-                nor PodScrapeSelector nor NodeScrapeSelector are specified, configuration
-                is unmanaged.
+                for scraping.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -608,7 +622,7 @@ spec:
               type: object
             podScrapeNamespaceSelector:
               description: PodScrapeNamespaceSelector defines Namespaces to be selected
-                for PodMonitor discovery. If nil, only check own namespace.
+                for VMPodScrape discovery. If nil, only check own namespace.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -652,9 +666,7 @@ spec:
               type: object
             podScrapeSelector:
               description: PodScrapeSelector defines PodScrapes to be selected for
-                target discovery. if neither PodScrapeNamespaceSelector nor ProbeSelector
-                nor PodScrapeSelector nor NodeScrapeSelector are specified, configuration
-                is unmanaged.
+                target discovery.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -752,9 +764,7 @@ spec:
               type: object
             probeSelector:
               description: ProbeSelector defines VMProbe to be selected for target
-                probing. if neither PodScrapeNamespaceSelector nor ProbeSelector nor
-                PodScrapeSelector nor NodeScrapeSelector are specified, configuration
-                is unmanaged.
+                probing.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1278,7 +1288,7 @@ spec:
               type: string
             serviceScrapeNamespaceSelector:
               description: ServiceScrapeNamespaceSelector Namespaces to be selected
-                for ServiceMonitor discovery. If nil, only check own namespace.
+                for VMServiceScrape discovery. If nil, only check own namespace.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1322,9 +1332,95 @@ spec:
               type: object
             serviceScrapeSelector:
               description: ServiceScrapeSelector defines ServiceScrapes to be selected
-                for target discovery. if if neither PodScrapeNamespaceSelector nor
-                ProbeSelector nor PodScrapeSelector nor NodeScrapeSelector are specified,
-                configuration is unmanaged.
+                for target discovery.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            staticScrapeNamespaceSelector:
+              description: StaticScrapeNamespaceSelector defines Namespaces to be
+                selected for VMStaticScrape discovery. If nil, only check own namespace.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            staticScrapeSelector:
+              description: StaticScrapeSelector defines PodScrapes to be selected
+                for target discovery.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -241,6 +241,12 @@ spec:
               description: EvaluationInterval how often evalute rules by default
               pattern: '[0-9]+(ms|s|m|h)'
               type: string
+            externalLabels:
+              additionalProperties:
+                type: string
+              description: 'ExternalLabels in the form ''name: value'' to add to all
+                generated recording rules and alerts.'
+              type: object
             extraArgs:
               additionalProperties:
                 type: string

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -54,6 +54,10 @@ spec:
         spec:
           description: VMClusterSpec defines the desired state of VMCluster
           properties:
+            clusterVersion:
+              description: ClusterVersion defines default images tag for all components.
+                it can be overwritten with component specific image.tag value.
+              type: string
             imagePullSecrets:
               description: ImagePullSecrets An optional list of references to secrets
                 in the same namespace to use for pulling images from registries see

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmstaticscrapes.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmstaticscrapes.yaml
@@ -1,0 +1,422 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: vmstaticscrapes.operator.victoriametrics.com
+spec:
+  group: operator.victoriametrics.com
+  names:
+    kind: VMStaticScrape
+    listKind: VMStaticScrapeList
+    plural: vmstaticscrapes
+    singular: vmstaticscrape
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VMStaticScrape is the Schema for the vmstaticscrapes API, which
+        defines static targets configuration for scraping.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VMStaticScrapeSpec defines the desired state of VMStaticScrape.
+          properties:
+            jobName:
+              description: JobName name of job.
+              type: string
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
+            targetEndpoints:
+              description: A list of target endpoints to scrape metrics from.
+              items:
+                description: TargetEndpoint defines single static target endpoint.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: The secret in the service scrape namespace that
+                          contains the password for authentication.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      username:
+                        description: The secret in the service scrape namespace that
+                          contains the username for authentication.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  bearerTokenFile:
+                    description: File to read bearer token for scraping targets.
+                    type: string
+                  bearerTokenSecret:
+                    description: Secret to mount to read bearer token for scraping
+                      targets. The secret needs to be in the same namespace as the
+                      service scrape and accessible by the victoria-metrics operator.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                  interval:
+                    description: Interval at which metrics should be scraped
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels static labels for targets.
+                    type: object
+                  metricRelabelConfigs:
+                    description: MetricRelabelConfigs to apply to samples before ingestion.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of configuration. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. Default is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        source_labels:
+                          description: UnderScoreSourceLabels - additional form of
+                            source labels source_labels for compatibility with original
+                            relabel config. if set  both sourceLabels and source_labels,
+                            sourceLabels has priority. for details https://github.com/VictoriaMetrics/operator/issues/131
+                          items:
+                            type: string
+                          type: array
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        target_label:
+                          description: UnderScoreTargetLabel - additional form of
+                            target label - target_label for compatibility with original
+                            relabel config. if set  both targetLabel and target_label,
+                            targetLabel has priority. for details https://github.com/VictoriaMetrics/operator/issues/131
+                          type: string
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  params:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: Optional HTTP URL parameters
+                    type: object
+                  path:
+                    description: HTTP path to scrape for metrics.
+                    type: string
+                  port:
+                    description: Default port for target.
+                    type: string
+                  proxyURL:
+                    description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                      to proxy through this endpoint.
+                    type: string
+                  relabelConfigs:
+                    description: 'RelabelConfigs to apply to samples before scraping.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of configuration. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. Default is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        source_labels:
+                          description: UnderScoreSourceLabels - additional form of
+                            source labels source_labels for compatibility with original
+                            relabel config. if set  both sourceLabels and source_labels,
+                            sourceLabels has priority. for details https://github.com/VictoriaMetrics/operator/issues/131
+                          items:
+                            type: string
+                          type: array
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        target_label:
+                          description: UnderScoreTargetLabel - additional form of
+                            target label - target_label for compatibility with original
+                            relabel config. if set  both targetLabel and target_label,
+                            targetLabel has priority. for details https://github.com/VictoriaMetrics/operator/issues/131
+                          type: string
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  scheme:
+                    description: HTTP scheme to use for scraping.
+                    type: string
+                  scrapeTimeout:
+                    description: Timeout after which the scrape is ended
+                    type: string
+                  targets:
+                    description: Targets static targets addresses in form of ["192.122.55.55:9100","some-name:9100"].
+                    items:
+                      type: string
+                    type: array
+                  tlsConfig:
+                    description: TLSConfig configuration to use when scraping the
+                      endpoint
+                    properties:
+                      ca:
+                        description: Stuct containing the CA cert to use for the targets.
+                        properties:
+                          configMap:
+                            description: ConfigMap containing data to use for the
+                              targets.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          secret:
+                            description: Secret containing data to use for the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      caFile:
+                        description: Path to the CA cert in the container to use for
+                          the targets.
+                        type: string
+                      cert:
+                        description: Struct containing the client cert file for the
+                          targets.
+                        properties:
+                          configMap:
+                            description: ConfigMap containing data to use for the
+                              targets.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          secret:
+                            description: Secret containing data to use for the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      certFile:
+                        description: Path to the client cert file in the container
+                          for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: Path to the client key file in the container
+                          for the targets.
+                        type: string
+                      keySecret:
+                        description: Secret containing the client key file for the
+                          targets.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                    type: object
+                required:
+                - targets
+                type: object
+              type: array
+          required:
+          - targetEndpoints
+          type: object
+        status:
+          description: VMStaticScrapeStatus defines the observed state of VMStaticScrape
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/monitoring/base/victoriametrics/upstream/crd/kustomization.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 
 - bases/operator.victoriametrics.com_vmprobes.yaml
 - bases/operator.victoriametrics.com_vmnodescrapes.yaml
+- bases/operator.victoriametrics.com_vmstaticscrapes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
@@ -27,6 +28,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_vmsingles.yaml
 #- patches/webhook_in_vmprobes.yaml
 #- patches/webhook_in_vmnodescrapes.yaml
+#- patches/webhook_in_vmstaticscrapes.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
@@ -40,6 +42,7 @@ patchesStrategicMerge:
 #- patches/cainjection_in_vmsingles.yaml
 #- patches/cainjection_in_vmprobes.yaml
 #- patches/cainjection_in_vmnodescrapes.yaml
+#- patches/cainjection_in_vmstaticscrapes.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/monitoring/base/victoriametrics/upstream/crd/patches/cainjection_in_vmstaticscrapes.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/patches/cainjection_in_vmstaticscrapes.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: vmstaticscrapes.operator.victoriametrics.com

--- a/monitoring/base/victoriametrics/upstream/crd/patches/webhook_in_vmstaticscrapes.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/patches/webhook_in_vmstaticscrapes.yaml
@@ -1,0 +1,17 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vmstaticscrapes.operator.victoriametrics.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+      caBundle: Cg==
+      service:
+        namespace: system
+        name: webhook-service
+        path: /convert

--- a/monitoring/base/victoriametrics/upstream/rbac/leader_election_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/leader_election_role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: leader-election-role
+  namespace: monitoring-system
 rules:
 - apiGroups:
   - ""

--- a/monitoring/base/victoriametrics/upstream/rbac/leader_election_role_binding.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/leader_election_role_binding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: leader-election-rolebinding
+  namespace: monitoring-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/monitoring/base/victoriametrics/upstream/rbac/role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
     - ""
   resources:
     - configmaps
+    - configmaps/finalizers
   verbs:
     - '*'
 - apiGroups:
@@ -35,6 +36,7 @@ rules:
     - ""
   resources:
     - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
   verbs:
     - '*'
 - apiGroups:
@@ -47,17 +49,13 @@ rules:
     - ""
   resources:
     - secrets
+    - secrets/finalizers
   verbs:
     - '*'
 - apiGroups:
     - ""
   resources:
     - services
-  verbs:
-    - '*'
-- apiGroups:
-    - ""
-  resources:
     - services/finalizers
   verbs:
     - '*'
@@ -65,6 +63,7 @@ rules:
     - apps
   resources:
     - deployments
+    - deployments/finalizers
   verbs:
     - '*'
 - apiGroups:
@@ -77,6 +76,7 @@ rules:
     - apps
   resources:
     - statefulsets
+    - statefulsets/finalizers
   verbs:
     - '*'
 - apiGroups:
@@ -304,7 +304,9 @@ rules:
     - "rbac.authorization.k8s.io"
   resources:
     - clusterrolebindings
+    - clusterrolebindings/finalizers
     - clusterroles
+    - clusterroles/finalizers
   verbs:
     - get
     - list
@@ -317,6 +319,7 @@ rules:
     - "policy"
   resources:
     - podsecuritypolicies
+    - podsecuritypolicies/finalizers
   verbs:
     - get
     - list
@@ -330,11 +333,15 @@ rules:
     - ""
   resources:
     - serviceaccounts
+    - serviceaccounts/finalizers
   verbs:
     - get
     - list
     - create
     - watch
+    - delete
+    - patch
+    - update
 - apiGroups:
   - operator.victoriametrics.com
   resources:
@@ -350,3 +357,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+    - operator.victoriametrics.com
+  resources:
+    - vmstaticscrapes
+    - vmnodescrapes/finalizers
+  verbs:
+    - '*'
+- apiGroups:
+    - operator.victoriametrics.com
+  resources:
+    - vmstaticscrapes/status
+  verbs:
+    - get
+    - patch
+    - update

--- a/monitoring/base/victoriametrics/upstream/rbac/vmagent_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmagent_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmalert_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmalert_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmalertmanager_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmalertmanager_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmnodescrape_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmnodescrape_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmprobe_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmprobe_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmrule_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmrule_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmservicescrape_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmservicescrape_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmsingle_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmsingle_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/monitoring/base/victoriametrics/upstream/rbac/vmstaticscrape_editor_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmstaticscrape_editor_role.yaml
@@ -1,13 +1,13 @@
-# permissions for end users to edit vmpodscrapes.
+# permissions for end users to edit vmstaticscrapes.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vmpodscrape-editor-role
+  name: vmstaticscrape-editor-role
 rules:
 - apiGroups:
   - operator.victoriametrics.com
   resources:
-  - vmpodscrapes
+  - vmstaticscrapes
   verbs:
   - create
   - delete
@@ -20,6 +20,6 @@ rules:
 - apiGroups:
   - operator.victoriametrics.com
   resources:
-  - vmpodscrapes/status
+  - vmstaticscrapes/status
   verbs:
   - get

--- a/monitoring/base/victoriametrics/upstream/rbac/vmstaticscrape_viewer_role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/vmstaticscrape_viewer_role.yaml
@@ -1,25 +1,20 @@
-# permissions for end users to edit vmpodscrapes.
+# permissions for end users to view vmstaticscrapes.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vmpodscrape-editor-role
+  name: vmstaticscrape-viewer-role
 rules:
 - apiGroups:
   - operator.victoriametrics.com
   resources:
-  - vmpodscrapes
+  - vmstaticscrapes
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
-  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:
-  - vmpodscrapes/status
+  - vmstaticscrapes/status
   verbs:
   - get

--- a/test/team-management_test.go
+++ b/test/team-management_test.go
@@ -33,6 +33,7 @@ var requiredResources = []string{
 	"vmprobes.operator.victoriametrics.com",
 	"vmrules.operator.victoriametrics.com",
 	"vmservicescrapes.operator.victoriametrics.com",
+	"vmstaticscrapes.operator.victoriametrics.com",
 }
 
 // prohibitedResources is a list of namespace resources that are not allowed to be created by unprivileged teams.


### PR DESCRIPTION
Update VictoriaMetrics operator to v0.10.0.

From v0.10.0, `VMStaticScrape` CR is introduced. In this PR, add the permission to tenant teams.
https://github.com/VictoriaMetrics/operator/blob/v0.10.0/docs/quick-start.MD#VMStaticScrape

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>