### PR TITLE
Remove Placemat v1 compatible codes

### DIFF
--- a/test/env.go
+++ b/test/env.go
@@ -6,17 +6,17 @@ import (
 )
 
 var (
-	overlayName          = os.Getenv("OVERLAY")
-	doUpgrade            = os.Getenv("UPGRADE") == "1"
-	doReboot             = os.Getenv("REBOOT") == "1"
-	boot0                = os.Getenv("BOOT0")
-	boot1                = os.Getenv("BOOT1")
-	boot2                = os.Getenv("BOOT2")
-	sshKeyFile           = os.Getenv("SSH_PRIVKEY")
-	testID               = os.Getenv("TEST_ID")
-	commitID             = os.Getenv("COMMIT_ID")
-	numGrafanaDashboard  = 0
-	testSuite            = os.Getenv("SUITE")
+	overlayName         = os.Getenv("OVERLAY")
+	doUpgrade           = os.Getenv("UPGRADE") == "1"
+	doReboot            = os.Getenv("REBOOT") == "1"
+	boot0               = os.Getenv("BOOT0")
+	boot1               = os.Getenv("BOOT1")
+	boot2               = os.Getenv("BOOT2")
+	sshKeyFile          = os.Getenv("SSH_PRIVKEY")
+	testID              = os.Getenv("TEST_ID")
+	commitID            = os.Getenv("COMMIT_ID")
+	numGrafanaDashboard = 0
+	testSuite           = os.Getenv("SUITE")
 )
 
 func init() {

--- a/test/env.go
+++ b/test/env.go
@@ -15,11 +15,8 @@ var (
 	sshKeyFile           = os.Getenv("SSH_PRIVKEY")
 	testID               = os.Getenv("TEST_ID")
 	commitID             = os.Getenv("COMMIT_ID")
-	externalPID          = os.Getenv("EXTERNAL_PID")
-	operationPID         = os.Getenv("OPERATION_PID")
 	numGrafanaDashboard  = 0
 	testSuite            = os.Getenv("SUITE")
-	placematMajorVersion = os.Getenv("PLACEMAT_MAJOR_VERSION")
 )
 
 func init() {

--- a/test/metallb_test.go
+++ b/test/metallb_test.go
@@ -117,11 +117,7 @@ func testMetalLB() {
 
 		By("access service from external")
 		Eventually(func() error {
-			if placematMajorVersion == "1" {
-				return exec.Command("nsenter", "-n", "-t", externalPID, "curl", targetIP, "-m", "5").Run()
-			} else {
-				return exec.Command("ip", "netns", "exec", "external", "curl", targetIP, "-m", "5").Run()
-			}
+			return exec.Command("ip", "netns", "exec", "external", "curl", targetIP, "-m", "5").Run()
 		}).Should(Succeed())
 	})
 }

--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -165,11 +165,7 @@ func testPushgateway() {
 			return nil
 		}).Should(Succeed())
 		Eventually(func() error {
-			if placematMajorVersion == "1" {
-				return exec.Command("nsenter", "-n", "-t", externalPID, "curl", "--resolve", forestPushgatewayFQDN+":80:"+forestIP, forestPushgatewayFQDN+"/-/healthy", "-m", "5").Run()
-			} else {
-				return exec.Command("ip", "netns", "exec", "external", "curl", "--resolve", forestPushgatewayFQDN+":80:"+forestIP, forestPushgatewayFQDN+"/-/healthy", "-m", "5").Run()
-			}
+			return exec.Command("ip", "netns", "exec", "external", "curl", "--resolve", forestPushgatewayFQDN+":80:"+forestIP, forestPushgatewayFQDN+"/-/healthy", "-m", "5").Run()
 		}).Should(Succeed())
 	})
 }

--- a/test/teleport_test.go
+++ b/test/teleport_test.go
@@ -63,6 +63,10 @@ func teleportSSHConnectionTest() {
 		"--output=jsonpath={.status.loadBalancer.ingress[0].ip}")
 	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 	addr := string(stdout)
+	// Save a backup before editing /etc/hosts
+	b, err := ioutil.ReadFile("/etc/hosts")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ioutil.WriteFile("./hosts", b, 0644)).NotTo(HaveOccurred())
 	f, err := os.OpenFile("/etc/hosts", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	Expect(err).ShouldNot(HaveOccurred())
 	_, err = f.Write([]byte(addr + " teleport.gcp0.dev-ne.co\n"))
@@ -186,8 +190,11 @@ func teleportSSHConnectionTest() {
 	}
 
 	By("clearing /etc/hosts")
-	output, err = exec.Command("sed", "-i", "-e", "/teleport.gcp0.dev-ne.co/d", "/etc/hosts").CombinedOutput()
-	Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
+	// /etc/hosts cannot be modified via sed directly inside a container because that is a mount point
+	b, err = ioutil.ReadFile("./hosts")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ioutil.WriteFile("/etc/hosts", b, 0644)).NotTo(HaveOccurred())
+	Expect(os.Remove("./hosts")).NotTo(HaveOccurred())
 }
 
 func teleportAuthTest() {

--- a/test/teleport_test.go
+++ b/test/teleport_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -57,25 +58,20 @@ func teleportNodeServiceTest() {
 }
 
 func teleportSSHConnectionTest() {
-	// Run on boot1 because this test changes kubectl config and it causes failures of other tests running in parallel when those execute kubectl on boot0
-	By("prepare .kube/config on boot1")
-	_, stderr, err := ExecAt(boot1, "mkdir", "-p", "~/.kube")
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-	_, stderr, err = ExecAt(boot1, "ckecli", "kubernetes", "issue", ">", "~/.kube/config")
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-
 	By("adding proxy addr entry to /etc/hosts")
-	stdout, stderr, err := ExecAt(boot1, "kubectl", "-n", "teleport", "get", "service", "teleport-proxy",
+	stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "get", "service", "teleport-proxy",
 		"--output=jsonpath={.status.loadBalancer.ingress[0].ip}")
 	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 	addr := string(stdout)
-	entry := fmt.Sprintf("%s teleport.gcp0.dev-ne.co", addr)
-	_, stderr, err = ExecAt(boot1, "sudo", "sh", "-c", fmt.Sprintf(`'echo "%s" >> /etc/hosts'`, entry))
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
+	f, err := os.OpenFile("/etc/hosts", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	Expect(err).ShouldNot(HaveOccurred())
+	_, err = f.Write([]byte(addr + " teleport.gcp0.dev-ne.co\n"))
+	Expect(err).ShouldNot(HaveOccurred())
+	f.Close()
 
 	By("creating user")
-	ExecAt(boot1, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "users", "rm", "cybozu")
-	stdout, stderr, err = ExecAt(boot1, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "users", "add", "cybozu", "cybozu,root")
+	ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "users", "rm", "cybozu")
+	stdout, stderr, err = ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "users", "add", "cybozu", "cybozu,root")
 	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 	tctlOutput := string(stdout)
 	fmt.Println("output:")
@@ -106,11 +102,12 @@ func teleportSSHConnectionTest() {
 
 	By("accessing invite URL")
 	filename := "teleport_cookie.txt"
-	_, stderr, err = ExecAt(boot1, "curl", "--fail", "--insecure", "-c", filename, inviteURL)
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-	stdout, stderr, err = ExecAt(boot1, "cat", filename)
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-	cookieFileContents := string(stdout)
+	cmd := exec.Command("curl", "--fail", "--insecure", "-c", filename, inviteURL)
+	output, err := cmd.CombinedOutput()
+	Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
+	buf, err := ioutil.ReadFile(filename)
+	Expect(err).ShouldNot(HaveOccurred(), "cookie=%s", buf)
+	cookieFileContents := string(buf)
 	fmt.Println("cookie file:")
 	fmt.Println(cookieFileContents)
 
@@ -131,29 +128,22 @@ func teleportSSHConnectionTest() {
 	fmt.Printf("CSRF token: %s\n", csrfToken)
 
 	By("updating password")
-	_, stderr, err = ExecAt(boot1,
+	cmd = exec.Command(
 		"curl",
 		"--fail", "--insecure",
 		"-X", "PUT",
 		"-b", filename,
-		"-H", fmt.Sprintf(`'X-CSRF-Token: %s'`, csrfToken),
-		"-H", `'Content-Type: application/json; charset=UTF-8'`,
-		"-d", fmt.Sprintf(`'%s'`, string(payload)),
+		"-H", "X-CSRF-Token: "+csrfToken,
+		"-H", "Content-Type: application/json; charset=UTF-8",
+		"-d", string(payload),
 		"https://teleport.gcp0.dev-ne.co/v1/webapi/users/password/token",
 	)
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
+	output, err = cmd.CombinedOutput()
+	Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
 
 	By("logging in using tsh command")
 	Eventually(func() error {
-		// Use ssh command and run tsh to input password using pty
-		var cmd *exec.Cmd
-		if placematMajorVersion == "1" {
-			cmd = exec.Command("nsenter", "-n", "-t", operationPID, "ssh", "-oStrictHostKeyChecking=no", "-i", sshKeyFile,
-				fmt.Sprintf("cybozu@%s", boot1), "-t", "tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu login")
-		} else {
-			cmd = exec.Command("ip", "netns", "exec", "operation", "ssh", "-oStrictHostKeyChecking=no", "-i", sshKeyFile,
-				fmt.Sprintf("cybozu@%s", boot1), "-t", "tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu login")
-		}
+		cmd = exec.Command("tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "login")
 		ptmx, err := pty.Start(cmd)
 		if err != nil {
 			return fmt.Errorf("pts.Start failed: %w", err)
@@ -168,15 +158,16 @@ func teleportSSHConnectionTest() {
 	}).Should(Succeed())
 
 	By("getting node resources with kubectl via teleport proxy")
-	_, stderr, err = ExecAt(boot1, "kubectl", "get", "nodes")
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
+	output, err = exec.Command("kubectl", "get", "nodes").CombinedOutput()
+	Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
 
 	By("accessing boot servers using tsh command")
 	for _, n := range []string{"boot-0", "boot-1", "boot-2"} {
 		Eventually(func() error {
-			_, stderr, err := ExecAt(boot1, "tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "ssh", "cybozu@gcp0-"+n, "date")
+			cmd := exec.Command("tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "ssh", "cybozu@gcp0-"+n, "date")
+			output, err := cmd.CombinedOutput()
 			if err != nil {
-				return fmt.Errorf("tsh ssh failed for %s: %s", n, string(stderr))
+				return fmt.Errorf("tsh ssh failed for %s: %s", n, string(output))
 			}
 			return nil
 		}).Should(Succeed())
@@ -185,29 +176,18 @@ func teleportSSHConnectionTest() {
 	By("confirming kubectl works in node Pod using tsh command")
 	for _, n := range []string{"node-maneki-0"} {
 		Eventually(func() error {
-			stdout, stderr, err := ExecAt(boot1, "tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "ssh", "cybozu@"+n, ". /etc/profile.d/update-necocli.sh && kubectl -v5 -n maneki get pod")
+			cmd := exec.Command("tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "ssh", "cybozu@"+n, ". /etc/profile.d/update-necocli.sh && kubectl -v5 -n maneki get pod")
+			output, err := cmd.CombinedOutput()
 			if err != nil {
-				return fmt.Errorf("tsh ssh failed for %s: stdout=%s, stderr=%s", n, string(stdout), string(stderr))
+				return fmt.Errorf("tsh ssh failed for %s: %s", n, string(output))
 			}
 			return nil
 		}).Should(Succeed())
 	}
 
-	By("logout tsh")
-	_, stderr, err = ExecAt(boot1, "tsh", "--insecure", "--proxy=teleport.gcp0.dev-ne.co:443", "--user=cybozu", "logout")
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-
-	By("clearing kubectl config")
-	_, stderr, err = ExecAt(boot1, "ckecli", "kubernetes", "issue", ">", "~/.kube/config")
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-
-	By("clearing teleport_cookie.txt")
-	_, stderr, err = ExecAt(boot1, "rm", filename)
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
-
 	By("clearing /etc/hosts")
-	_, stderr, err = ExecAt(boot1, "sudo", "sed", "-i", "-e", "/teleport.gcp0.dev-ne.co/d", "/etc/hosts")
-	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
+	output, err = exec.Command("sed", "-i", "-e", "/teleport.gcp0.dev-ne.co/d", "/etc/hosts").CombinedOutput()
+	Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
 }
 
 func teleportAuthTest() {

--- a/test/teleport_test.go
+++ b/test/teleport_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -64,9 +63,9 @@ func teleportSSHConnectionTest() {
 	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 	addr := string(stdout)
 	// Save a backup before editing /etc/hosts
-	b, err := ioutil.ReadFile("/etc/hosts")
+	b, err := os.ReadFile("/etc/hosts")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile("./hosts", b, 0644)).NotTo(HaveOccurred())
+	Expect(os.WriteFile("./hosts", b, 0644)).NotTo(HaveOccurred())
 	f, err := os.OpenFile("/etc/hosts", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	Expect(err).ShouldNot(HaveOccurred())
 	_, err = f.Write([]byte(addr + " teleport.gcp0.dev-ne.co\n"))
@@ -109,7 +108,7 @@ func teleportSSHConnectionTest() {
 	cmd := exec.Command("curl", "--fail", "--insecure", "-c", filename, inviteURL)
 	output, err := cmd.CombinedOutput()
 	Expect(err).ShouldNot(HaveOccurred(), "output=%s", output)
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	Expect(err).ShouldNot(HaveOccurred(), "cookie=%s", buf)
 	cookieFileContents := string(buf)
 	fmt.Println("cookie file:")
@@ -191,9 +190,9 @@ func teleportSSHConnectionTest() {
 
 	By("clearing /etc/hosts")
 	// /etc/hosts cannot be modified via sed directly inside a container because that is a mount point
-	b, err = ioutil.ReadFile("./hosts")
+	b, err = os.ReadFile("./hosts")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile("/etc/hosts", b, 0644)).NotTo(HaveOccurred())
+	Expect(os.WriteFile("/etc/hosts", b, 0644)).NotTo(HaveOccurred())
 	Expect(os.Remove("./hosts")).NotTo(HaveOccurred())
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,20 +5,7 @@ if [ "$SUDO" = "" ]; then
     SUDO_OPTION=""
 fi
 
-PLACEMAT_MAJOR_VERSION="1"
-PLACEMAT_PID="$(pgrep --exact placemat2)"
-if [ "$PLACEMAT_PID" != "" ]; then
-    PLACEMAT_MAJOR_VERSION="2"
-fi
-export PLACEMAT_MAJOR_VERSION
-
-go mod download
-if [ "$PLACEMAT_MAJOR_VERSION" = "1" ]; then
-    EXTERNAL_PID=$(pmctl pod show external | jq .pid)
-    OPERATION_PID=$(pmctl pod show operation | jq .pid)
-    export EXTERNAL_PID OPERATION_PID
-
-    $SUDO $SUDO_OPTION nsenter -t $(pmctl pod show operation | jq .pid) -n env PATH=$PATH SUITE=$SUITE $GINKGO
-else
-    $SUDO $SUDO_OPTION ip netns exec operation env PATH=$PATH SUITE=$SUITE $GINKGO
-fi
+go build ./...
+go test -c .
+rm test.test
+$SUDO $SUDO_OPTION ip netns exec operation env PATH=$PATH SUITE=$SUITE $GINKGO


### PR DESCRIPTION
This PR removes placemat v1 compatible codes. Also, reverts Teleport test to run on the test host. 
The original teleport test modifies `/etc/hosts` using sed and it leads to the error when the test runs inside a k8s container. So this PR fixes it to stop using sed as well.