### PR TITLE
monitoring: extend alerting threshold for smallset to 60m

### DIFF
--- a/monitoring/base/victoriametrics/rules/monitoring-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/monitoring-alertrule.yaml
@@ -43,7 +43,7 @@ spec:
           runbook: TBD
         expr: |
           absent(up{job="vmagent-smallset"} == 1)
-        for: 15m
+        for: 60m
         labels:
           severity: critical
       - alert: VMAlertSmallsetDown
@@ -52,7 +52,7 @@ spec:
           runbook: TBD
         expr: |
           absent(up{job="vmalert-smallset"} == 1)
-        for: 15m
+        for: 60m
         labels:
           severity: critical
       - alert: VMSingleSmallsetDown

--- a/test/vmalert_test/monitoring.yaml
+++ b/test/vmalert_test/monitoring.yaml
@@ -50,9 +50,9 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="vmagent-smallset"}'
-        values: '0+0x15'
+        values: '0+0x60'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 60m
         alertname: VMAgentSmallsetDown
         exp_alerts:
           - exp_labels:
@@ -63,9 +63,9 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="vmalert-smallset"}'
-        values: '0+0x15'
+        values: '0+0x60'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 60m
         alertname: VMAlertSmallsetDown
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
Currently, the alerting thresholds for some of the victoria-metrics smallset are set to 15m.
However, this is too short and alerts comes up if rebooting the node where the smallset pods are running takes more than 15m,
unnecessary alerts come up.

This PR extends the value to 60m to suppress the unnecessary alerts.
Signed-off-by: Hiroshi Muraoka <h.muraoka714@gmail.com>