### PR TITLE
Increase maxScrapeSize

### DIFF
--- a/monitoring/base/victoriametrics/vmagent-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmagent-largeset.yaml
@@ -4,6 +4,8 @@ metadata:
   name: vmagent-largeset
   namespace: monitoring
 spec:
+  extraArgs:
+    promscrape.maxScrapeSize: "33554432"
   serviceScrapeSelector:
     matchExpressions:
       - key: managed-by

--- a/monitoring/base/victoriametrics/vmagent-smallset.yaml
+++ b/monitoring/base/victoriametrics/vmagent-smallset.yaml
@@ -4,6 +4,8 @@ metadata:
   name: vmagent-smallset
   namespace: monitoring
 spec:
+  extraArgs:
+    promscrape.maxScrapeSize: "33554432"
   serviceScrapeSelector:
     matchLabels:
       smallset: "true"


### PR DESCRIPTION
As we faced the scraping error caused by the response size of the scraping metrics, this PR increased the maxScrapeSize parameter of VictoriaMetrics Agent.