### PR TITLE
monitoring: update VictoriaMetrics operator to 0.12.2

### DIFF
--- a/monitoring/base/victoriametrics/operator.yaml
+++ b/monitoring/base/victoriametrics/operator.yaml
@@ -77,7 +77,7 @@ spec:
           value: "0.21.0.2"
         - name: VM_VMALERTMANAGER_CONFIGRELOADERIMAGE
           value: quay.io/cybozu/configmap-reload:0.5.0.1
-        image: quay.io/cybozu/victoriametrics-operator:0.10.0.1
+        image: quay.io/cybozu/victoriametrics-operator:0.12.2.1
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/monitoring/base/victoriametrics/rules/monitoring-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/monitoring-scrape.yaml
@@ -37,7 +37,7 @@ spec:
       app.kubernetes.io/name: vmalertmanager
       managed-by: vm-operator
   endpoints:
-  - port: web
+  - port: http
     relabelConfigs:
       - replacement: vmalertmanager-smallset
         targetLabel: job
@@ -125,7 +125,7 @@ spec:
       app.kubernetes.io/name: vmalertmanager
       managed-by: vm-operator
   endpoints:
-  - port: web
+  - port: http
     relabelConfigs:
       - replacement: vmalertmanager-largeset
         targetLabel: job

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -592,6 +592,29 @@ spec:
               description: OverrideHonorTimestamps allows to globally enforce honoring
                 timestamps in all scrape configs.
               type: boolean
+            podDisruptionBudget:
+              description: PodDisruptionBudget created by operator
+              properties:
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: An eviction is allowed if at most "maxUnavailable"
+                    pods selected by "selector" are unavailable after the eviction,
+                    i.e. even in absence of the evicted pod. For example, one can
+                    prevent all voluntary evictions by specifying 0. This is a mutually
+                    exclusive setting with "minAvailable".
+                  x-kubernetes-int-or-string: true
+                minAvailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: An eviction is allowed if at least "minAvailable" pods
+                    selected by "selector" will still be available after the eviction,
+                    i.e. even in the absence of the evicted pod.  So for example you
+                    can prevent all voluntary evictions by specifying "100%".
+                  x-kubernetes-int-or-string: true
+              type: object
             podMetadata:
               description: PodMetadata configures Labels and Annotations which are
                 propagated to the vmagent pods.
@@ -1121,6 +1144,41 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            rollingUpdate:
+              description: RollingUpdate - overrides deployment update params.
+              properties:
+                maxSurge:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'The maximum number of pods that can be scheduled above
+                    the desired number of pods. Value can be an absolute number (ex:
+                    5) or a percentage of desired pods (ex: 10%). This can not be
+                    0 if MaxUnavailable is 0. Absolute number is calculated from percentage
+                    by rounding up. Defaults to 25%. Example: when this is set to
+                    30%, the new ReplicaSet can be scaled up immediately when the
+                    rolling update starts, such that the total number of old and new
+                    pods do not exceed 130% of desired pods. Once old pods have been
+                    killed, new ReplicaSet can be scaled up further, ensuring that
+                    total number of pods running at any time during the update is
+                    at most 130% of desired pods.'
+                  x-kubernetes-int-or-string: true
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'The maximum number of pods that can be unavailable
+                    during the update. Value can be an absolute number (ex: 5) or
+                    a percentage of desired pods (ex: 10%). Absolute number is calculated
+                    from percentage by rounding down. This can not be 0 if MaxSurge
+                    is 0. Defaults to 25%. Example: when this is set to 30%, the old
+                    ReplicaSet can be scaled down to 70% of desired pods immediately
+                    when the rolling update starts. Once new pods are ready, old ReplicaSet
+                    can be scaled down further, followed by scaling up the new ReplicaSet,
+                    ensuring that the total number of pods available at all times
+                    during the update is at least 70% of desired pods.'
+                  x-kubernetes-int-or-string: true
+              type: object
             runtimeClassName:
               description: RuntimeClassName - defines runtime class for kubernetes
                 pod. https://kubernetes.io/docs/concepts/containers/runtime-class/
@@ -1374,6 +1432,288 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            serviceSpec:
+              description: ServiceSpec that will be added to vmagent service spec
+              properties:
+                metadata:
+                  description: EmbeddedObjectMetadata defines objectMeta for additional
+                    service.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations is an unstructured key value map stored
+                        with a resource that may be set by external tools to store
+                        and retrieve arbitrary metadata. They are not queryable and
+                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: 'Labels Map of string keys and values that can
+                        be used to organize and categorize (scope and select) objects.
+                        May match selectors of replication controllers and services.
+                        More info: http://kubernetes.io/docs/user-guide/labels'
+                      type: object
+                    name:
+                      description: 'Name must be unique within a namespace. Is required
+                        when creating resources, although some resources may allow
+                        a client to request the generation of an appropriate name
+                        automatically. Name is primarily intended for creation idempotence
+                        and configuration definition. Cannot be updated. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  type: object
+                spec:
+                  description: 'ServiceSpec describes the attributes that a user creates
+                    on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                  properties:
+                    allocateLoadBalancerNodePorts:
+                      description: allocateLoadBalancerNodePorts defines if NodePorts
+                        will be automatically allocated for services with type LoadBalancer.  Default
+                        is "true". It may be set to "false" if the cluster load-balancer
+                        does not rely on NodePorts. allocateLoadBalancerNodePorts
+                        may only be set for services with type LoadBalancer and will
+                        be cleared if the type is changed to any other type. This
+                        field is alpha-level and is only honored by servers that enable
+                        the ServiceLBNodePortControl feature.
+                      type: boolean
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly. If an address is specified manually,
+                        is in-range (as per system configuration), and is not in use,
+                        it will be allocated to the service; otherwise creation of
+                        the service will fail. This field may not be changed through
+                        updates unless the type field is also being changed to ExternalName
+                        (which requires this field to be blank) or the type field
+                        is being changed from ExternalName (in which case this field
+                        may optionally be specified, as describe above).  Valid values
+                        are "None", empty string (""), or a valid IP address. Setting
+                        this to "None" makes a "headless service" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    clusterIPs:
+                      description: "ClusterIPs is a list of IP addresses assigned
+                        to this service, and are usually assigned randomly.  If an
+                        address is specified manually, is in-range (as per system
+                        configuration), and is not in use, it will be allocated to
+                        the service; otherwise creation of the service will fail.
+                        This field may not be changed through updates unless the type
+                        field is also being changed to ExternalName (which requires
+                        this field to be empty) or the type field is being changed
+                        from ExternalName (in which case this field may optionally
+                        be specified, as describe above).  Valid values are \"None\",
+                        empty string (\"\"), or a valid IP address.  Setting this
+                        to \"None\" makes a \"headless service\" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        \ If this field is not specified, it will be initialized from
+                        the clusterIP field.  If this field is specified, clients
+                        must ensure that clusterIPs[0] and clusterIP have the same
+                        value. \n Unless the \"IPv6DualStack\" feature gate is enabled,
+                        this field is limited to one value, which must be the same
+                        as the clusterIP field.  If the feature gate is enabled, this
+                        field may hold a maximum of two entries (dual-stack IPs, in
+                        either order).  These IPs must correspond to the values of
+                        the ipFamilies field. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that discovery
+                        mechanisms will return as an alias for this service (e.g.
+                        a DNS CNAME record). No proxying will be involved.  Must be
+                        a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        and requires Type to be
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. This only applies when type is set to LoadBalancer
+                        and externalTrafficPolicy is set to Local. If a value is specified,
+                        is in-range, and is not in use, it will be used.  If not specified,
+                        a value will be automatically allocated.  External systems
+                        (e.g. load-balancers) can use this port to determine if a
+                        given node holds endpoints for this service or not.  If this
+                        field is specified when creating a Service which does not
+                        need it, creation will fail. This field will be wiped when
+                        updating a Service to no longer need it (e.g. changing type).
+                      format: int32
+                      type: integer
+                    ipFamilies:
+                      description: "IPFamilies is a list of IP families (e.g. IPv4,
+                        IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                        feature gate.  This field is usually assigned automatically
+                        based on cluster configuration and the ipFamilyPolicy field.
+                        If this field is specified manually, the requested family
+                        is available in the cluster, and ipFamilyPolicy allows it,
+                        it will be used; otherwise creation of the service will fail.
+                        \ This field is conditionally mutable: it allows for adding
+                        or removing a secondary IP family, but it does not allow changing
+                        the primary IP family of the Service.  Valid values are \"IPv4\"
+                        and \"IPv6\".  This field only applies to Services of types
+                        ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\"
+                        services.  This field will be wiped when updating a Service
+                        to type ExternalName. \n This field may hold a maximum of
+                        two entries (dual-stack families, in either order).  These
+                        families must correspond to the values of the clusterIPs field,
+                        if specified. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field."
+                      items:
+                        description: IPFamily represents the IP Family (IPv4 or IPv6).
+                          This type is used to express the family of an IP expressed
+                          by a type (e.g. service.spec.ipFamilies).
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ipFamilyPolicy:
+                      description: IPFamilyPolicy represents the dual-stack-ness requested
+                        or required by this Service, and is gated by the "IPv6DualStack"
+                        feature gate.  If there is no value provided, then this field
+                        will be set to SingleStack. Services can be "SingleStack"
+                        (a single IP family), "PreferDualStack" (two IP families on
+                        dual-stack configured clusters or a single IP family on single-stack
+                        clusters), or "RequireDualStack" (two IP families on dual-stack
+                        configured clusters, otherwise fail). The ipFamilies and clusterIPs
+                        fields depend on the value of this field.  This field will
+                        be wiped when updating a service to type ExternalName.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses indicates that any agent
+                        which deals with endpoints for this Service should disregard
+                        any indications of ready/not-ready. The primary use case for
+                        setting this field is for a StatefulSet's Headless Service
+                        to propagate SRV DNS records for its Pods for the purpose
+                        of peer discovery. The Kubernetes controllers that generate
+                        Endpoints and EndpointSlice resources for Services interpret
+                        this to mean that all endpoints are considered "ready" even
+                        if the Pods themselves are not. Agents which consume only
+                        Kubernetes generated endpoints through the Endpoints or EndpointSlice
+                        resources can safely assume this behavior.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    topologyKeys:
+                      description: topologyKeys is a preference-order list of topology
+                        keys which implementations of services should use to preferentially
+                        sort endpoints when accessing this Service, it can not be
+                        used at the same time as externalTrafficPolicy=Local. Topology
+                        keys must be valid label keys and at most 16 keys may be specified.
+                        Endpoints are chosen based on the first topology key with
+                        available backends. If this field is specified and all entries
+                        have no backends that match the topology of the client, the
+                        service has no backends for that client and connections should
+                        fail. The special value "*" may be used to mean "any topology".
+                        This catch-all value, if used, only makes sense as the last
+                        value in the list. If this is not specified or empty, no topology
+                        constraints will be applied. This field is alpha-level and
+                        is only honored by servers that enable the ServiceTopology
+                        feature.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                        IP address for load-balancing to endpoints. Endpoints are
+                        determined by the selector or if that is not specified, by
+                        manual construction of an Endpoints object or EndpointSlice
+                        objects. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the same endpoints as
+                        the clusterIP. "LoadBalancer" builds on NodePort and creates
+                        an external load-balancer (if supported in the current cloud)
+                        which routes to the same endpoints as the clusterIP. "ExternalName"
+                        aliases this service to the specified externalName. Several
+                        other fields do not apply to ExternalName services. More info:
+                        https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+              required:
+              - spec
+              type: object
+            shardCount:
+              description: ShardCount - numbers of shards of VMAgent in this case
+                operator will use 1 deployment/sts per shard with replicas count according
+                to spec.replicas https://victoriametrics.github.io/vmagent.html#scraping-big-number-of-targets
+              type: integer
             staticScrapeNamespaceSelector:
               description: StaticScrapeNamespaceSelector defines Namespaces to be
                 selected for VMStaticScrape discovery. If nil, only check own namespace.
@@ -1516,6 +1856,13 @@ spec:
                 - whenUnsatisfiable
                 type: object
               type: array
+            updateStrategy:
+              description: UpdateStrategy - overrides default update strategy. works
+                only for deployments, statefulset always use OnDelete.
+              enum:
+              - Recreate
+              - RollingUpdate
+              type: string
             vmAgentExternalLabelName:
               description: VMAgentExternalLabelName Name of vmAgent external label
                 used to denote vmAgent instance name. Defaults to the value of `prometheus`.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -169,6 +169,29 @@ spec:
               description: Paused If set to true all actions on the underlaying managed
                 objects are not goint to be performed, except for delete actions.
               type: boolean
+            podDisruptionBudget:
+              description: PodDisruptionBudget created by operator
+              properties:
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: An eviction is allowed if at most "maxUnavailable"
+                    pods selected by "selector" are unavailable after the eviction,
+                    i.e. even in absence of the evicted pod. For example, one can
+                    prevent all voluntary evictions by specifying 0. This is a mutually
+                    exclusive setting with "minAvailable".
+                  x-kubernetes-int-or-string: true
+                minAvailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: An eviction is allowed if at least "minAvailable" pods
+                    selected by "selector" will still be available after the eviction,
+                    i.e. even in the absence of the evicted pod.  So for example you
+                    can prevent all voluntary evictions by specifying "100%".
+                  x-kubernetes-int-or-string: true
+              type: object
             podMetadata:
               description: PodMetadata configures Labels and Annotations which are
                 propagated to the alertmanager pods.
@@ -415,6 +438,284 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use
               type: string
+            serviceSpec:
+              description: ServiceSpec that will be added to vmalertmanager service
+                spec
+              properties:
+                metadata:
+                  description: EmbeddedObjectMetadata defines objectMeta for additional
+                    service.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations is an unstructured key value map stored
+                        with a resource that may be set by external tools to store
+                        and retrieve arbitrary metadata. They are not queryable and
+                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: 'Labels Map of string keys and values that can
+                        be used to organize and categorize (scope and select) objects.
+                        May match selectors of replication controllers and services.
+                        More info: http://kubernetes.io/docs/user-guide/labels'
+                      type: object
+                    name:
+                      description: 'Name must be unique within a namespace. Is required
+                        when creating resources, although some resources may allow
+                        a client to request the generation of an appropriate name
+                        automatically. Name is primarily intended for creation idempotence
+                        and configuration definition. Cannot be updated. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  type: object
+                spec:
+                  description: 'ServiceSpec describes the attributes that a user creates
+                    on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                  properties:
+                    allocateLoadBalancerNodePorts:
+                      description: allocateLoadBalancerNodePorts defines if NodePorts
+                        will be automatically allocated for services with type LoadBalancer.  Default
+                        is "true". It may be set to "false" if the cluster load-balancer
+                        does not rely on NodePorts. allocateLoadBalancerNodePorts
+                        may only be set for services with type LoadBalancer and will
+                        be cleared if the type is changed to any other type. This
+                        field is alpha-level and is only honored by servers that enable
+                        the ServiceLBNodePortControl feature.
+                      type: boolean
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly. If an address is specified manually,
+                        is in-range (as per system configuration), and is not in use,
+                        it will be allocated to the service; otherwise creation of
+                        the service will fail. This field may not be changed through
+                        updates unless the type field is also being changed to ExternalName
+                        (which requires this field to be blank) or the type field
+                        is being changed from ExternalName (in which case this field
+                        may optionally be specified, as describe above).  Valid values
+                        are "None", empty string (""), or a valid IP address. Setting
+                        this to "None" makes a "headless service" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    clusterIPs:
+                      description: "ClusterIPs is a list of IP addresses assigned
+                        to this service, and are usually assigned randomly.  If an
+                        address is specified manually, is in-range (as per system
+                        configuration), and is not in use, it will be allocated to
+                        the service; otherwise creation of the service will fail.
+                        This field may not be changed through updates unless the type
+                        field is also being changed to ExternalName (which requires
+                        this field to be empty) or the type field is being changed
+                        from ExternalName (in which case this field may optionally
+                        be specified, as describe above).  Valid values are \"None\",
+                        empty string (\"\"), or a valid IP address.  Setting this
+                        to \"None\" makes a \"headless service\" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        \ If this field is not specified, it will be initialized from
+                        the clusterIP field.  If this field is specified, clients
+                        must ensure that clusterIPs[0] and clusterIP have the same
+                        value. \n Unless the \"IPv6DualStack\" feature gate is enabled,
+                        this field is limited to one value, which must be the same
+                        as the clusterIP field.  If the feature gate is enabled, this
+                        field may hold a maximum of two entries (dual-stack IPs, in
+                        either order).  These IPs must correspond to the values of
+                        the ipFamilies field. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that discovery
+                        mechanisms will return as an alias for this service (e.g.
+                        a DNS CNAME record). No proxying will be involved.  Must be
+                        a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        and requires Type to be
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. This only applies when type is set to LoadBalancer
+                        and externalTrafficPolicy is set to Local. If a value is specified,
+                        is in-range, and is not in use, it will be used.  If not specified,
+                        a value will be automatically allocated.  External systems
+                        (e.g. load-balancers) can use this port to determine if a
+                        given node holds endpoints for this service or not.  If this
+                        field is specified when creating a Service which does not
+                        need it, creation will fail. This field will be wiped when
+                        updating a Service to no longer need it (e.g. changing type).
+                      format: int32
+                      type: integer
+                    ipFamilies:
+                      description: "IPFamilies is a list of IP families (e.g. IPv4,
+                        IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                        feature gate.  This field is usually assigned automatically
+                        based on cluster configuration and the ipFamilyPolicy field.
+                        If this field is specified manually, the requested family
+                        is available in the cluster, and ipFamilyPolicy allows it,
+                        it will be used; otherwise creation of the service will fail.
+                        \ This field is conditionally mutable: it allows for adding
+                        or removing a secondary IP family, but it does not allow changing
+                        the primary IP family of the Service.  Valid values are \"IPv4\"
+                        and \"IPv6\".  This field only applies to Services of types
+                        ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\"
+                        services.  This field will be wiped when updating a Service
+                        to type ExternalName. \n This field may hold a maximum of
+                        two entries (dual-stack families, in either order).  These
+                        families must correspond to the values of the clusterIPs field,
+                        if specified. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field."
+                      items:
+                        description: IPFamily represents the IP Family (IPv4 or IPv6).
+                          This type is used to express the family of an IP expressed
+                          by a type (e.g. service.spec.ipFamilies).
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ipFamilyPolicy:
+                      description: IPFamilyPolicy represents the dual-stack-ness requested
+                        or required by this Service, and is gated by the "IPv6DualStack"
+                        feature gate.  If there is no value provided, then this field
+                        will be set to SingleStack. Services can be "SingleStack"
+                        (a single IP family), "PreferDualStack" (two IP families on
+                        dual-stack configured clusters or a single IP family on single-stack
+                        clusters), or "RequireDualStack" (two IP families on dual-stack
+                        configured clusters, otherwise fail). The ipFamilies and clusterIPs
+                        fields depend on the value of this field.  This field will
+                        be wiped when updating a service to type ExternalName.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses indicates that any agent
+                        which deals with endpoints for this Service should disregard
+                        any indications of ready/not-ready. The primary use case for
+                        setting this field is for a StatefulSet's Headless Service
+                        to propagate SRV DNS records for its Pods for the purpose
+                        of peer discovery. The Kubernetes controllers that generate
+                        Endpoints and EndpointSlice resources for Services interpret
+                        this to mean that all endpoints are considered "ready" even
+                        if the Pods themselves are not. Agents which consume only
+                        Kubernetes generated endpoints through the Endpoints or EndpointSlice
+                        resources can safely assume this behavior.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    topologyKeys:
+                      description: topologyKeys is a preference-order list of topology
+                        keys which implementations of services should use to preferentially
+                        sort endpoints when accessing this Service, it can not be
+                        used at the same time as externalTrafficPolicy=Local. Topology
+                        keys must be valid label keys and at most 16 keys may be specified.
+                        Endpoints are chosen based on the first topology key with
+                        available backends. If this field is specified and all entries
+                        have no backends that match the topology of the client, the
+                        service has no backends for that client and connections should
+                        fail. The special value "*" may be used to mean "any topology".
+                        This catch-all value, if used, only makes sense as the last
+                        value in the list. If this is not specified or empty, no topology
+                        constraints will be applied. This field is alpha-level and
+                        is only honored by servers that enable the ServiceTopology
+                        feature.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                        IP address for load-balancing to endpoints. Endpoints are
+                        determined by the selector or if that is not specified, by
+                        manual construction of an Endpoints object or EndpointSlice
+                        objects. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the same endpoints as
+                        the clusterIP. "LoadBalancer" builds on NodePort and creates
+                        an external load-balancer (if supported in the current cloud)
+                        which routes to the same endpoints as the clusterIP. "ExternalName"
+                        aliases this service to the specified externalName. Several
+                        other fields do not apply to ExternalName services. More info:
+                        https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+              required:
+              - spec
+              type: object
             storage:
               description: Storage is the definition of how storage will be used by
                 the VMAlertmanager instances.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -781,6 +781,29 @@ spec:
                 - url
                 type: object
               type: array
+            podDisruptionBudget:
+              description: PodDisruptionBudget created by operator
+              properties:
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: An eviction is allowed if at most "maxUnavailable"
+                    pods selected by "selector" are unavailable after the eviction,
+                    i.e. even in absence of the evicted pod. For example, one can
+                    prevent all voluntary evictions by specifying 0. This is a mutually
+                    exclusive setting with "minAvailable".
+                  x-kubernetes-int-or-string: true
+                minAvailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: An eviction is allowed if at least "minAvailable" pods
+                    selected by "selector" will still be available after the eviction,
+                    i.e. even in the absence of the evicted pod.  So for example you
+                    can prevent all voluntary evictions by specifying "100%".
+                  x-kubernetes-int-or-string: true
+              type: object
             podMetadata:
               description: PodMetadata configures Labels and Annotations which are
                 propagated to the VMAlert pods.
@@ -1224,6 +1247,41 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            rollingUpdate:
+              description: RollingUpdate - overrides deployment update params.
+              properties:
+                maxSurge:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'The maximum number of pods that can be scheduled above
+                    the desired number of pods. Value can be an absolute number (ex:
+                    5) or a percentage of desired pods (ex: 10%). This can not be
+                    0 if MaxUnavailable is 0. Absolute number is calculated from percentage
+                    by rounding up. Defaults to 25%. Example: when this is set to
+                    30%, the new ReplicaSet can be scaled up immediately when the
+                    rolling update starts, such that the total number of old and new
+                    pods do not exceed 130% of desired pods. Once old pods have been
+                    killed, new ReplicaSet can be scaled up further, ensuring that
+                    total number of pods running at any time during the update is
+                    at most 130% of desired pods.'
+                  x-kubernetes-int-or-string: true
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'The maximum number of pods that can be unavailable
+                    during the update. Value can be an absolute number (ex: 5) or
+                    a percentage of desired pods (ex: 10%). Absolute number is calculated
+                    from percentage by rounding down. This can not be 0 if MaxSurge
+                    is 0. Defaults to 25%. Example: when this is set to 30%, the old
+                    ReplicaSet can be scaled down to 70% of desired pods immediately
+                    when the rolling update starts. Once new pods are ready, old ReplicaSet
+                    can be scaled down further, followed by scaling up the new ReplicaSet,
+                    ensuring that the total number of pods available at all times
+                    during the update is at least 70% of desired pods.'
+                  x-kubernetes-int-or-string: true
+              type: object
             ruleNamespaceSelector:
               description: RuleNamespaceSelector to be selected for VMRules discovery.
                 If unspecified, only the same namespace as the vmalert object is in
@@ -1483,6 +1541,283 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMAlert Pods.
               type: string
+            serviceSpec:
+              description: ServiceSpec that will be added to vmalert service spec
+              properties:
+                metadata:
+                  description: EmbeddedObjectMetadata defines objectMeta for additional
+                    service.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations is an unstructured key value map stored
+                        with a resource that may be set by external tools to store
+                        and retrieve arbitrary metadata. They are not queryable and
+                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: 'Labels Map of string keys and values that can
+                        be used to organize and categorize (scope and select) objects.
+                        May match selectors of replication controllers and services.
+                        More info: http://kubernetes.io/docs/user-guide/labels'
+                      type: object
+                    name:
+                      description: 'Name must be unique within a namespace. Is required
+                        when creating resources, although some resources may allow
+                        a client to request the generation of an appropriate name
+                        automatically. Name is primarily intended for creation idempotence
+                        and configuration definition. Cannot be updated. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  type: object
+                spec:
+                  description: 'ServiceSpec describes the attributes that a user creates
+                    on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                  properties:
+                    allocateLoadBalancerNodePorts:
+                      description: allocateLoadBalancerNodePorts defines if NodePorts
+                        will be automatically allocated for services with type LoadBalancer.  Default
+                        is "true". It may be set to "false" if the cluster load-balancer
+                        does not rely on NodePorts. allocateLoadBalancerNodePorts
+                        may only be set for services with type LoadBalancer and will
+                        be cleared if the type is changed to any other type. This
+                        field is alpha-level and is only honored by servers that enable
+                        the ServiceLBNodePortControl feature.
+                      type: boolean
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly. If an address is specified manually,
+                        is in-range (as per system configuration), and is not in use,
+                        it will be allocated to the service; otherwise creation of
+                        the service will fail. This field may not be changed through
+                        updates unless the type field is also being changed to ExternalName
+                        (which requires this field to be blank) or the type field
+                        is being changed from ExternalName (in which case this field
+                        may optionally be specified, as describe above).  Valid values
+                        are "None", empty string (""), or a valid IP address. Setting
+                        this to "None" makes a "headless service" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    clusterIPs:
+                      description: "ClusterIPs is a list of IP addresses assigned
+                        to this service, and are usually assigned randomly.  If an
+                        address is specified manually, is in-range (as per system
+                        configuration), and is not in use, it will be allocated to
+                        the service; otherwise creation of the service will fail.
+                        This field may not be changed through updates unless the type
+                        field is also being changed to ExternalName (which requires
+                        this field to be empty) or the type field is being changed
+                        from ExternalName (in which case this field may optionally
+                        be specified, as describe above).  Valid values are \"None\",
+                        empty string (\"\"), or a valid IP address.  Setting this
+                        to \"None\" makes a \"headless service\" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        \ If this field is not specified, it will be initialized from
+                        the clusterIP field.  If this field is specified, clients
+                        must ensure that clusterIPs[0] and clusterIP have the same
+                        value. \n Unless the \"IPv6DualStack\" feature gate is enabled,
+                        this field is limited to one value, which must be the same
+                        as the clusterIP field.  If the feature gate is enabled, this
+                        field may hold a maximum of two entries (dual-stack IPs, in
+                        either order).  These IPs must correspond to the values of
+                        the ipFamilies field. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that discovery
+                        mechanisms will return as an alias for this service (e.g.
+                        a DNS CNAME record). No proxying will be involved.  Must be
+                        a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        and requires Type to be
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. This only applies when type is set to LoadBalancer
+                        and externalTrafficPolicy is set to Local. If a value is specified,
+                        is in-range, and is not in use, it will be used.  If not specified,
+                        a value will be automatically allocated.  External systems
+                        (e.g. load-balancers) can use this port to determine if a
+                        given node holds endpoints for this service or not.  If this
+                        field is specified when creating a Service which does not
+                        need it, creation will fail. This field will be wiped when
+                        updating a Service to no longer need it (e.g. changing type).
+                      format: int32
+                      type: integer
+                    ipFamilies:
+                      description: "IPFamilies is a list of IP families (e.g. IPv4,
+                        IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                        feature gate.  This field is usually assigned automatically
+                        based on cluster configuration and the ipFamilyPolicy field.
+                        If this field is specified manually, the requested family
+                        is available in the cluster, and ipFamilyPolicy allows it,
+                        it will be used; otherwise creation of the service will fail.
+                        \ This field is conditionally mutable: it allows for adding
+                        or removing a secondary IP family, but it does not allow changing
+                        the primary IP family of the Service.  Valid values are \"IPv4\"
+                        and \"IPv6\".  This field only applies to Services of types
+                        ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\"
+                        services.  This field will be wiped when updating a Service
+                        to type ExternalName. \n This field may hold a maximum of
+                        two entries (dual-stack families, in either order).  These
+                        families must correspond to the values of the clusterIPs field,
+                        if specified. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field."
+                      items:
+                        description: IPFamily represents the IP Family (IPv4 or IPv6).
+                          This type is used to express the family of an IP expressed
+                          by a type (e.g. service.spec.ipFamilies).
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ipFamilyPolicy:
+                      description: IPFamilyPolicy represents the dual-stack-ness requested
+                        or required by this Service, and is gated by the "IPv6DualStack"
+                        feature gate.  If there is no value provided, then this field
+                        will be set to SingleStack. Services can be "SingleStack"
+                        (a single IP family), "PreferDualStack" (two IP families on
+                        dual-stack configured clusters or a single IP family on single-stack
+                        clusters), or "RequireDualStack" (two IP families on dual-stack
+                        configured clusters, otherwise fail). The ipFamilies and clusterIPs
+                        fields depend on the value of this field.  This field will
+                        be wiped when updating a service to type ExternalName.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses indicates that any agent
+                        which deals with endpoints for this Service should disregard
+                        any indications of ready/not-ready. The primary use case for
+                        setting this field is for a StatefulSet's Headless Service
+                        to propagate SRV DNS records for its Pods for the purpose
+                        of peer discovery. The Kubernetes controllers that generate
+                        Endpoints and EndpointSlice resources for Services interpret
+                        this to mean that all endpoints are considered "ready" even
+                        if the Pods themselves are not. Agents which consume only
+                        Kubernetes generated endpoints through the Endpoints or EndpointSlice
+                        resources can safely assume this behavior.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    topologyKeys:
+                      description: topologyKeys is a preference-order list of topology
+                        keys which implementations of services should use to preferentially
+                        sort endpoints when accessing this Service, it can not be
+                        used at the same time as externalTrafficPolicy=Local. Topology
+                        keys must be valid label keys and at most 16 keys may be specified.
+                        Endpoints are chosen based on the first topology key with
+                        available backends. If this field is specified and all entries
+                        have no backends that match the topology of the client, the
+                        service has no backends for that client and connections should
+                        fail. The special value "*" may be used to mean "any topology".
+                        This catch-all value, if used, only makes sense as the last
+                        value in the list. If this is not specified or empty, no topology
+                        constraints will be applied. This field is alpha-level and
+                        is only honored by servers that enable the ServiceTopology
+                        feature.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                        IP address for load-balancing to endpoints. Endpoints are
+                        determined by the selector or if that is not specified, by
+                        manual construction of an Endpoints object or EndpointSlice
+                        objects. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the same endpoints as
+                        the clusterIP. "LoadBalancer" builds on NodePort and creates
+                        an external load-balancer (if supported in the current cloud)
+                        which routes to the same endpoints as the clusterIP. "ExternalName"
+                        aliases this service to the specified externalName. Several
+                        other fields do not apply to ExternalName services. More info:
+                        https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+              required:
+              - spec
+              type: object
             tolerations:
               description: Tolerations If specified, the pod's tolerations.
               items:
@@ -1537,6 +1872,12 @@ spec:
                 - whenUnsatisfiable
                 type: object
               type: array
+            updateStrategy:
+              description: UpdateStrategy - overrides default update strategy.
+              enum:
+              - Recreate
+              - RollingUpdate
+              type: string
             volumeMounts:
               description: VolumeMounts allows configuration of additional VolumeMounts
                 on the output Deployment definition. VolumeMounts specified will be

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -294,6 +294,30 @@ spec:
                   type: string
                 name:
                   type: string
+                podDisruptionBudget:
+                  description: PodDisruptionBudget created by operator
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: An eviction is allowed if at most "maxUnavailable"
+                        pods selected by "selector" are unavailable after the eviction,
+                        i.e. even in absence of the evicted pod. For example, one
+                        can prevent all voluntary evictions by specifying 0. This
+                        is a mutually exclusive setting with "minAvailable".
+                      x-kubernetes-int-or-string: true
+                    minAvailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: An eviction is allowed if at least "minAvailable"
+                        pods selected by "selector" will still be available after
+                        the eviction, i.e. even in the absence of the evicted pod.  So
+                        for example you can prevent all voluntary evictions by specifying
+                        "100%".
+                      x-kubernetes-int-or-string: true
+                  type: object
                 podMetadata:
                   description: PodMetadata configures Labels and Annotations which
                     are propagated to the VMSelect pods.
@@ -360,6 +384,43 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                  type: object
+                rollingUpdate:
+                  description: RollingUpdate - overrides deployment update params.
+                  properties:
+                    maxSurge:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'The maximum number of pods that can be scheduled
+                        above the desired number of pods. Value can be an absolute
+                        number (ex: 5) or a percentage of desired pods (ex: 10%).
+                        This can not be 0 if MaxUnavailable is 0. Absolute number
+                        is calculated from percentage by rounding up. Defaults to
+                        25%. Example: when this is set to 30%, the new ReplicaSet
+                        can be scaled up immediately when the rolling update starts,
+                        such that the total number of old and new pods do not exceed
+                        130% of desired pods. Once old pods have been killed, new
+                        ReplicaSet can be scaled up further, ensuring that total number
+                        of pods running at any time during the update is at most 130%
+                        of desired pods.'
+                      x-kubernetes-int-or-string: true
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'The maximum number of pods that can be unavailable
+                        during the update. Value can be an absolute number (ex: 5)
+                        or a percentage of desired pods (ex: 10%). Absolute number
+                        is calculated from percentage by rounding down. This can not
+                        be 0 if MaxSurge is 0. Defaults to 25%. Example: when this
+                        is set to 30%, the old ReplicaSet can be scaled down to 70%
+                        of desired pods immediately when the rolling update starts.
+                        Once new pods are ready, old ReplicaSet can be scaled down
+                        further, followed by scaling up the new ReplicaSet, ensuring
+                        that the total number of pods available at all times during
+                        the update is at least 70% of desired pods.'
+                      x-kubernetes-int-or-string: true
                   type: object
                 runtimeClassName:
                   description: RuntimeClassName - defines runtime class for kubernetes
@@ -520,6 +581,298 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceSpec:
+                  description: ServiceSpec that will be added to vminsert service
+                    spec
+                  properties:
+                    metadata:
+                      description: EmbeddedObjectMetadata defines objectMeta for additional
+                        service.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: 'Labels Map of string keys and values that
+                            can be used to organize and categorize (scope and select)
+                            objects. May match selectors of replication controllers
+                            and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                      type: object
+                    spec:
+                      description: 'ServiceSpec describes the attributes that a user
+                        creates on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          description: allocateLoadBalancerNodePorts defines if NodePorts
+                            will be automatically allocated for services with type
+                            LoadBalancer.  Default is "true". It may be set to "false"
+                            if the cluster load-balancer does not rely on NodePorts.
+                            allocateLoadBalancerNodePorts may only be set for services
+                            with type LoadBalancer and will be cleared if the type
+                            is changed to any other type. This field is alpha-level
+                            and is only honored by servers that enable the ServiceLBNodePortControl
+                            feature.
+                          type: boolean
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly. If an address is specified
+                            manually, is in-range (as per system configuration), and
+                            is not in use, it will be allocated to the service; otherwise
+                            creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also
+                            being changed to ExternalName (which requires this field
+                            to be blank) or the type field is being changed from ExternalName
+                            (in which case this field may optionally be specified,
+                            as describe above).  Valid values are "None", empty string
+                            (""), or a valid IP address. Setting this to "None" makes
+                            a "headless service" (no virtual IP), which is useful
+                            when direct endpoint connections are preferred and proxying
+                            is not required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        clusterIPs:
+                          description: "ClusterIPs is a list of IP addresses assigned
+                            to this service, and are usually assigned randomly.  If
+                            an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated
+                            to the service; otherwise creation of the service will
+                            fail. This field may not be changed through updates unless
+                            the type field is also being changed to ExternalName (which
+                            requires this field to be empty) or the type field is
+                            being changed from ExternalName (in which case this field
+                            may optionally be specified, as describe above).  Valid
+                            values are \"None\", empty string (\"\"), or a valid IP
+                            address.  Setting this to \"None\" makes a \"headless
+                            service\" (no virtual IP), which is useful when direct
+                            endpoint connections are preferred and proxying is not
+                            required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            \ If this field is not specified, it will be initialized
+                            from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have
+                            the same value. \n Unless the \"IPv6DualStack\" feature
+                            gate is enabled, this field is limited to one value, which
+                            must be the same as the clusterIP field.  If the feature
+                            gate is enabled, this field may hold a maximum of two
+                            entries (dual-stack IPs, in either order).  These IPs
+                            must correspond to the values of the ipFamilies field.
+                            Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            discovery mechanisms will return as an alias for this
+                            service (e.g. a DNS CNAME record). No proxying will be
+                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. This only applies when type
+                            is set to LoadBalancer and externalTrafficPolicy is set
+                            to Local. If a value is specified, is in-range, and is
+                            not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g.
+                            load-balancers) can use this port to determine if a given
+                            node holds endpoints for this service or not.  If this
+                            field is specified when creating a Service which does
+                            not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing
+                            type).
+                          format: int32
+                          type: integer
+                        ipFamilies:
+                          description: "IPFamilies is a list of IP families (e.g.
+                            IPv4, IPv6) assigned to this service, and is gated by
+                            the \"IPv6DualStack\" feature gate.  This field is usually
+                            assigned automatically based on cluster configuration
+                            and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise
+                            creation of the service will fail.  This field is conditionally
+                            mutable: it allows for adding or removing a secondary
+                            IP family, but it does not allow changing the primary
+                            IP family of the Service.  Valid values are \"IPv4\" and
+                            \"IPv6\".  This field only applies to Services of types
+                            ClusterIP, NodePort, and LoadBalancer, and does apply
+                            to \"headless\" services.  This field will be wiped when
+                            updating a Service to type ExternalName. \n This field
+                            may hold a maximum of two entries (dual-stack families,
+                            in either order).  These families must correspond to the
+                            values of the clusterIPs field, if specified. Both clusterIPs
+                            and ipFamilies are governed by the ipFamilyPolicy field."
+                          items:
+                            description: IPFamily represents the IP Family (IPv4 or
+                              IPv6). This type is used to express the family of an
+                              IP expressed by a type (e.g. service.spec.ipFamilies).
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service, and is gated by
+                            the "IPv6DualStack" feature gate.  If there is no value
+                            provided, then this field will be set to SingleStack.
+                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail). The ipFamilies and clusterIPs fields depend on
+                            the value of this field.  This field will be wiped when
+                            updating a service to type ExternalName.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses indicates that any
+                            agent which deals with endpoints for this Service should
+                            disregard any indications of ready/not-ready. The primary
+                            use case for setting this field is for a StatefulSet's
+                            Headless Service to propagate SRV DNS records for its
+                            Pods for the purpose of peer discovery. The Kubernetes
+                            controllers that generate Endpoints and EndpointSlice
+                            resources for Services interpret this to mean that all
+                            endpoints are considered "ready" even if the Pods themselves
+                            are not. Agents which consume only Kubernetes generated
+                            endpoints through the Endpoints or EndpointSlice resources
+                            can safely assume this behavior.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied. This field is alpha-level
+                            and is only honored by servers that enable the ServiceTopology
+                            feature.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object or EndpointSlice objects. If clusterIP is "None",
+                            no virtual IP is allocated and the endpoints are published
+                            as a set of endpoints rather than a virtual IP. "NodePort"
+                            builds on ClusterIP and allocates a port on every node
+                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
+                            builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the
+                            same endpoints as the clusterIP. "ExternalName" aliases
+                            this service to the specified externalName. Several other
+                            fields do not apply to ExternalName services. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  required:
+                  - spec
+                  type: object
                 tolerations:
                   description: Tolerations If specified, the pod's tolerations.
                   items:
@@ -574,6 +927,12 @@ spec:
                     - whenUnsatisfiable
                     type: object
                   type: array
+                updateStrategy:
+                  description: UpdateStrategy - overrides default update strategy.
+                  enum:
+                  - Recreate
+                  - RollingUpdate
+                  type: string
                 volumeMounts:
                   description: VolumeMounts allows configuration of additional VolumeMounts
                     on the output Deployment definition. VolumeMounts specified will
@@ -826,7 +1185,7 @@ spec:
                   type: string
                 persistentVolume:
                   description: Storage - add persistent volume for cacheMounthPath
-                    its useful for persistent cache
+                    its useful for persistent cache use storage instead of persistentVolume.
                   properties:
                     disableMountSubPath:
                       description: 'Deprecated: subPath usage will be disabled by
@@ -862,6 +1221,30 @@ spec:
                     volumeClaimTemplate:
                       description: A PVC spec to be used by the VMAlertManager StatefulSets.
                       type: object
+                  type: object
+                podDisruptionBudget:
+                  description: PodDisruptionBudget created by operator
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: An eviction is allowed if at most "maxUnavailable"
+                        pods selected by "selector" are unavailable after the eviction,
+                        i.e. even in absence of the evicted pod. For example, one
+                        can prevent all voluntary evictions by specifying 0. This
+                        is a mutually exclusive setting with "minAvailable".
+                      x-kubernetes-int-or-string: true
+                    minAvailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: An eviction is allowed if at least "minAvailable"
+                        pods selected by "selector" will still be available after
+                        the eviction, i.e. even in the absence of the evicted pod.  So
+                        for example you can prevent all voluntary evictions by specifying
+                        "100%".
+                      x-kubernetes-int-or-string: true
                   type: object
                 podMetadata:
                   description: PodMetadata configures Labels and Annotations which
@@ -1087,6 +1470,572 @@ spec:
                             If set in both SecurityContext and PodSecurityContext,
                             the value specified in SecurityContext takes precedence.
                           type: string
+                      type: object
+                  type: object
+                serviceSpec:
+                  description: ServiceSpec that will be added to vmselect service
+                    spec
+                  properties:
+                    metadata:
+                      description: EmbeddedObjectMetadata defines objectMeta for additional
+                        service.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: 'Labels Map of string keys and values that
+                            can be used to organize and categorize (scope and select)
+                            objects. May match selectors of replication controllers
+                            and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                      type: object
+                    spec:
+                      description: 'ServiceSpec describes the attributes that a user
+                        creates on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          description: allocateLoadBalancerNodePorts defines if NodePorts
+                            will be automatically allocated for services with type
+                            LoadBalancer.  Default is "true". It may be set to "false"
+                            if the cluster load-balancer does not rely on NodePorts.
+                            allocateLoadBalancerNodePorts may only be set for services
+                            with type LoadBalancer and will be cleared if the type
+                            is changed to any other type. This field is alpha-level
+                            and is only honored by servers that enable the ServiceLBNodePortControl
+                            feature.
+                          type: boolean
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly. If an address is specified
+                            manually, is in-range (as per system configuration), and
+                            is not in use, it will be allocated to the service; otherwise
+                            creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also
+                            being changed to ExternalName (which requires this field
+                            to be blank) or the type field is being changed from ExternalName
+                            (in which case this field may optionally be specified,
+                            as describe above).  Valid values are "None", empty string
+                            (""), or a valid IP address. Setting this to "None" makes
+                            a "headless service" (no virtual IP), which is useful
+                            when direct endpoint connections are preferred and proxying
+                            is not required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        clusterIPs:
+                          description: "ClusterIPs is a list of IP addresses assigned
+                            to this service, and are usually assigned randomly.  If
+                            an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated
+                            to the service; otherwise creation of the service will
+                            fail. This field may not be changed through updates unless
+                            the type field is also being changed to ExternalName (which
+                            requires this field to be empty) or the type field is
+                            being changed from ExternalName (in which case this field
+                            may optionally be specified, as describe above).  Valid
+                            values are \"None\", empty string (\"\"), or a valid IP
+                            address.  Setting this to \"None\" makes a \"headless
+                            service\" (no virtual IP), which is useful when direct
+                            endpoint connections are preferred and proxying is not
+                            required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            \ If this field is not specified, it will be initialized
+                            from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have
+                            the same value. \n Unless the \"IPv6DualStack\" feature
+                            gate is enabled, this field is limited to one value, which
+                            must be the same as the clusterIP field.  If the feature
+                            gate is enabled, this field may hold a maximum of two
+                            entries (dual-stack IPs, in either order).  These IPs
+                            must correspond to the values of the ipFamilies field.
+                            Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            discovery mechanisms will return as an alias for this
+                            service (e.g. a DNS CNAME record). No proxying will be
+                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. This only applies when type
+                            is set to LoadBalancer and externalTrafficPolicy is set
+                            to Local. If a value is specified, is in-range, and is
+                            not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g.
+                            load-balancers) can use this port to determine if a given
+                            node holds endpoints for this service or not.  If this
+                            field is specified when creating a Service which does
+                            not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing
+                            type).
+                          format: int32
+                          type: integer
+                        ipFamilies:
+                          description: "IPFamilies is a list of IP families (e.g.
+                            IPv4, IPv6) assigned to this service, and is gated by
+                            the \"IPv6DualStack\" feature gate.  This field is usually
+                            assigned automatically based on cluster configuration
+                            and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise
+                            creation of the service will fail.  This field is conditionally
+                            mutable: it allows for adding or removing a secondary
+                            IP family, but it does not allow changing the primary
+                            IP family of the Service.  Valid values are \"IPv4\" and
+                            \"IPv6\".  This field only applies to Services of types
+                            ClusterIP, NodePort, and LoadBalancer, and does apply
+                            to \"headless\" services.  This field will be wiped when
+                            updating a Service to type ExternalName. \n This field
+                            may hold a maximum of two entries (dual-stack families,
+                            in either order).  These families must correspond to the
+                            values of the clusterIPs field, if specified. Both clusterIPs
+                            and ipFamilies are governed by the ipFamilyPolicy field."
+                          items:
+                            description: IPFamily represents the IP Family (IPv4 or
+                              IPv6). This type is used to express the family of an
+                              IP expressed by a type (e.g. service.spec.ipFamilies).
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service, and is gated by
+                            the "IPv6DualStack" feature gate.  If there is no value
+                            provided, then this field will be set to SingleStack.
+                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail). The ipFamilies and clusterIPs fields depend on
+                            the value of this field.  This field will be wiped when
+                            updating a service to type ExternalName.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses indicates that any
+                            agent which deals with endpoints for this Service should
+                            disregard any indications of ready/not-ready. The primary
+                            use case for setting this field is for a StatefulSet's
+                            Headless Service to propagate SRV DNS records for its
+                            Pods for the purpose of peer discovery. The Kubernetes
+                            controllers that generate Endpoints and EndpointSlice
+                            resources for Services interpret this to mean that all
+                            endpoints are considered "ready" even if the Pods themselves
+                            are not. Agents which consume only Kubernetes generated
+                            endpoints through the Endpoints or EndpointSlice resources
+                            can safely assume this behavior.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied. This field is alpha-level
+                            and is only honored by servers that enable the ServiceTopology
+                            feature.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object or EndpointSlice objects. If clusterIP is "None",
+                            no virtual IP is allocated and the endpoints are published
+                            as a set of endpoints rather than a virtual IP. "NodePort"
+                            builds on ClusterIP and allocates a port on every node
+                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
+                            builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the
+                            same endpoints as the clusterIP. "ExternalName" aliases
+                            this service to the specified externalName. Several other
+                            fields do not apply to ExternalName services. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  required:
+                  - spec
+                  type: object
+                storage:
+                  description: StorageSpec - add persistent volume claim for cacheMounthPath
+                    its needed for persistent cache
+                  properties:
+                    disableMountSubPath:
+                      description: 'Deprecated: subPath usage will be disabled by
+                        default in a future release, this option will become unnecessary.
+                        DisableMountSubPath allows to remove any subPath usage in
+                        volume mounts.'
+                      type: boolean
+                    emptyDir:
+                      description: 'EmptyDirVolumeSource to be used by the Prometheus
+                        StatefulSets. If specified, used in place of any volumeClaimTemplate.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
+                      properties:
+                        medium:
+                          description: 'What type of storage medium should back this
+                            directory. The default is "" which means to use the node''s
+                            default medium. Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'Total amount of local storage required for
+                            this EmptyDir volume. The size limit is also applicable
+                            for memory medium. The maximum usage on memory medium
+                            EmptyDir would be the minimum value between the SizeLimit
+                            specified here and the sum of memory limits of all containers
+                            in a pod. The default is nil which means that the limit
+                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    volumeClaimTemplate:
+                      description: A PVC spec to be used by the VMAlertManager StatefulSets.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: EmbeddedMetadata contains metadata relevant
+                            to an EmbeddedResource.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: 'Annotations is an unstructured key value
+                                map stored with a resource that may be set by external
+                                tools to store and retrieve arbitrary metadata. They
+                                are not queryable and should be preserved when modifying
+                                objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: 'Labels Map of string keys and values that
+                                can be used to organize and categorize (scope and
+                                select) objects. May match selectors of replication
+                                controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              type: object
+                            name:
+                              description: 'Name must be unique within a namespace.
+                                Is required when creating resources, although some
+                                resources may allow a client to request the generation
+                                of an appropriate name automatically. Name is primarily
+                                intended for creation idempotence and configuration
+                                definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          type: object
+                        spec:
+                          description: 'Spec defines the desired characteristics of
+                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) * An existing
+                                custom resource that implements data population (Alpha)
+                                In order to use custom resource types that implement
+                                data population, the AnyVolumeDataSource feature gate
+                                must be enabled. If the provisioner or an external
+                                controller can support the specified data source,
+                                it will create a new volume based on the contents
+                                of the specified data source.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        status:
+                          description: 'Status represents the current information/status
+                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the actual access
+                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            capacity:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Represents the actual resources of the
+                                underlying volume.
+                              type: object
+                            conditions:
+                              description: Current Condition of persistent volume
+                                claim. If underlying persistent volume is being resized
+                                then the Condition will be set to 'ResizeStarted'.
+                              items:
+                                description: PersistentVolumeClaimCondition contails
+                                  details about state of pvc
+                                properties:
+                                  lastProbeTime:
+                                    description: Last time we probed the condition.
+                                    format: date-time
+                                    type: string
+                                  lastTransitionTime:
+                                    description: Last time the condition transitioned
+                                      from one status to another.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: Human-readable message indicating
+                                      details about last transition.
+                                    type: string
+                                  reason:
+                                    description: Unique, this should be a short, machine
+                                      understandable string that gives the reason
+                                      for condition's last transition. If it reports
+                                      "ResizeStarted" that means the underlying persistent
+                                      volume is being resized.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: PersistentVolumeClaimConditionType
+                                      is a valid value of PersistentVolumeClaimCondition.Type
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                            phase:
+                              description: Phase represents the current phase of PersistentVolumeClaim.
+                              type: string
+                          type: object
                       type: object
                   type: object
                 tolerations:
@@ -1390,6 +2339,30 @@ spec:
                   type: string
                 name:
                   type: string
+                podDisruptionBudget:
+                  description: PodDisruptionBudget created by operator
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: An eviction is allowed if at most "maxUnavailable"
+                        pods selected by "selector" are unavailable after the eviction,
+                        i.e. even in absence of the evicted pod. For example, one
+                        can prevent all voluntary evictions by specifying 0. This
+                        is a mutually exclusive setting with "minAvailable".
+                      x-kubernetes-int-or-string: true
+                    minAvailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: An eviction is allowed if at least "minAvailable"
+                        pods selected by "selector" will still be available after
+                        the eviction, i.e. even in the absence of the evicted pod.  So
+                        for example you can prevent all voluntary evictions by specifying
+                        "100%".
+                      x-kubernetes-int-or-string: true
+                  type: object
                 podMetadata:
                   description: PodMetadata configures Labels and Annotations which
                     are propagated to the VMSelect pods.
@@ -1616,6 +2589,298 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceSpec:
+                  description: ServiceSpec that will be create additional service
+                    for vmstorage
+                  properties:
+                    metadata:
+                      description: EmbeddedObjectMetadata defines objectMeta for additional
+                        service.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: 'Labels Map of string keys and values that
+                            can be used to organize and categorize (scope and select)
+                            objects. May match selectors of replication controllers
+                            and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                      type: object
+                    spec:
+                      description: 'ServiceSpec describes the attributes that a user
+                        creates on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          description: allocateLoadBalancerNodePorts defines if NodePorts
+                            will be automatically allocated for services with type
+                            LoadBalancer.  Default is "true". It may be set to "false"
+                            if the cluster load-balancer does not rely on NodePorts.
+                            allocateLoadBalancerNodePorts may only be set for services
+                            with type LoadBalancer and will be cleared if the type
+                            is changed to any other type. This field is alpha-level
+                            and is only honored by servers that enable the ServiceLBNodePortControl
+                            feature.
+                          type: boolean
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly. If an address is specified
+                            manually, is in-range (as per system configuration), and
+                            is not in use, it will be allocated to the service; otherwise
+                            creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also
+                            being changed to ExternalName (which requires this field
+                            to be blank) or the type field is being changed from ExternalName
+                            (in which case this field may optionally be specified,
+                            as describe above).  Valid values are "None", empty string
+                            (""), or a valid IP address. Setting this to "None" makes
+                            a "headless service" (no virtual IP), which is useful
+                            when direct endpoint connections are preferred and proxying
+                            is not required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        clusterIPs:
+                          description: "ClusterIPs is a list of IP addresses assigned
+                            to this service, and are usually assigned randomly.  If
+                            an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated
+                            to the service; otherwise creation of the service will
+                            fail. This field may not be changed through updates unless
+                            the type field is also being changed to ExternalName (which
+                            requires this field to be empty) or the type field is
+                            being changed from ExternalName (in which case this field
+                            may optionally be specified, as describe above).  Valid
+                            values are \"None\", empty string (\"\"), or a valid IP
+                            address.  Setting this to \"None\" makes a \"headless
+                            service\" (no virtual IP), which is useful when direct
+                            endpoint connections are preferred and proxying is not
+                            required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            \ If this field is not specified, it will be initialized
+                            from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have
+                            the same value. \n Unless the \"IPv6DualStack\" feature
+                            gate is enabled, this field is limited to one value, which
+                            must be the same as the clusterIP field.  If the feature
+                            gate is enabled, this field may hold a maximum of two
+                            entries (dual-stack IPs, in either order).  These IPs
+                            must correspond to the values of the ipFamilies field.
+                            Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            discovery mechanisms will return as an alias for this
+                            service (e.g. a DNS CNAME record). No proxying will be
+                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. This only applies when type
+                            is set to LoadBalancer and externalTrafficPolicy is set
+                            to Local. If a value is specified, is in-range, and is
+                            not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g.
+                            load-balancers) can use this port to determine if a given
+                            node holds endpoints for this service or not.  If this
+                            field is specified when creating a Service which does
+                            not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing
+                            type).
+                          format: int32
+                          type: integer
+                        ipFamilies:
+                          description: "IPFamilies is a list of IP families (e.g.
+                            IPv4, IPv6) assigned to this service, and is gated by
+                            the \"IPv6DualStack\" feature gate.  This field is usually
+                            assigned automatically based on cluster configuration
+                            and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise
+                            creation of the service will fail.  This field is conditionally
+                            mutable: it allows for adding or removing a secondary
+                            IP family, but it does not allow changing the primary
+                            IP family of the Service.  Valid values are \"IPv4\" and
+                            \"IPv6\".  This field only applies to Services of types
+                            ClusterIP, NodePort, and LoadBalancer, and does apply
+                            to \"headless\" services.  This field will be wiped when
+                            updating a Service to type ExternalName. \n This field
+                            may hold a maximum of two entries (dual-stack families,
+                            in either order).  These families must correspond to the
+                            values of the clusterIPs field, if specified. Both clusterIPs
+                            and ipFamilies are governed by the ipFamilyPolicy field."
+                          items:
+                            description: IPFamily represents the IP Family (IPv4 or
+                              IPv6). This type is used to express the family of an
+                              IP expressed by a type (e.g. service.spec.ipFamilies).
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service, and is gated by
+                            the "IPv6DualStack" feature gate.  If there is no value
+                            provided, then this field will be set to SingleStack.
+                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail). The ipFamilies and clusterIPs fields depend on
+                            the value of this field.  This field will be wiped when
+                            updating a service to type ExternalName.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses indicates that any
+                            agent which deals with endpoints for this Service should
+                            disregard any indications of ready/not-ready. The primary
+                            use case for setting this field is for a StatefulSet's
+                            Headless Service to propagate SRV DNS records for its
+                            Pods for the purpose of peer discovery. The Kubernetes
+                            controllers that generate Endpoints and EndpointSlice
+                            resources for Services interpret this to mean that all
+                            endpoints are considered "ready" even if the Pods themselves
+                            are not. Agents which consume only Kubernetes generated
+                            endpoints through the Endpoints or EndpointSlice resources
+                            can safely assume this behavior.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied. This field is alpha-level
+                            and is only honored by servers that enable the ServiceTopology
+                            feature.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object or EndpointSlice objects. If clusterIP is "None",
+                            no virtual IP is allocated and the endpoints are published
+                            as a set of endpoints rather than a virtual IP. "NodePort"
+                            builds on ClusterIP and allocates a port on every node
+                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
+                            builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the
+                            same endpoints as the clusterIP. "ExternalName" aliases
+                            this service to the specified externalName. Several other
+                            fields do not apply to ExternalName services. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  required:
+                  - spec
+                  type: object
                 storage:
                   description: Storage - add persistent volume for StorageDataPath
                     its useful for persistent cache
@@ -1653,241 +2918,6 @@ spec:
                       type: object
                     volumeClaimTemplate:
                       description: A PVC spec to be used by the VMAlertManager StatefulSets.
-                      properties:
-                        apiVersion:
-                          description: 'APIVersion defines the versioned schema of
-                            this representation of an object. Servers should convert
-                            recognized schemas to the latest internal value, and may
-                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                          type: string
-                        kind:
-                          description: 'Kind is a string value representing the REST
-                            resource this object represents. Servers may infer this
-                            from the endpoint the client submits requests to. Cannot
-                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                          type: string
-                        metadata:
-                          description: EmbeddedMetadata contains metadata relevant
-                            to an EmbeddedResource.
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              description: 'Annotations is an unstructured key value
-                                map stored with a resource that may be set by external
-                                tools to store and retrieve arbitrary metadata. They
-                                are not queryable and should be preserved when modifying
-                                objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                              type: object
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: 'Labels Map of string keys and values that
-                                can be used to organize and categorize (scope and
-                                select) objects. May match selectors of replication
-                                controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-                              type: object
-                            name:
-                              description: 'Name must be unique within a namespace.
-                                Is required when creating resources, although some
-                                resources may allow a client to request the generation
-                                of an appropriate name automatically. Name is primarily
-                                intended for creation idempotence and configuration
-                                definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                              type: string
-                          type: object
-                        spec:
-                          description: 'Spec defines the desired characteristics of
-                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          properties:
-                            accessModes:
-                              description: 'AccessModes contains the desired access
-                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                              items:
-                                type: string
-                              type: array
-                            dataSource:
-                              description: 'This field can be used to specify either:
-                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                * An existing PVC (PersistentVolumeClaim) * An existing
-                                custom resource that implements data population (Alpha)
-                                In order to use custom resource types that implement
-                                data population, the AnyVolumeDataSource feature gate
-                                must be enabled. If the provisioner or an external
-                                controller can support the specified data source,
-                                it will create a new volume based on the contents
-                                of the specified data source.'
-                              properties:
-                                apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being
-                                    referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being
-                                    referenced
-                                  type: string
-                              required:
-                              - kind
-                              - name
-                              type: object
-                            resources:
-                              description: 'Resources represents the minimum resources
-                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                  type: object
-                              type: object
-                            selector:
-                              description: A label query over volumes to consider
-                                for binding.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
-                                  type: object
-                              type: object
-                            storageClassName:
-                              description: 'Name of the StorageClass required by the
-                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                              type: string
-                            volumeMode:
-                              description: volumeMode defines what type of volume
-                                is required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
-                              type: string
-                            volumeName:
-                              description: VolumeName is the binding reference to
-                                the PersistentVolume backing this claim.
-                              type: string
-                          type: object
-                        status:
-                          description: 'Status represents the current information/status
-                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          properties:
-                            accessModes:
-                              description: 'AccessModes contains the actual access
-                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                              items:
-                                type: string
-                              type: array
-                            capacity:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: Represents the actual resources of the
-                                underlying volume.
-                              type: object
-                            conditions:
-                              description: Current Condition of persistent volume
-                                claim. If underlying persistent volume is being resized
-                                then the Condition will be set to 'ResizeStarted'.
-                              items:
-                                description: PersistentVolumeClaimCondition contails
-                                  details about state of pvc
-                                properties:
-                                  lastProbeTime:
-                                    description: Last time we probed the condition.
-                                    format: date-time
-                                    type: string
-                                  lastTransitionTime:
-                                    description: Last time the condition transitioned
-                                      from one status to another.
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Human-readable message indicating
-                                      details about last transition.
-                                    type: string
-                                  reason:
-                                    description: Unique, this should be a short, machine
-                                      understandable string that gives the reason
-                                      for condition's last transition. If it reports
-                                      "ResizeStarted" that means the underlying persistent
-                                      volume is being resized.
-                                    type: string
-                                  status:
-                                    type: string
-                                  type:
-                                    description: PersistentVolumeClaimConditionType
-                                      is a valid value of PersistentVolumeClaimCondition.Type
-                                    type: string
-                                required:
-                                - status
-                                - type
-                                type: object
-                              type: array
-                            phase:
-                              description: Phase represents the current phase of PersistentVolumeClaim.
-                              type: string
-                          type: object
                       type: object
                   type: object
                 storageDataPath:
@@ -1953,6 +2983,11 @@ spec:
                 vmBackup:
                   description: VMBackup configuration for backup
                   properties:
+                    acceptEULA:
+                      description: AcceptEULA accepts enterprise feature usage, must
+                        be set to true. otherwise backupmanager cannot be added to
+                        single/cluster version. https://victoriametrics.com/assets/VM_EULA.pdf
+                      type: boolean
                     concurrency:
                       description: Defines number of concurrent workers. Higher concurrency
                         may reduce backup duration (default 10)
@@ -2175,6 +3210,8 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
+                  required:
+                  - acceptEULA
                   type: object
                 vmInsertPort:
                   description: VMInsertPort for VMInsert connections
@@ -2233,1454 +3270,6 @@ spec:
                   items:
                     description: Volume represents a named volume in a pod that may
                       be accessed by any container in the pod.
-                    properties:
-                      awsElasticBlockStore:
-                        description: 'AWSElasticBlockStore represents an AWS Disk
-                          resource that is attached to a kubelet''s host machine and
-                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        properties:
-                          fsType:
-                            description: 'Filesystem type of the volume that you want
-                              to mount. Tip: Ensure that the filesystem type is supported
-                              by the host operating system. Examples: "ext4", "xfs",
-                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                              TODO: how do we prevent errors in the filesystem from
-                              compromising the machine'
-                            type: string
-                          partition:
-                            description: 'The partition in the volume that you want
-                              to mount. If omitted, the default is to mount by volume
-                              name. Examples: For volume /dev/sda1, you specify the
-                              partition as "1". Similarly, the volume partition for
-                              /dev/sda is "0" (or you can leave the property empty).'
-                            format: int32
-                            type: integer
-                          readOnly:
-                            description: 'Specify "true" to force and set the ReadOnly
-                              property in VolumeMounts to "true". If omitted, the
-                              default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                            type: boolean
-                          volumeID:
-                            description: 'Unique ID of the persistent disk resource
-                              in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      azureDisk:
-                        description: AzureDisk represents an Azure Data Disk mount
-                          on the host and bind mount to the pod.
-                        properties:
-                          cachingMode:
-                            description: 'Host Caching mode: None, Read Only, Read
-                              Write.'
-                            type: string
-                          diskName:
-                            description: The Name of the data disk in the blob storage
-                            type: string
-                          diskURI:
-                            description: The URI the data disk in the blob storage
-                            type: string
-                          fsType:
-                            description: Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          kind:
-                            description: 'Expected values Shared: multiple blob disks
-                              per storage account  Dedicated: single blob disk per
-                              storage account  Managed: azure managed data disk (only
-                              in managed availability set). defaults to shared'
-                            type: string
-                          readOnly:
-                            description: Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                        required:
-                        - diskName
-                        - diskURI
-                        type: object
-                      azureFile:
-                        description: AzureFile represents an Azure File Service mount
-                          on the host and bind mount to the pod.
-                        properties:
-                          readOnly:
-                            description: Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          secretName:
-                            description: the name of secret that contains Azure Storage
-                              Account Name and Key
-                            type: string
-                          shareName:
-                            description: Share Name
-                            type: string
-                        required:
-                        - secretName
-                        - shareName
-                        type: object
-                      cephfs:
-                        description: CephFS represents a Ceph FS mount on the host
-                          that shares a pod's lifetime
-                        properties:
-                          monitors:
-                            description: 'Required: Monitors is a collection of Ceph
-                              monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            description: 'Optional: Used as the mounted root, rather
-                              than the full Ceph tree, default is /'
-                            type: string
-                          readOnly:
-                            description: 'Optional: Defaults to false (read/write).
-                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            type: boolean
-                          secretFile:
-                            description: 'Optional: SecretFile is the path to key
-                              ring for User, default is /etc/ceph/user.secret More
-                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            type: string
-                          secretRef:
-                            description: 'Optional: SecretRef is reference to the
-                              authentication secret for User, default is empty. More
-                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          user:
-                            description: 'Optional: User is the rados user name, default
-                              is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            type: string
-                        required:
-                        - monitors
-                        type: object
-                      cinder:
-                        description: 'Cinder represents a cinder volume attached and
-                          mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        properties:
-                          fsType:
-                            description: 'Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Examples:
-                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                            type: string
-                          readOnly:
-                            description: 'Optional: Defaults to false (read/write).
-                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                            type: boolean
-                          secretRef:
-                            description: 'Optional: points to a secret object containing
-                              parameters used to connect to OpenStack.'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          volumeID:
-                            description: 'volume id used to identify the volume in
-                              cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      configMap:
-                        description: ConfigMap represents a configMap that should
-                          populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its keys
-                              must be defined
-                            type: boolean
-                        type: object
-                      csi:
-                        description: CSI (Container Storage Interface) represents
-                          ephemeral storage that is handled by certain external CSI
-                          drivers (Beta feature).
-                        properties:
-                          driver:
-                            description: Driver is the name of the CSI driver that
-                              handles this volume. Consult with your admin for the
-                              correct name as registered in the cluster.
-                            type: string
-                          fsType:
-                            description: Filesystem type to mount. Ex. "ext4", "xfs",
-                              "ntfs". If not provided, the empty value is passed to
-                              the associated CSI driver which will determine the default
-                              filesystem to apply.
-                            type: string
-                          nodePublishSecretRef:
-                            description: NodePublishSecretRef is a reference to the
-                              secret object containing sensitive information to pass
-                              to the CSI driver to complete the CSI NodePublishVolume
-                              and NodeUnpublishVolume calls. This field is optional,
-                              and  may be empty if no secret is required. If the secret
-                              object contains more than one secret, all secret references
-                              are passed.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          readOnly:
-                            description: Specifies a read-only configuration for the
-                              volume. Defaults to false (read/write).
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            description: VolumeAttributes stores driver-specific properties
-                              that are passed to the CSI driver. Consult your driver's
-                              documentation for supported values.
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      downwardAPI:
-                        description: DownwardAPI represents downward API about the
-                          pod that should populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits to use on created files
-                              by default. Must be a Optional: mode bits used to set
-                              permissions on created files by default. Must be an
-                              octal value between 0000 and 0777 or a decimal value
-                              between 0 and 511. YAML accepts both octal and decimal
-                              values, JSON requires decimal values for mode bits.
-                              Defaults to 0644. Directories within the path are not
-                              affected by this setting. This might be in conflict
-                              with other options that affect the file mode, like fsGroup,
-                              and the result can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: Items is a list of downward API volume file
-                            items:
-                              description: DownwardAPIVolumeFile represents information
-                                to create the file containing the pod field
-                              properties:
-                                fieldRef:
-                                  description: 'Required: Selects a field of the pod:
-                                    only annotations, labels, name and namespace are
-                                    supported.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file, must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: 'Required: Path is  the relative path
-                                    name of the file to be created. Must not be absolute
-                                    or contain the ''..'' path. Must be utf-8 encoded.
-                                    The first item of the relative path must not start
-                                    with ''..'''
-                                  type: string
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, requests.cpu and requests.memory)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                              required:
-                              - path
-                              type: object
-                            type: array
-                        type: object
-                      emptyDir:
-                        description: 'EmptyDir represents a temporary directory that
-                          shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        properties:
-                          medium:
-                            description: 'What type of storage medium should back
-                              this directory. The default is "" which means to use
-                              the node''s default medium. Must be an empty string
-                              (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                            type: string
-                          sizeLimit:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Total amount of local storage required for
-                              this EmptyDir volume. The size limit is also applicable
-                              for memory medium. The maximum usage on memory medium
-                              EmptyDir would be the minimum value between the SizeLimit
-                              specified here and the sum of memory limits of all containers
-                              in a pod. The default is nil which means that the limit
-                              is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                        type: object
-                      ephemeral:
-                        description: "Ephemeral represents a volume that is handled
-                          by a cluster storage driver (Alpha feature). The volume's
-                          lifecycle is tied to the pod that defines it - it will be
-                          created before the pod starts, and deleted when the pod
-                          is removed. \n Use this if: a) the volume is only needed
-                          while the pod runs, b) features of normal volumes like restoring
-                          from snapshot or capacity    tracking are needed, c) the
-                          storage driver is specified through a storage class, and
-                          d) the storage driver supports dynamic volume provisioning
-                          through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                          for more    information on the connection between this volume
-                          type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                          or one of the vendor-specific APIs for volumes that persist
-                          for longer than the lifecycle of an individual pod. \n Use
-                          CSI for light-weight local ephemeral volumes if the CSI
-                          driver is meant to be used that way - see the documentation
-                          of the driver for more information. \n A pod can use both
-                          types of ephemeral volumes and persistent volumes at the
-                          same time."
-                        properties:
-                          readOnly:
-                            description: Specifies a read-only configuration for the
-                              volume. Defaults to false (read/write).
-                            type: boolean
-                          volumeClaimTemplate:
-                            description: "Will be used to create a stand-alone PVC
-                              to provision the volume. The pod in which this EphemeralVolumeSource
-                              is embedded will be the owner of the PVC, i.e. the PVC
-                              will be deleted together with the pod.  The name of
-                              the PVC will be `<pod name>-<volume name>` where `<volume
-                              name>` is the name from the `PodSpec.Volumes` array
-                              entry. Pod validation will reject the pod if the concatenated
-                              name is not valid for a PVC (for example, too long).
-                              \n An existing PVC with that name that is not owned
-                              by the pod will *not* be used for the pod to avoid using
-                              an unrelated volume by mistake. Starting the pod is
-                              then blocked until the unrelated PVC is removed. If
-                              such a pre-created PVC is meant to be used by the pod,
-                              the PVC has to updated with an owner reference to the
-                              pod once the pod exists. Normally this should not be
-                              necessary, but it may be useful when manually reconstructing
-                              a broken cluster. \n This field is read-only and no
-                              changes will be made by Kubernetes to the PVC after
-                              it has been created. \n Required, must not be nil."
-                            properties:
-                              metadata:
-                                description: May contain labels and annotations that
-                                  will be copied into the PVC when creating it. No
-                                  other fields are allowed and will be rejected during
-                                  validation.
-                                type: object
-                              spec:
-                                description: The specification for the PersistentVolumeClaim.
-                                  The entire content is copied unchanged into the
-                                  PVC that gets created from this template. The same
-                                  fields as in a PersistentVolumeClaim are also valid
-                                  here.
-                                properties:
-                                  accessModes:
-                                    description: 'AccessModes contains the desired
-                                      access modes the volume should have. More info:
-                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                    items:
-                                      type: string
-                                    type: array
-                                  dataSource:
-                                    description: 'This field can be used to specify
-                                      either: * An existing VolumeSnapshot object
-                                      (snapshot.storage.k8s.io/VolumeSnapshot) * An
-                                      existing PVC (PersistentVolumeClaim) * An existing
-                                      custom resource that implements data population
-                                      (Alpha) In order to use custom resource types
-                                      that implement data population, the AnyVolumeDataSource
-                                      feature gate must be enabled. If the provisioner
-                                      or an external controller can support the specified
-                                      data source, it will create a new volume based
-                                      on the contents of the specified data source.'
-                                    properties:
-                                      apiGroup:
-                                        description: APIGroup is the group for the
-                                          resource being referenced. If APIGroup is
-                                          not specified, the specified Kind must be
-                                          in the core API group. For any other third-party
-                                          types, APIGroup is required.
-                                        type: string
-                                      kind:
-                                        description: Kind is the type of resource
-                                          being referenced
-                                        type: string
-                                      name:
-                                        description: Name is the name of resource
-                                          being referenced
-                                        type: string
-                                    required:
-                                    - kind
-                                    - name
-                                    type: object
-                                  resources:
-                                    description: 'Resources represents the minimum
-                                      resources the volume should have. More info:
-                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                    properties:
-                                      limits:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                        type: object
-                                      requests:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                        type: object
-                                    type: object
-                                  selector:
-                                    description: A label query over volumes to consider
-                                      for binding.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  storageClassName:
-                                    description: 'Name of the StorageClass required
-                                      by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                    type: string
-                                  volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
-                                    type: string
-                                  volumeName:
-                                    description: VolumeName is the binding reference
-                                      to the PersistentVolume backing this claim.
-                                    type: string
-                                type: object
-                            required:
-                            - spec
-                            type: object
-                        type: object
-                      fc:
-                        description: FC represents a Fibre Channel resource that is
-                          attached to a kubelet's host machine and then exposed to
-                          the pod.
-                        properties:
-                          fsType:
-                            description: 'Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              TODO: how do we prevent errors in the filesystem from
-                              compromising the machine'
-                            type: string
-                          lun:
-                            description: 'Optional: FC target lun number'
-                            format: int32
-                            type: integer
-                          readOnly:
-                            description: 'Optional: Defaults to false (read/write).
-                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                            type: boolean
-                          targetWWNs:
-                            description: 'Optional: FC target worldwide names (WWNs)'
-                            items:
-                              type: string
-                            type: array
-                          wwids:
-                            description: 'Optional: FC volume world wide identifiers
-                              (wwids) Either wwids or combination of targetWWNs and
-                              lun must be set, but not both simultaneously.'
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      flexVolume:
-                        description: FlexVolume represents a generic volume resource
-                          that is provisioned/attached using an exec based plugin.
-                        properties:
-                          driver:
-                            description: Driver is the name of the driver to use for
-                              this volume.
-                            type: string
-                          fsType:
-                            description: Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". The default filesystem depends on FlexVolume
-                              script.
-                            type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            description: 'Optional: Extra command options if any.'
-                            type: object
-                          readOnly:
-                            description: 'Optional: Defaults to false (read/write).
-                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                            type: boolean
-                          secretRef:
-                            description: 'Optional: SecretRef is reference to the
-                              secret object containing sensitive information to pass
-                              to the plugin scripts. This may be empty if no secret
-                              object is specified. If the secret object contains more
-                              than one secret, all secrets are passed to the plugin
-                              scripts.'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      flocker:
-                        description: Flocker represents a Flocker volume attached
-                          to a kubelet's host machine. This depends on the Flocker
-                          control service being running
-                        properties:
-                          datasetName:
-                            description: Name of the dataset stored as metadata ->
-                              name on the dataset for Flocker should be considered
-                              as deprecated
-                            type: string
-                          datasetUUID:
-                            description: UUID of the dataset. This is unique identifier
-                              of a Flocker dataset
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        description: 'GCEPersistentDisk represents a GCE Disk resource
-                          that is attached to a kubelet''s host machine and then exposed
-                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        properties:
-                          fsType:
-                            description: 'Filesystem type of the volume that you want
-                              to mount. Tip: Ensure that the filesystem type is supported
-                              by the host operating system. Examples: "ext4", "xfs",
-                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              TODO: how do we prevent errors in the filesystem from
-                              compromising the machine'
-                            type: string
-                          partition:
-                            description: 'The partition in the volume that you want
-                              to mount. If omitted, the default is to mount by volume
-                              name. Examples: For volume /dev/sda1, you specify the
-                              partition as "1". Similarly, the volume partition for
-                              /dev/sda is "0" (or you can leave the property empty).
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            format: int32
-                            type: integer
-                          pdName:
-                            description: 'Unique name of the PD resource in GCE. Used
-                              to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            type: string
-                          readOnly:
-                            description: 'ReadOnly here will force the ReadOnly setting
-                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            type: boolean
-                        required:
-                        - pdName
-                        type: object
-                      gitRepo:
-                        description: 'GitRepo represents a git repository at a particular
-                          revision. DEPRECATED: GitRepo is deprecated. To provision
-                          a container with a git repo, mount an EmptyDir into an InitContainer
-                          that clones the repo using git, then mount the EmptyDir
-                          into the Pod''s container.'
-                        properties:
-                          directory:
-                            description: Target directory name. Must not contain or
-                              start with '..'.  If '.' is supplied, the volume directory
-                              will be the git repository.  Otherwise, if specified,
-                              the volume will contain the git repository in the subdirectory
-                              with the given name.
-                            type: string
-                          repository:
-                            description: Repository URL
-                            type: string
-                          revision:
-                            description: Commit hash for the specified revision.
-                            type: string
-                        required:
-                        - repository
-                        type: object
-                      glusterfs:
-                        description: 'Glusterfs represents a Glusterfs mount on the
-                          host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                        properties:
-                          endpoints:
-                            description: 'EndpointsName is the endpoint name that
-                              details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                            type: string
-                          path:
-                            description: 'Path is the Glusterfs volume path. More
-                              info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                            type: string
-                          readOnly:
-                            description: 'ReadOnly here will force the Glusterfs volume
-                              to be mounted with read-only permissions. Defaults to
-                              false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                            type: boolean
-                        required:
-                        - endpoints
-                        - path
-                        type: object
-                      hostPath:
-                        description: 'HostPath represents a pre-existing file or directory
-                          on the host machine that is directly exposed to the container.
-                          This is generally used for system agents or other privileged
-                          things that are allowed to see the host machine. Most containers
-                          will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                          --- TODO(jonesdl) We need to restrict who can use host directory
-                          mounts and who can/can not mount host directories as read/write.'
-                        properties:
-                          path:
-                            description: 'Path of the directory on the host. If the
-                              path is a symlink, it will follow the link to the real
-                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                            type: string
-                          type:
-                            description: 'Type for HostPath Volume Defaults to ""
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                            type: string
-                        required:
-                        - path
-                        type: object
-                      iscsi:
-                        description: 'ISCSI represents an ISCSI Disk resource that
-                          is attached to a kubelet''s host machine and then exposed
-                          to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                        properties:
-                          chapAuthDiscovery:
-                            description: whether support iSCSI Discovery CHAP authentication
-                            type: boolean
-                          chapAuthSession:
-                            description: whether support iSCSI Session CHAP authentication
-                            type: boolean
-                          fsType:
-                            description: 'Filesystem type of the volume that you want
-                              to mount. Tip: Ensure that the filesystem type is supported
-                              by the host operating system. Examples: "ext4", "xfs",
-                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                              TODO: how do we prevent errors in the filesystem from
-                              compromising the machine'
-                            type: string
-                          initiatorName:
-                            description: Custom iSCSI Initiator Name. If initiatorName
-                              is specified with iscsiInterface simultaneously, new
-                              iSCSI interface <target portal>:<volume name> will be
-                              created for the connection.
-                            type: string
-                          iqn:
-                            description: Target iSCSI Qualified Name.
-                            type: string
-                          iscsiInterface:
-                            description: iSCSI Interface Name that uses an iSCSI transport.
-                              Defaults to 'default' (tcp).
-                            type: string
-                          lun:
-                            description: iSCSI Target Lun number.
-                            format: int32
-                            type: integer
-                          portals:
-                            description: iSCSI Target Portal List. The portal is either
-                              an IP or ip_addr:port if the port is other than default
-                              (typically TCP ports 860 and 3260).
-                            items:
-                              type: string
-                            type: array
-                          readOnly:
-                            description: ReadOnly here will force the ReadOnly setting
-                              in VolumeMounts. Defaults to false.
-                            type: boolean
-                          secretRef:
-                            description: CHAP Secret for iSCSI target and initiator
-                              authentication
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          targetPortal:
-                            description: iSCSI Target Portal. The Portal is either
-                              an IP or ip_addr:port if the port is other than default
-                              (typically TCP ports 860 and 3260).
-                            type: string
-                        required:
-                        - iqn
-                        - lun
-                        - targetPortal
-                        type: object
-                      name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique
-                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      nfs:
-                        description: 'NFS represents an NFS mount on the host that
-                          shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        properties:
-                          path:
-                            description: 'Path that is exported by the NFS server.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                            type: string
-                          readOnly:
-                            description: 'ReadOnly here will force the NFS export
-                              to be mounted with read-only permissions. Defaults to
-                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                            type: boolean
-                          server:
-                            description: 'Server is the hostname or IP address of
-                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                            type: string
-                        required:
-                        - path
-                        - server
-                        type: object
-                      persistentVolumeClaim:
-                        description: 'PersistentVolumeClaimVolumeSource represents
-                          a reference to a PersistentVolumeClaim in the same namespace.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          claimName:
-                            description: 'ClaimName is the name of a PersistentVolumeClaim
-                              in the same namespace as the pod using this volume.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            type: string
-                          readOnly:
-                            description: Will force the ReadOnly setting in VolumeMounts.
-                              Default false.
-                            type: boolean
-                        required:
-                        - claimName
-                        type: object
-                      photonPersistentDisk:
-                        description: PhotonPersistentDisk represents a PhotonController
-                          persistent disk attached and mounted on kubelets host machine
-                        properties:
-                          fsType:
-                            description: Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          pdID:
-                            description: ID that identifies Photon Controller persistent
-                              disk
-                            type: string
-                        required:
-                        - pdID
-                        type: object
-                      portworxVolume:
-                        description: PortworxVolume represents a portworx volume attached
-                          and mounted on kubelets host machine
-                        properties:
-                          fsType:
-                            description: FSType represents the filesystem type to
-                              mount Must be a filesystem type supported by the host
-                              operating system. Ex. "ext4", "xfs". Implicitly inferred
-                              to be "ext4" if unspecified.
-                            type: string
-                          readOnly:
-                            description: Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          volumeID:
-                            description: VolumeID uniquely identifies a Portworx volume
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      projected:
-                        description: Items for all in one resources secrets, configmaps,
-                          and downward API
-                        properties:
-                          defaultMode:
-                            description: Mode bits used to set permissions on created
-                              files by default. Must be an octal value between 0000
-                              and 0777 or a decimal value between 0 and 511. YAML
-                              accepts both octal and decimal values, JSON requires
-                              decimal values for mode bits. Directories within the
-                              path are not affected by this setting. This might be
-                              in conflict with other options that affect the file
-                              mode, like fsGroup, and the result can be other mode
-                              bits set.
-                            format: int32
-                            type: integer
-                          sources:
-                            description: list of volume projections
-                            items:
-                              description: Projection that may be projected along
-                                with other supported volume types
-                              properties:
-                                configMap:
-                                  description: information about the configMap data
-                                    to project
-                                  properties:
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file. Must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its keys must be defined
-                                      type: boolean
-                                  type: object
-                                downwardAPI:
-                                  description: information about the downwardAPI data
-                                    to project
-                                  properties:
-                                    items:
-                                      description: Items is a list of DownwardAPIVolume
-                                        file
-                                      items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
-                                        properties:
-                                          fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
-                                            properties:
-                                              apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
-                                                type: string
-                                              fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
-                                            type: string
-                                          resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
-                                            properties:
-                                              containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                description: 'Required: resource to
-                                                  select'
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                        required:
-                                        - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                secret:
-                                  description: information about the secret data to
-                                    project
-                                  properties:
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file. Must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  type: object
-                                serviceAccountToken:
-                                  description: information about the serviceAccountToken
-                                    data to project
-                                  properties:
-                                    audience:
-                                      description: Audience is the intended audience
-                                        of the token. A recipient of a token must
-                                        identify itself with an identifier specified
-                                        in the audience of the token, and otherwise
-                                        should reject the token. The audience defaults
-                                        to the identifier of the apiserver.
-                                      type: string
-                                    expirationSeconds:
-                                      description: ExpirationSeconds is the requested
-                                        duration of validity of the service account
-                                        token. As the token approaches expiration,
-                                        the kubelet volume plugin will proactively
-                                        rotate the service account token. The kubelet
-                                        will start trying to rotate the token if the
-                                        token is older than 80 percent of its time
-                                        to live or if the token is older than 24 hours.Defaults
-                                        to 1 hour and must be at least 10 minutes.
-                                      format: int64
-                                      type: integer
-                                    path:
-                                      description: Path is the path relative to the
-                                        mount point of the file to project the token
-                                        into.
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                      quobyte:
-                        description: Quobyte represents a Quobyte mount on the host
-                          that shares a pod's lifetime
-                        properties:
-                          group:
-                            description: Group to map volume access to Default is
-                              no group
-                            type: string
-                          readOnly:
-                            description: ReadOnly here will force the Quobyte volume
-                              to be mounted with read-only permissions. Defaults to
-                              false.
-                            type: boolean
-                          registry:
-                            description: Registry represents a single or multiple
-                              Quobyte Registry services specified as a string as host:port
-                              pair (multiple entries are separated with commas) which
-                              acts as the central registry for volumes
-                            type: string
-                          tenant:
-                            description: Tenant owning the given Quobyte volume in
-                              the Backend Used with dynamically provisioned Quobyte
-                              volumes, value is set by the plugin
-                            type: string
-                          user:
-                            description: User to map volume access to Defaults to
-                              serivceaccount user
-                            type: string
-                          volume:
-                            description: Volume is a string that references an already
-                              created Quobyte volume by name.
-                            type: string
-                        required:
-                        - registry
-                        - volume
-                        type: object
-                      rbd:
-                        description: 'RBD represents a Rados Block Device mount on
-                          the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                        properties:
-                          fsType:
-                            description: 'Filesystem type of the volume that you want
-                              to mount. Tip: Ensure that the filesystem type is supported
-                              by the host operating system. Examples: "ext4", "xfs",
-                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                              TODO: how do we prevent errors in the filesystem from
-                              compromising the machine'
-                            type: string
-                          image:
-                            description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                          keyring:
-                            description: 'Keyring is the path to key ring for RBDUser.
-                              Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                          monitors:
-                            description: 'A collection of Ceph monitors. More info:
-                              https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            description: 'The rados pool name. Default is rbd. More
-                              info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                          readOnly:
-                            description: 'ReadOnly here will force the ReadOnly setting
-                              in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: boolean
-                          secretRef:
-                            description: 'SecretRef is name of the authentication
-                              secret for RBDUser. If provided overrides keyring. Default
-                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          user:
-                            description: 'The rados user name. Default is admin. More
-                              info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                        required:
-                        - image
-                        - monitors
-                        type: object
-                      scaleIO:
-                        description: ScaleIO represents a ScaleIO persistent volume
-                          attached and mounted on Kubernetes nodes.
-                        properties:
-                          fsType:
-                            description: Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". Default is "xfs".
-                            type: string
-                          gateway:
-                            description: The host address of the ScaleIO API Gateway.
-                            type: string
-                          protectionDomain:
-                            description: The name of the ScaleIO Protection Domain
-                              for the configured storage.
-                            type: string
-                          readOnly:
-                            description: Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          secretRef:
-                            description: SecretRef references to the secret for ScaleIO
-                              user and other sensitive information. If this is not
-                              provided, Login operation will fail.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          sslEnabled:
-                            description: Flag to enable/disable SSL communication
-                              with Gateway, default false
-                            type: boolean
-                          storageMode:
-                            description: Indicates whether the storage for a volume
-                              should be ThickProvisioned or ThinProvisioned. Default
-                              is ThinProvisioned.
-                            type: string
-                          storagePool:
-                            description: The ScaleIO Storage Pool associated with
-                              the protection domain.
-                            type: string
-                          system:
-                            description: The name of the storage system as configured
-                              in ScaleIO.
-                            type: string
-                          volumeName:
-                            description: The name of a volume already created in the
-                              ScaleIO system that is associated with this volume source.
-                            type: string
-                        required:
-                        - gateway
-                        - secretRef
-                        - system
-                        type: object
-                      secret:
-                        description: 'Secret represents a secret that should populate
-                          this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the Secret, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          optional:
-                            description: Specify whether the Secret or its keys must
-                              be defined
-                            type: boolean
-                          secretName:
-                            description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
-                      storageos:
-                        description: StorageOS represents a StorageOS volume attached
-                          and mounted on Kubernetes nodes.
-                        properties:
-                          fsType:
-                            description: Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          readOnly:
-                            description: Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          secretRef:
-                            description: SecretRef specifies the secret to use for
-                              obtaining the StorageOS API credentials.  If not specified,
-                              default values will be attempted.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                          volumeName:
-                            description: VolumeName is the human-readable name of
-                              the StorageOS volume.  Volume names are only unique
-                              within a namespace.
-                            type: string
-                          volumeNamespace:
-                            description: VolumeNamespace specifies the scope of the
-                              volume within StorageOS.  If no namespace is specified
-                              then the Pod's namespace will be used.  This allows
-                              the Kubernetes name scoping to be mirrored within StorageOS
-                              for tighter integration. Set VolumeName to any name
-                              to override the default behaviour. Set to "default"
-                              if you are not using namespaces within StorageOS. Namespaces
-                              that do not pre-exist within StorageOS will be created.
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        description: VsphereVolume represents a vSphere volume attached
-                          and mounted on kubelets host machine
-                        properties:
-                          fsType:
-                            description: Filesystem type to mount. Must be a filesystem
-                              type supported by the host operating system. Ex. "ext4",
-                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          storagePolicyID:
-                            description: Storage Policy Based Management (SPBM) profile
-                              ID associated with the StoragePolicyName.
-                            type: string
-                          storagePolicyName:
-                            description: Storage Policy Based Management (SPBM) profile
-                              name.
-                            type: string
-                          volumePath:
-                            description: Path that identifies vSphere volume vmdk
-                            type: string
-                        required:
-                        - volumePath
-                        type: object
                     required:
                     - name
                     type: object

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmprobes.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmprobes.yaml
@@ -186,6 +186,66 @@ spec:
                       description: Labels assigned to all metrics scraped from the
                         targets.
                       type: object
+                    relabelingConfigs:
+                      description: 'More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      items:
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of configuration.
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        properties:
+                          action:
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'
+                            type: string
+                          modulus:
+                            description: Modulus to take of the hash of the source
+                              label values.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
+                            type: string
+                          replacement:
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
+                            type: string
+                          separator:
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
+                            type: string
+                          source_labels:
+                            description: UnderScoreSourceLabels - additional form
+                              of source labels source_labels for compatibility with
+                              original relabel config. if set  both sourceLabels and
+                              source_labels, sourceLabels has priority. for details
+                              https://github.com/VictoriaMetrics/operator/issues/131
+                            items:
+                              type: string
+                            type: array
+                          sourceLabels:
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
+                            items:
+                              type: string
+                            type: array
+                          target_label:
+                            description: UnderScoreTargetLabel - additional form of
+                              target label - target_label for compatibility with original
+                              relabel config. if set  both targetLabel and target_label,
+                              targetLabel has priority. for details https://github.com/VictoriaMetrics/operator/issues/131
+                            type: string
+                          targetLabel:
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
                     targets:
                       description: Targets is a list of URLs to probe using the configured
                         prober.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmsingles.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmsingles.yaml
@@ -502,6 +502,283 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMSingle Pods.
               type: string
+            serviceSpec:
+              description: ServiceSpec that will be added to vmsingle service spec
+              properties:
+                metadata:
+                  description: EmbeddedObjectMetadata defines objectMeta for additional
+                    service.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations is an unstructured key value map stored
+                        with a resource that may be set by external tools to store
+                        and retrieve arbitrary metadata. They are not queryable and
+                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: 'Labels Map of string keys and values that can
+                        be used to organize and categorize (scope and select) objects.
+                        May match selectors of replication controllers and services.
+                        More info: http://kubernetes.io/docs/user-guide/labels'
+                      type: object
+                    name:
+                      description: 'Name must be unique within a namespace. Is required
+                        when creating resources, although some resources may allow
+                        a client to request the generation of an appropriate name
+                        automatically. Name is primarily intended for creation idempotence
+                        and configuration definition. Cannot be updated. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  type: object
+                spec:
+                  description: 'ServiceSpec describes the attributes that a user creates
+                    on a service. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                  properties:
+                    allocateLoadBalancerNodePorts:
+                      description: allocateLoadBalancerNodePorts defines if NodePorts
+                        will be automatically allocated for services with type LoadBalancer.  Default
+                        is "true". It may be set to "false" if the cluster load-balancer
+                        does not rely on NodePorts. allocateLoadBalancerNodePorts
+                        may only be set for services with type LoadBalancer and will
+                        be cleared if the type is changed to any other type. This
+                        field is alpha-level and is only honored by servers that enable
+                        the ServiceLBNodePortControl feature.
+                      type: boolean
+                    clusterIP:
+                      description: 'clusterIP is the IP address of the service and
+                        is usually assigned randomly. If an address is specified manually,
+                        is in-range (as per system configuration), and is not in use,
+                        it will be allocated to the service; otherwise creation of
+                        the service will fail. This field may not be changed through
+                        updates unless the type field is also being changed to ExternalName
+                        (which requires this field to be blank) or the type field
+                        is being changed from ExternalName (in which case this field
+                        may optionally be specified, as describe above).  Valid values
+                        are "None", empty string (""), or a valid IP address. Setting
+                        this to "None" makes a "headless service" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    clusterIPs:
+                      description: "ClusterIPs is a list of IP addresses assigned
+                        to this service, and are usually assigned randomly.  If an
+                        address is specified manually, is in-range (as per system
+                        configuration), and is not in use, it will be allocated to
+                        the service; otherwise creation of the service will fail.
+                        This field may not be changed through updates unless the type
+                        field is also being changed to ExternalName (which requires
+                        this field to be empty) or the type field is being changed
+                        from ExternalName (in which case this field may optionally
+                        be specified, as describe above).  Valid values are \"None\",
+                        empty string (\"\"), or a valid IP address.  Setting this
+                        to \"None\" makes a \"headless service\" (no virtual IP),
+                        which is useful when direct endpoint connections are preferred
+                        and proxying is not required.  Only applies to types ClusterIP,
+                        NodePort, and LoadBalancer. If this field is specified when
+                        creating a Service of type ExternalName, creation will fail.
+                        This field will be wiped when updating a Service to type ExternalName.
+                        \ If this field is not specified, it will be initialized from
+                        the clusterIP field.  If this field is specified, clients
+                        must ensure that clusterIPs[0] and clusterIP have the same
+                        value. \n Unless the \"IPv6DualStack\" feature gate is enabled,
+                        this field is limited to one value, which must be the same
+                        as the clusterIP field.  If the feature gate is enabled, this
+                        field may hold a maximum of two entries (dual-stack IPs, in
+                        either order).  These IPs must correspond to the values of
+                        the ipFamilies field. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    externalIPs:
+                      description: externalIPs is a list of IP addresses for which
+                        nodes in the cluster will also accept traffic for this service.  These
+                        IPs are not managed by Kubernetes.  The user is responsible
+                        for ensuring that traffic arrives at a node with this IP.  A
+                        common example is external load-balancers that are not part
+                        of the Kubernetes system.
+                      items:
+                        type: string
+                      type: array
+                    externalName:
+                      description: externalName is the external reference that discovery
+                        mechanisms will return as an alias for this service (e.g.
+                        a DNS CNAME record). No proxying will be involved.  Must be
+                        a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        and requires Type to be
+                      type: string
+                    externalTrafficPolicy:
+                      description: externalTrafficPolicy denotes if this Service desires
+                        to route external traffic to node-local or cluster-wide endpoints.
+                        "Local" preserves the client source IP and avoids a second
+                        hop for LoadBalancer and Nodeport type services, but risks
+                        potentially imbalanced traffic spreading. "Cluster" obscures
+                        the client source IP and may cause a second hop to another
+                        node, but should have good overall load-spreading.
+                      type: string
+                    healthCheckNodePort:
+                      description: healthCheckNodePort specifies the healthcheck nodePort
+                        for the service. This only applies when type is set to LoadBalancer
+                        and externalTrafficPolicy is set to Local. If a value is specified,
+                        is in-range, and is not in use, it will be used.  If not specified,
+                        a value will be automatically allocated.  External systems
+                        (e.g. load-balancers) can use this port to determine if a
+                        given node holds endpoints for this service or not.  If this
+                        field is specified when creating a Service which does not
+                        need it, creation will fail. This field will be wiped when
+                        updating a Service to no longer need it (e.g. changing type).
+                      format: int32
+                      type: integer
+                    ipFamilies:
+                      description: "IPFamilies is a list of IP families (e.g. IPv4,
+                        IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                        feature gate.  This field is usually assigned automatically
+                        based on cluster configuration and the ipFamilyPolicy field.
+                        If this field is specified manually, the requested family
+                        is available in the cluster, and ipFamilyPolicy allows it,
+                        it will be used; otherwise creation of the service will fail.
+                        \ This field is conditionally mutable: it allows for adding
+                        or removing a secondary IP family, but it does not allow changing
+                        the primary IP family of the Service.  Valid values are \"IPv4\"
+                        and \"IPv6\".  This field only applies to Services of types
+                        ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\"
+                        services.  This field will be wiped when updating a Service
+                        to type ExternalName. \n This field may hold a maximum of
+                        two entries (dual-stack families, in either order).  These
+                        families must correspond to the values of the clusterIPs field,
+                        if specified. Both clusterIPs and ipFamilies are governed
+                        by the ipFamilyPolicy field."
+                      items:
+                        description: IPFamily represents the IP Family (IPv4 or IPv6).
+                          This type is used to express the family of an IP expressed
+                          by a type (e.g. service.spec.ipFamilies).
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ipFamilyPolicy:
+                      description: IPFamilyPolicy represents the dual-stack-ness requested
+                        or required by this Service, and is gated by the "IPv6DualStack"
+                        feature gate.  If there is no value provided, then this field
+                        will be set to SingleStack. Services can be "SingleStack"
+                        (a single IP family), "PreferDualStack" (two IP families on
+                        dual-stack configured clusters or a single IP family on single-stack
+                        clusters), or "RequireDualStack" (two IP families on dual-stack
+                        configured clusters, otherwise fail). The ipFamilies and clusterIPs
+                        fields depend on the value of this field.  This field will
+                        be wiped when updating a service to type ExternalName.
+                      type: string
+                    loadBalancerIP:
+                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                        will get created with the IP specified in this field. This
+                        feature depends on whether the underlying cloud-provider supports
+                        specifying the loadBalancerIP when a load balancer is created.
+                        This field will be ignored if the cloud-provider does not
+                        support the feature.'
+                      type: string
+                    loadBalancerSourceRanges:
+                      description: 'If specified and supported by the platform, this
+                        will restrict traffic through the cloud-provider load-balancer
+                        will be restricted to the specified client IPs. This field
+                        will be ignored if the cloud-provider does not support the
+                        feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                      items:
+                        type: string
+                      type: array
+                    publishNotReadyAddresses:
+                      description: publishNotReadyAddresses indicates that any agent
+                        which deals with endpoints for this Service should disregard
+                        any indications of ready/not-ready. The primary use case for
+                        setting this field is for a StatefulSet's Headless Service
+                        to propagate SRV DNS records for its Pods for the purpose
+                        of peer discovery. The Kubernetes controllers that generate
+                        Endpoints and EndpointSlice resources for Services interpret
+                        this to mean that all endpoints are considered "ready" even
+                        if the Pods themselves are not. Agents which consume only
+                        Kubernetes generated endpoints through the Endpoints or EndpointSlice
+                        resources can safely assume this behavior.
+                      type: boolean
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: 'Route service traffic to pods with label keys
+                        and values matching this selector. If empty or not present,
+                        the service is assumed to have an external process managing
+                        its endpoints, which Kubernetes will not modify. Only applies
+                        to types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                        type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                      type: object
+                    sessionAffinity:
+                      description: 'Supports "ClientIP" and "None". Used to maintain
+                        session affinity. Enable client IP based session affinity.
+                        Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                      type: string
+                    sessionAffinityConfig:
+                      description: sessionAffinityConfig contains the configurations
+                        of session affinity.
+                      properties:
+                        clientIP:
+                          description: clientIP contains the configurations of Client
+                            IP based session affinity.
+                          properties:
+                            timeoutSeconds:
+                              description: timeoutSeconds specifies the seconds of
+                                ClientIP type session sticky time. The value must
+                                be >0 && <=86400(for 1 day) if ServiceAffinity ==
+                                "ClientIP". Default value is 10800(for 3 hours).
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    topologyKeys:
+                      description: topologyKeys is a preference-order list of topology
+                        keys which implementations of services should use to preferentially
+                        sort endpoints when accessing this Service, it can not be
+                        used at the same time as externalTrafficPolicy=Local. Topology
+                        keys must be valid label keys and at most 16 keys may be specified.
+                        Endpoints are chosen based on the first topology key with
+                        available backends. If this field is specified and all entries
+                        have no backends that match the topology of the client, the
+                        service has no backends for that client and connections should
+                        fail. The special value "*" may be used to mean "any topology".
+                        This catch-all value, if used, only makes sense as the last
+                        value in the list. If this is not specified or empty, no topology
+                        constraints will be applied. This field is alpha-level and
+                        is only honored by servers that enable the ServiceTopology
+                        feature.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: 'type determines how the Service is exposed. Defaults
+                        to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort,
+                        and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                        IP address for load-balancing to endpoints. Endpoints are
+                        determined by the selector or if that is not specified, by
+                        manual construction of an Endpoints object or EndpointSlice
+                        objects. If clusterIP is "None", no virtual IP is allocated
+                        and the endpoints are published as a set of endpoints rather
+                        than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                        a port on every node which routes to the same endpoints as
+                        the clusterIP. "LoadBalancer" builds on NodePort and creates
+                        an external load-balancer (if supported in the current cloud)
+                        which routes to the same endpoints as the clusterIP. "ExternalName"
+                        aliases this service to the specified externalName. Several
+                        other fields do not apply to ExternalName services. More info:
+                        https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                      type: string
+                  type: object
+              required:
+              - spec
+              type: object
             storage:
               description: Storage is the definition of how storage will be used by
                 the VMSingle by default it`s empty dir
@@ -680,6 +957,11 @@ spec:
             vmBackup:
               description: VMBackup configuration for backup
               properties:
+                acceptEULA:
+                  description: AcceptEULA accepts enterprise feature usage, must be
+                    set to true. otherwise backupmanager cannot be added to single/cluster
+                    version. https://victoriametrics.com/assets/VM_EULA.pdf
+                  type: boolean
                 concurrency:
                   description: Defines number of concurrent workers. Higher concurrency
                     may reduce backup duration (default 10)
@@ -893,6 +1175,8 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
+              required:
+              - acceptEULA
               type: object
             volumeMounts:
               description: VolumeMounts allows configuration of additional VolumeMounts

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmstaticscrapes.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmstaticscrapes.yaml
@@ -1,11 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
   name: vmstaticscrapes.operator.victoriametrics.com
 spec:
   group: operator.victoriametrics.com
@@ -19,8 +16,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: VMStaticScrape is the Schema for the vmstaticscrapes API, which
-        defines static targets configuration for scraping.
+      description: VMStaticScrape  defines static targets configuration for scraping.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -116,6 +112,14 @@ spec:
                     required:
                     - key
                     type: object
+                  honorLabels:
+                    description: HonorLabels chooses the metric's labels on collisions
+                      with target labels.
+                    type: boolean
+                  honorTimestamps:
+                    description: HonorTimestamps controls whether vmagent respects
+                      the timestamps present in scraped data.
+                    type: boolean
                   interval:
                     description: Interval at which metrics should be scraped
                     type: string
@@ -414,9 +418,3 @@ spec:
   - name: v1beta1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/monitoring/base/victoriametrics/upstream/rbac/role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/role.yaml
@@ -80,6 +80,13 @@ rules:
   verbs:
     - '*'
 - apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - '*'
+- apiGroups:
     - monitoring.coreos.com
   resources:
     - '*'
@@ -286,7 +293,9 @@ rules:
     - list
     - watch
 - apiGroups:
+    - extensions
     - "extensions"
+    - networking.k8s.io
     - "networking.k8s.io"
   resources:
     - ingresses
@@ -372,3 +381,11 @@ rules:
     - get
     - patch
     - update
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - list
+    - get
+    - watch

--- a/monitoring/base/victoriametrics/vmagent-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmagent-largeset.yaml
@@ -37,27 +37,5 @@ spec:
     requests:
       cpu: 100m
       memory: 200Mi
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          app.kubernetes.io/component: monitoring
-          app.kubernetes.io/instance: vmagent-largeset
-          app.kubernetes.io/name: vmagent
-          managed-by: vm-operator
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: vmagent-largeset
-  namespace: monitoring
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: vmagent-largeset
-      app.kubernetes.io/name: vmagent
-      managed-by: vm-operator
+  podDisruptionBudget:
+    minAvailable: 2

--- a/monitoring/base/victoriametrics/vmalert-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmalert-largeset.yaml
@@ -22,27 +22,5 @@ spec:
     requests:
       cpu: 100m
       memory: 200Mi
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          app.kubernetes.io/component: monitoring
-          app.kubernetes.io/instance: vmalert-largeset
-          app.kubernetes.io/name: vmalert
-          managed-by: vm-operator
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: vmalert-largeset
-  namespace: monitoring
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: vmalert-largeset
-      app.kubernetes.io/name: vmalert
-      managed-by: vm-operator
+  podDisruptionBudget:
+    minAvailable: 2

--- a/monitoring/base/victoriametrics/vmalertmanager-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmalertmanager-largeset.yaml
@@ -54,27 +54,5 @@ spec:
               # to satisfy rule1 and 2: vmsingle-smallset and vmalertmanager-largest are place in the different node.
               app.kubernetes.io/instance: vmsingle-smallset
               managed-by: vm-operator
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          app.kubernetes.io/component: monitoring
-          app.kubernetes.io/instance: vmalertmanager-largeset
-          app.kubernetes.io/name: vmalertmanager
-          managed-by: vm-operator
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: vmalertmanager-largeset
-  namespace: monitoring
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: vmalertmanager-largeset
-      app.kubernetes.io/name: vmalertmanager
-      managed-by: vm-operator
+  podDisruptionBudget:
+    minAvailable: 2

--- a/monitoring/base/victoriametrics/vmcluster-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmcluster-largeset.yaml
@@ -20,18 +20,19 @@ spec:
       requests:
         cpu: 100m
         memory: 500Mi
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/component: monitoring
-            app.kubernetes.io/instance: vmcluster-largeset
-            app.kubernetes.io/name: vmstorage
-            managed-by: vm-operator
+    podDisruptionBudget:
+      maxUnavailable: 1
     containers:
       - name: vmstorage
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8482
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
         startupProbe:
           httpGet:
             path: /health
@@ -48,16 +49,8 @@ spec:
       requests:
         cpu: 100m
         memory: 500Mi
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/component: monitoring
-            app.kubernetes.io/instance: vmcluster-largeset
-            app.kubernetes.io/name: vmselect
-            managed-by: vm-operator
+    podDisruptionBudget:
+      minAvailable: 2
 
     # the following volumes and volumeMounts should be removed eventually
     volumes:
@@ -75,55 +68,5 @@ spec:
       requests:
         cpu: 100m
         memory: 500Mi
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/component: monitoring
-            app.kubernetes.io/instance: vmcluster-largeset
-            app.kubernetes.io/name: vminsert
-            managed-by: vm-operator
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: vmstorage-vmcluster-largeset
-  namespace: monitoring
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: vmcluster-largeset
-      app.kubernetes.io/name: vmstorage
-      managed-by: vm-operator
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: vmselect-vmcluster-largeset
-  namespace: monitoring
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: vmcluster-largeset
-      app.kubernetes.io/name: vmselect
-      managed-by: vm-operator
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: vminsert-vmcluster-largeset
-  namespace: monitoring
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: vmcluster-largeset
-      app.kubernetes.io/name: vminsert
-      managed-by: vm-operator
+    podDisruptionBudget:
+      minAvailable: 2


### PR DESCRIPTION
This PR updates VictoriaMetrics operator from 0.10.0 to 0.12.2, and refines its manifests as follows.

* use embedded PodDisruptionBudget; introduced in 0.12.0
* remove `topologySpreadConstraints`s because they are duplicates of the default setting in Neco environment
  cf. https://github.com/cybozu-go/neco/blob/main/etc/cke-template.yml
* restore `livenessProbe` for vmstorage; removed in 0.12.1
* fix port name of vmalertmanager for scraping; changed in 0.11.0

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
