### PR TITLE
add app-forest-archive namespace and allow maneki to manage it.

### DIFF
--- a/team-management/base/maneki/app-forest-archive.yaml
+++ b/team-management/base/maneki/app-forest-archive.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-forest-archive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: maneki-role-binding
+  namespace: app-forest-archive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: Group
+    name: maneki
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: node-maneki
+    namespace: teleport

--- a/team-management/base/maneki/kustomization.yaml
+++ b/team-management/base/maneki/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - app-comconv-earthlab.yaml
   - app-elasticsearch.yaml
+  - app-forest-archive.yaml
   - app-forest-certs.yaml
   - app-kodama.yaml
   - app-maneki-static-cybozu-com.yaml

--- a/team-management/base/maneki/project.yaml
+++ b/team-management/base/maneki/project.yaml
@@ -30,6 +30,8 @@ spec:
     server: '*'
   - namespace: app-elasticsearch
     server: '*'
+  - namespace: app-forest-archive
+    server: '*'
   - namespace: app-forest-certs
     server: '*'
   - namespace: app-kodama


### PR DESCRIPTION
- add app-forest-archive to deploy ObjectBucketClaim to store old logs.
- allow maneki team to manage it.