### PR TITLE
Add app-garoon-monitoring namespace.

### DIFF
--- a/team-management/base/cydec/app-gorush.yaml
+++ b/team-management/base/cydec/app-gorush.yaml
@@ -19,3 +19,6 @@ subjects:
   - kind: Group
     name: maneki
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: node-maneki
+    namespace: teleport

--- a/team-management/base/ept/app-ept-monitoring.yaml
+++ b/team-management/base/ept/app-ept-monitoring.yaml
@@ -19,3 +19,6 @@ subjects:
   - kind: Group
     name: maneki
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: node-maneki
+    namespace: teleport

--- a/team-management/base/ept/app-ept-wiki.yaml
+++ b/team-management/base/ept/app-ept-wiki.yaml
@@ -19,3 +19,6 @@ subjects:
   - kind: Group
     name: maneki
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: node-maneki
+    namespace: teleport

--- a/team-management/base/garoon/app-garoon-monitoring.yaml
+++ b/team-management/base/garoon/app-garoon-monitoring.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-garoon-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: garoon-role-binding
+  namespace: app-garoon-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: Group
+    name: garoon
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: maneki
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: node-maneki
+    namespace: teleport

--- a/team-management/base/garoon/app-garoon-static.yaml
+++ b/team-management/base/garoon/app-garoon-static.yaml
@@ -19,3 +19,6 @@ subjects:
   - kind: Group
     name: maneki
     apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: node-maneki
+    namespace: teleport

--- a/team-management/base/garoon/kustomization.yaml
+++ b/team-management/base/garoon/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - app-garoon-monitoring.yaml
   - app-garoon-static.yaml
   - project.yaml
 commonLabels:

--- a/team-management/base/garoon/project.yaml
+++ b/team-management/base/garoon/project.yaml
@@ -7,6 +7,8 @@ spec:
   sourceRepos:
   - '*'
   destinations:
+  - namespace: app-garoon-monitoring
+    server: '*'
   - namespace: app-garoon-static
     server: '*'
   - namespace: sandbox

--- a/team-management/base/maneki/project.yaml
+++ b/team-management/base/maneki/project.yaml
@@ -20,6 +20,8 @@ spec:
   # namespaces for garoon team
   - namespace: app-garoon-static
     server: '*'
+  - namespace: app-garoon-monitoring
+    server: '*'
 
   # namespaces for maneki team
   - namespace: app-comconv-earthlab


### PR DESCRIPTION
This PR includes:
- Add `app-garoon-monitoring` namespace and bind admin roles to `garoon` and `maneki` team
- Fix: add admin role binding of tenant teams's namespace to `node-maneki` ServiceAccount

Signed-off-by: Kazuhito MATSUDA <kazuhito.matuda@gmail.com>