### PR TITLE
monitoring: Update high memory usage panel to use available bytes

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
+++ b/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
@@ -68,7 +68,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "(topk(10, (node_memory_MemTotal_bytes - node_memory_MemFree_bytes) / (node_memory_MemTotal_bytes ))) * 100",
+                        "expr": "(topk(10, 1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100",
                         "legendFormat": "{{instance}}",
                         "refId": "A"
                     }


### PR DESCRIPTION
The panel `Top 10 Nodes: High Memory Usage` in Grafana dashboard calculates the available bytes without omitting disk cache memory usage.
This PR fixes the configuration to use `node_memory_MemAvailable_bytes`, which is truly meaningful for node monitoring.
Signed-off-by: Hiroshi Muraoka <h.muraoka714@gmail.com>