### PR TITLE
Update manifests for k8s 1.20

### DIFF
--- a/argocd-config/base/prometheus-adapter.yaml
+++ b/argocd-config/base/prometheus-adapter.yaml
@@ -32,7 +32,7 @@ spec:
       values: |
         image:
           repository: quay.io/cybozu/prometheus-adapter
-          tag: 0.8.3.1
+          tag: 0.8.4.1
           pullPolicy: IfNotPresent
         
         # Url to access prometheus

--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -9,7 +9,7 @@ patchesStrategicMerge:
   - service.yaml
 images:
   - name: quay.io/cybozu/argocd
-    newTag: 1.8.3.3
+    newTag: 1.8.3.4
   - name: quay.io/cybozu/dex
     newTag: 2.27.0.2
   - name: quay.io/cybozu/redis

--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/deployment.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: bmc-reverse-proxy
     spec:
       containers:
-        - image: quay.io/cybozu/bmc-reverse-proxy:0.1.9
+        - image: quay.io/cybozu/bmc-reverse-proxy:0.1.12
           name: bmc-reverse-proxy
           volumeMounts:
           - name: secret-fs

--- a/bmc-reverse-proxy/base/machines-endpoints/cronjob.yaml
+++ b/bmc-reverse-proxy/base/machines-endpoints/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
             - name: machines-endpoints
-              image: quay.io/cybozu/machines-endpoints:0.4.6
+              image: quay.io/cybozu/machines-endpoints:0.4.9
               args:
                 - --bmc-configmap
               imagePullPolicy: IfNotPresent

--- a/customer-egress/base/kustomization.yaml
+++ b/customer-egress/base/kustomization.yaml
@@ -8,4 +8,4 @@ images:
   - name: quay.io/cybozu/squid
     newTag: 4.14.1
   - name: quay.io/cybozu/unbound
-    newTag: 1.13.0.1
+    newTag: 1.13.1.1

--- a/ingress/base/bastion/deployment.yaml
+++ b/ingress/base/bastion/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         name: contour
       - args:
         - --ingress-class-name=bastion
-        env:
-        - name: CP_SERVICE_NAME
-          value: ingress-bastion/envoy
+        - --service-name=ingress-bastion/envoy
+        - --default-issuer-name=clouddns
+        - --zap-stacktrace-level=panic
         name: contour-plus

--- a/ingress/base/contour/01-contour-config.yaml
+++ b/ingress/base/contour/01-contour-config.yaml
@@ -11,17 +11,32 @@ data:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
     #
+    # Specify the gateway-api Gateway Contour should watch.
+    # gateway:
+    #   name: contour
+    #   namespace: projectcontour
+    #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #
     # path to kubeconfig (if not running inside a k8s cluster)
     # kubeconfig: /path/to/.kube/config
     #
-    # disable HTTPProxy permitInsecure field
+    # Disable RFC-compliant behavior to strip "Content-Length" header if
+    # "Tranfer-Encoding: chunked" is also set.
+    # disableAllowChunkedLength: false
+    # Disable HTTPProxy permitInsecure field
     disablePermitInsecure: false
     tls:
     # minimum TLS version that Contour will negotiate
-    # minimum-protocol-version: "1.1"
+    # minimum-protocol-version: "1.2"
+    # TLS ciphers to be supported by Envoy TLS listeners when negotiating
+    # TLS 1.2.
+    # cipher-suites:
+    # - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+    # - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+    # - 'ECDHE-ECDSA-AES256-GCM-SHA384'
+    # - 'ECDHE-RSA-AES256-GCM-SHA384'
     # Defines the Kubernetes name/namespace matching a secret to use
     # as the fallback certificate when requests which don't match the
     # SNI defined for a vhost.
@@ -77,6 +92,7 @@ data:
     #   connection-idle-timeout: 60s
     #   stream-idle-timeout: 5m
     #   max-connection-duration: infinity
+    #   delayed-close-timeout: 1s
     #   connection-shutdown-grace-period: 5s
     #
     # Envoy cluster settings.
@@ -84,3 +100,45 @@ data:
     #   configure the cluster dns lookup family
     #   valid options are: auto (default), v4, v6
     #   dns-lookup-family: auto
+    #
+    # Envoy network settings.
+    # network:
+    #   Configure the number of additional ingress proxy hops from the
+    #   right side of the x-forwarded-for HTTP header to trust.
+    #   num-trusted-hops: 0
+    #
+    # Configure an optional global rate limit service.
+    # rateLimitService:
+    #   Identifies the extension service defining the rate limit service,
+    #   formatted as <namespace>/<name>.
+    #   extensionService: projectcontour/ratelimit
+    #   Defines the rate limit domain to pass to the rate limit service.
+    #   Acts as a container for a set of rate limit definitions within
+    #   the RLS.
+    #   domain: contour
+    #   Defines whether to allow requests to proceed when the rate limit
+    #   service fails to respond with a valid rate limit decision within
+    #   the timeout defined on the extension service.
+    #   failOpen: false
+    #   Defines whether to include the X-RateLimit headers X-RateLimit-Limit,
+    #   X-RateLimit-Remaining, and X-RateLimit-Reset (as defined by the IETF
+    #   Internet-Draft linked below), on responses to clients when the Rate
+    #   Limit Service is consulted for a request.
+    #   ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html
+    #   enableXRateLimitHeaders: false
+    #
+    # Global Policy settings.
+    # policy:
+    #   # Default headers to set on all requests (unless set/removed on the HTTPProxy object itself)
+    #   request-headers:
+    #     set:
+    #       # example: the hostname of the Envoy instance that proxied the request
+    #       X-Envoy-Hostname: %HOSTNAME%
+    #       # example: add a l5d-dst-override header to instruct Linkerd what service the request is destined for
+    #       l5d-dst-override: %CONTOUR_SERVICE_NAME%.%CONTOUR_NAMESPACE%.svc.cluster.local:%CONTOUR_SERVICE_PORT%
+    #   # default headers to set on all responses (unless set/removed on the HTTPProxy object itself)
+    #   response-headers:
+    #     set:
+    #       # example: Envoy flags that provide additional details about the response or connection
+    #       X-Envoy-Response-Flags: %RESPONSE_FLAGS%
+    #

--- a/ingress/base/contour/01-crds.yaml
+++ b/ingress/base/contour/01-crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: extensionservices.projectcontour.io
 spec:
@@ -36,14 +36,32 @@ spec:
             description: ExtensionServiceSpec defines the desired state of an ExtensionService resource.
             properties:
               loadBalancerPolicy:
-                description: The policy for load balancing GRPC service requests. Note that the `Cookie` load balancing strategy cannot be used here.
+                description: The policy for load balancing GRPC service requests. Note that the `Cookie` and `RequestHash` load balancing strategies cannot be used here.
                 properties:
+                  requestHashPolicies:
+                    description: RequestHashPolicies contains a list of hash policies to apply when the `RequestHash` load balancing strategy is chosen. If an element of the supplied list of hash policies is invalid, it will be ignored. If the list of hash policies is empty after validation, the load balancing strategy will fall back the the default `RoundRobin`.
+                    items:
+                      description: RequestHashPolicy contains configuration for an individual hash policy on a request attribute.
+                      properties:
+                        headerHashOptions:
+                          description: HeaderHashOptions should be set when request header hash based load balancing is desired. It must be the only hash option field set, otherwise this request hash policy object will be ignored.
+                          properties:
+                            headerName:
+                              description: HeaderName is the name of the HTTP request header that will be used to calculate the hash key. If the header specified is not present on a request, no hash will be produced.
+                              minLength: 1
+                              type: string
+                          type: object
+                        terminal:
+                          description: Terminal is a flag that allows for short-circuiting computing of a hash for a given request. If set to true, and the request attribute specified in the attribute hash options is present, no further hash policies will be used to calculate a hash for the request.
+                          type: boolean
+                      type: object
+                    type: array
                   strategy:
-                    description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                    description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
                     type: string
                 type: object
               protocol:
-                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
                 enum:
                 - h2
                 - h2c
@@ -240,7 +258,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: httpproxies.projectcontour.io
 spec:
@@ -425,8 +443,26 @@ spec:
                     loadBalancerPolicy:
                       description: The load balancing policy for this route.
                       properties:
+                        requestHashPolicies:
+                          description: RequestHashPolicies contains a list of hash policies to apply when the `RequestHash` load balancing strategy is chosen. If an element of the supplied list of hash policies is invalid, it will be ignored. If the list of hash policies is empty after validation, the load balancing strategy will fall back the the default `RoundRobin`.
+                          items:
+                            description: RequestHashPolicy contains configuration for an individual hash policy on a request attribute.
+                            properties:
+                              headerHashOptions:
+                                description: HeaderHashOptions should be set when request header hash based load balancing is desired. It must be the only hash option field set, otherwise this request hash policy object will be ignored.
+                                properties:
+                                  headerName:
+                                    description: HeaderName is the name of the HTTP request header that will be used to calculate the hash key. If the header specified is not present on a request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              terminal:
+                                description: Terminal is a flag that allows for short-circuiting computing of a hash for a given request. If set to true, and the request attribute specified in the attribute hash options is present, no further hash policies will be used to calculate a hash for the request.
+                                type: boolean
+                            type: object
+                          type: array
                         strategy:
-                          description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                          description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
                           type: string
                       type: object
                     pathRewritePolicy:
@@ -453,6 +489,103 @@ spec:
                     permitInsecure:
                       description: Allow this path to respond to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.
                       type: boolean
+                    rateLimitPolicy:
+                      description: The policy for rate limiting on the route.
+                      properties:
+                        global:
+                          description: Global defines global rate limiting parameters, i.e. parameters defining descriptors that are sent to an external rate limit service (RLS) for a rate limit decision on each request.
+                          properties:
+                            descriptors:
+                              description: Descriptors defines the list of descriptors that will be generated and sent to the rate limit service. Each descriptor contains 1+ key-value pair entries.
+                              items:
+                                description: RateLimitDescriptor defines a list of key-value pair generators.
+                                properties:
+                                  entries:
+                                    description: Entries is the list of key-value pair generators.
+                                    items:
+                                      description: RateLimitDescriptorEntry is a key-value pair generator. Exactly one field on this struct must be non-nil.
+                                      properties:
+                                        genericKey:
+                                          description: GenericKey defines a descriptor entry with a static key and value.
+                                          properties:
+                                            key:
+                                              description: Key defines the key of the descriptor entry. If not set, the key is set to "generic_key".
+                                              type: string
+                                            value:
+                                              description: Value defines the value of the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        remoteAddress:
+                                          description: RemoteAddress defines a descriptor entry with a key of "remote_address" and a value equal to the client's IP address (from x-forwarded-for).
+                                          type: object
+                                        requestHeader:
+                                          description: RequestHeader defines a descriptor entry that's populated only if a given header is present on the request. The descriptor key is static, and the descriptor value is equal to the value of the header.
+                                          properties:
+                                            descriptorKey:
+                                              description: DescriptorKey defines the key to use on the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                            headerName:
+                                              description: HeaderName defines the name of the header to look for on the request.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                type: object
+                              minItems: 1
+                              type: array
+                          type: object
+                        local:
+                          description: Local defines local rate limiting parameters, i.e. parameters for rate limiting that occurs within each Envoy pod as requests are handled.
+                          properties:
+                            burst:
+                              description: Burst defines the number of requests above the requests per unit that should be allowed within a short period of time.
+                              format: int32
+                              type: integer
+                            requests:
+                              description: Requests defines how many requests per unit of time should be allowed before rate limiting occurs.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            responseHeadersToAdd:
+                              description: ResponseHeadersToAdd is an optional list of response headers to set when a request is rate-limited.
+                              items:
+                                description: HeaderValue represents a header name/value pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            responseStatusCode:
+                              description: ResponseStatusCode is the HTTP status code to use for responses to rate-limited requests. Codes must be in the 400-599 range (inclusive). If not specified, the Envoy default of 429 (Too Many Requests) is used.
+                              format: int32
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            unit:
+                              description: Unit defines the period of time within which requests over the limit will be rate limited. Valid values are "second", "minute" and "hour".
+                              enum:
+                              - second
+                              - minute
+                              - hour
+                              type: string
+                          required:
+                          - requests
+                          - unit
+                          type: object
+                      type: object
                     requestHeadersPolicy:
                       description: The policy for managing request headers during proxying.
                       properties:
@@ -712,10 +845,28 @@ spec:
                     - name
                     type: object
                   loadBalancerPolicy:
-                    description: The load balancing policy for the backend services.
+                    description: The load balancing policy for the backend services. Note that the `Cookie` and `RequestHash` load balancing strategies cannot be used here.
                     properties:
+                      requestHashPolicies:
+                        description: RequestHashPolicies contains a list of hash policies to apply when the `RequestHash` load balancing strategy is chosen. If an element of the supplied list of hash policies is invalid, it will be ignored. If the list of hash policies is empty after validation, the load balancing strategy will fall back the the default `RoundRobin`.
+                        items:
+                          description: RequestHashPolicy contains configuration for an individual hash policy on a request attribute.
+                          properties:
+                            headerHashOptions:
+                              description: HeaderHashOptions should be set when request header hash based load balancing is desired. It must be the only hash option field set, otherwise this request hash policy object will be ignored.
+                              properties:
+                                headerName:
+                                  description: HeaderName is the name of the HTTP request header that will be used to calculate the hash key. If the header specified is not present on a request, no hash will be produced.
+                                  minLength: 1
+                                  type: string
+                              type: object
+                            terminal:
+                              description: Terminal is a flag that allows for short-circuiting computing of a hash for a given request. If set to true, and the request attribute specified in the attribute hash options is present, no further hash policies will be used to calculate a hash for the request.
+                              type: boolean
+                          type: object
+                        type: array
                       strategy:
-                        description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                        description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
                         type: string
                     type: object
                   services:
@@ -906,6 +1057,103 @@ spec:
                   fqdn:
                     description: The fully qualified domain name of the root of the ingress tree all leaves of the DAG rooted at this object relate to the fqdn.
                     type: string
+                  rateLimitPolicy:
+                    description: The policy for rate limiting on the virtual host.
+                    properties:
+                      global:
+                        description: Global defines global rate limiting parameters, i.e. parameters defining descriptors that are sent to an external rate limit service (RLS) for a rate limit decision on each request.
+                        properties:
+                          descriptors:
+                            description: Descriptors defines the list of descriptors that will be generated and sent to the rate limit service. Each descriptor contains 1+ key-value pair entries.
+                            items:
+                              description: RateLimitDescriptor defines a list of key-value pair generators.
+                              properties:
+                                entries:
+                                  description: Entries is the list of key-value pair generators.
+                                  items:
+                                    description: RateLimitDescriptorEntry is a key-value pair generator. Exactly one field on this struct must be non-nil.
+                                    properties:
+                                      genericKey:
+                                        description: GenericKey defines a descriptor entry with a static key and value.
+                                        properties:
+                                          key:
+                                            description: Key defines the key of the descriptor entry. If not set, the key is set to "generic_key".
+                                            type: string
+                                          value:
+                                            description: Value defines the value of the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        type: object
+                                      remoteAddress:
+                                        description: RemoteAddress defines a descriptor entry with a key of "remote_address" and a value equal to the client's IP address (from x-forwarded-for).
+                                        type: object
+                                      requestHeader:
+                                        description: RequestHeader defines a descriptor entry that's populated only if a given header is present on the request. The descriptor key is static, and the descriptor value is equal to the value of the header.
+                                        properties:
+                                          descriptorKey:
+                                            description: DescriptorKey defines the key to use on the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                          headerName:
+                                            description: HeaderName defines the name of the header to look for on the request.
+                                            minLength: 1
+                                            type: string
+                                        type: object
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                              type: object
+                            minItems: 1
+                            type: array
+                        type: object
+                      local:
+                        description: Local defines local rate limiting parameters, i.e. parameters for rate limiting that occurs within each Envoy pod as requests are handled.
+                        properties:
+                          burst:
+                            description: Burst defines the number of requests above the requests per unit that should be allowed within a short period of time.
+                            format: int32
+                            type: integer
+                          requests:
+                            description: Requests defines how many requests per unit of time should be allowed before rate limiting occurs.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          responseHeadersToAdd:
+                            description: ResponseHeadersToAdd is an optional list of response headers to set when a request is rate-limited.
+                            items:
+                              description: HeaderValue represents a header name/value pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          responseStatusCode:
+                            description: ResponseStatusCode is the HTTP status code to use for responses to rate-limited requests. Codes must be in the 400-599 range (inclusive). If not specified, the Envoy default of 429 (Too Many Requests) is used.
+                            format: int32
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          unit:
+                            description: Unit defines the period of time within which requests over the limit will be rate limited. Valid values are "second", "minute" and "hour".
+                            enum:
+                            - second
+                            - minute
+                            - hour
+                            type: string
+                        required:
+                        - requests
+                        - unit
+                        type: object
+                    type: object
                   tls:
                     description: If present the fields describes TLS properties of the virtual host. The SNI names that will be matched on are described in fqdn, the tls.secretName secret must contain a certificate that itself contains a name that matches the FQDN.
                     properties:
@@ -923,7 +1171,7 @@ spec:
                         description: EnableFallbackCertificate defines if the vhost should allow a default certificate to be applied which handles all requests which don't match the SNI defined in this vhost.
                         type: boolean
                       minimumProtocolVersion:
-                        description: Minimum TLS version this vhost should negotiate
+                        description: MinimumProtocolVersion is the minimum TLS version this vhost should negotiate. Valid options are `1.2` (default) and `1.3`. Any other value defaults to TLS 1.2.
                         type: string
                       passthrough:
                         description: Passthrough defines whether the encrypted TLS handshake will be passed through to the backing cluster. Either Passthrough or SecretName must be specified, but not both.
@@ -1072,6 +1320,29 @@ spec:
                         ip:
                           description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
                           type: string
+                        ports:
+                          description: Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use   CamelCase names - cloud provider specific error values must have names that comply with the   format foo.example.com/CamelCase. --- The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     type: array
                 type: object
@@ -1095,7 +1366,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: tlscertificatedelegations.projectcontour.io
 spec:

--- a/ingress/base/contour/02-job-certgen.yaml
+++ b/ingress/base/contour/02-job-certgen.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.11.0
+  name: contour-certgen-v1.14.1
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: contour
-        image: docker.io/projectcontour/contour:v1.11.0
+        image: docker.io/projectcontour/contour:v1.14.1
         imagePullPolicy: Always
         command:
         - contour

--- a/ingress/base/contour/02-role-contour.yaml
+++ b/ingress/base/contour/02-role-contour.yaml
@@ -28,6 +28,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
@@ -50,10 +58,7 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - gatewayclasses
-  - gateways
-  - httproutes
-  - tcproutes
+  - ingressclasses
   verbs:
   - get
   - list
@@ -74,6 +79,17 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies
+  - gateways
+  - httproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - projectcontour.io
   resources:

--- a/ingress/base/contour/02-service-envoy.yaml
+++ b/ingress/base/contour/02-service-envoy.yaml
@@ -18,9 +18,11 @@ spec:
   - port: 80
     name: http
     protocol: TCP
+    targetPort: 8080
   - port: 443
     name: https
     protocol: TCP
+    targetPort: 8443
   selector:
     app: envoy
   type: LoadBalancer

--- a/ingress/base/contour/03-contour.yaml
+++ b/ingress/base/contour/03-contour.yaml
@@ -40,14 +40,12 @@ spec:
         - --incluster
         - --xds-address=0.0.0.0
         - --xds-port=8001
-        - --envoy-service-http-port=80
-        - --envoy-service-https-port=443
         - --contour-cafile=/certs/ca.crt
         - --contour-cert-file=/certs/tls.crt
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.11.0
+        image: docker.io/projectcontour/contour:v1.14.1
         imagePullPolicy: Always
         name: contour
         ports:

--- a/ingress/base/contour/03-envoy.yaml
+++ b/ingress/base/contour/03-envoy.yaml
@@ -29,7 +29,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.11.0
+        image: docker.io/projectcontour/contour:v1.14.1
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -53,7 +53,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.16.2
+        image: docker.io/envoyproxy/envoy:v1.17.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:
@@ -68,11 +68,11 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           hostPort: 80
           name: http
           protocol: TCP
-        - containerPort: 443
+        - containerPort: 8443
           hostPort: 443
           name: https
           protocol: TCP
@@ -85,8 +85,10 @@ spec:
         volumeMounts:
           - name: envoy-config
             mountPath: /config
+            readOnly: true
           - name: envoycert
             mountPath: /certs
+            readOnly: true
         lifecycle:
           preStop:
             httpGet:
@@ -106,7 +108,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.11.0
+        image: docker.io/projectcontour/contour:v1.14.1
         imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:

--- a/ingress/base/forest/deployment.yaml
+++ b/ingress/base/forest/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         name: contour
       - args:
         - --ingress-class-name=forest
-        env:
-        - name: CP_SERVICE_NAME
-          value: ingress-forest/envoy
+        - --service-name=ingress-forest/envoy
+        - --default-issuer-name=clouddns
+        - --zap-stacktrace-level=panic
         name: contour-plus

--- a/ingress/base/global/deployment.yaml
+++ b/ingress/base/global/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         name: contour
       - args:
         - --ingress-class-name=global
-        env:
-        - name: CP_SERVICE_NAME
-          value: ingress-global/envoy
+        - --service-name=ingress-global/envoy
+        - --default-issuer-name=clouddns
+        - --zap-stacktrace-level=panic
         name: contour-plus

--- a/ingress/base/kustomization.yaml
+++ b/ingress/base/kustomization.yaml
@@ -11,8 +11,8 @@ patchesStrategicMerge:
   - patch/crd.yaml
 images:
   - name: quay.io/cybozu/contour
-    newTag: 1.11.0.1
+    newTag: 1.14.1.1
   - name: quay.io/cybozu/contour-plus
-    newTag: 0.6.0
+    newTag: 0.6.2
   - name: quay.io/cybozu/envoy
-    newTag: 1.16.2.1
+    newTag: 1.17.2.1

--- a/ingress/base/template/deployment-contour.yaml
+++ b/ingress/base/template/deployment-contour.yaml
@@ -39,8 +39,6 @@ spec:
         - --incluster
         - --xds-address=0.0.0.0
         - --xds-port=8001
-        - --envoy-service-http-port=8080
-        - --envoy-service-https-port=8443
         - --contour-cafile=/certs/ca.crt
         - --contour-cert-file=/certs/tls.crt
         - --contour-key-file=/certs/tls.key

--- a/ingress/base/template/deployment-contour.yaml
+++ b/ingress/base/template/deployment-contour.yaml
@@ -92,9 +92,6 @@ spec:
               command: ["sleep", "5"]
       - image: quay.io/cybozu/contour-plus
         name: contour-plus
-        env:
-        - name: CP_DEFAULT_ISSUER_NAME
-          value: clouddns
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       volumes:

--- a/ingress/base/template/deployment-envoy.yaml
+++ b/ingress/base/template/deployment-envoy.yaml
@@ -88,8 +88,10 @@ spec:
         volumeMounts:
           - name: envoy-config
             mountPath: /config
+            readOnly: true
           - name: envoycert
             mountPath: /certs
+            readOnly: true
         livenessProbe:
           httpGet:
             path: /
@@ -132,7 +134,6 @@ spec:
         volumeMounts:
         - name: envoy-config
           mountPath: /config
-          readOnly: true
         - name: envoycert
           mountPath: /certs
           readOnly: true

--- a/ingress/base/template/deployment-envoy.yaml
+++ b/ingress/base/template/deployment-envoy.yaml
@@ -132,6 +132,7 @@ spec:
         volumeMounts:
         - name: envoy-config
           mountPath: /config
+          readOnly: true
         - name: envoycert
           mountPath: /certs
           readOnly: true

--- a/ingress/base/template/rbac.yaml
+++ b/ingress/base/template/rbac.yaml
@@ -4,24 +4,27 @@ metadata:
   name: contour-leaderelection
   namespace: projectcontour
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - update
-  - patch
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kube-metrics-adapter/base/kustomization.yaml
+++ b/kube-metrics-adapter/base/kustomization.yaml
@@ -10,4 +10,4 @@ patchesStrategicMerge:
 images:
 - name: registry.opensource.zalan.do/teapot/kube-metrics-adapter
   newName: quay.io/cybozu/kube-metrics-adapter
-  newTag: 0.1.10.1
+  newTag: 0.1.10.2

--- a/local-pv-provisioner/base/daemonset.yaml
+++ b/local-pv-provisioner/base/daemonset.yaml
@@ -21,10 +21,11 @@ spec:
     spec:
       containers:
         - name: local-pv-provisioner
-          image: quay.io/cybozu/local-pv-provisioner:0.2.1
+          image: quay.io/cybozu/local-pv-provisioner:0.2.3
           imagePullPolicy: IfNotPresent
           args:
             - --device-dir=/dev/crypt-disk/by-path
+            - --zap-stacktrace-level=panic
           env:
             - name: LP_NODE_NAME
               valueFrom:

--- a/metallb/base/kustomization.yaml
+++ b/metallb/base/kustomization.yaml
@@ -8,7 +8,7 @@ patchesStrategicMerge:
 images:
 - name: metallb/speaker
   newName: quay.io/cybozu/metallb
-  newTag: 0.9.5.1
+  newTag: 0.9.6.1
 - name: metallb/controller
   newName: quay.io/cybozu/metallb
-  newTag: 0.9.5.1
+  newTag: 0.9.6.1

--- a/metallb/base/upstream/metallb.yaml
+++ b/metallb/base/upstream/metallb.yaml
@@ -313,7 +313,7 @@ spec:
             secretKeyRef:
               name: memberlist
               key: secretkey
-        image: metallb/speaker:v0.9.5
+        image: metallb/speaker:v0.9.6
         imagePullPolicy: Always
         name: speaker
         ports:
@@ -369,7 +369,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: metallb/controller:v0.9.5
+        image: metallb/controller:v0.9.6
         imagePullPolicy: Always
         name: controller
         ports:

--- a/monitoring/base/grafana-operator/dashboards/contour.yaml
+++ b/monitoring/base/grafana-operator/dashboards/contour.yaml
@@ -81,7 +81,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "avg(contour_httpproxy_total{namespace=~\"$Namespace\"}) by (namespace)",
+                        "expr": "avg(contour_httpproxy{namespace=~\"$Namespace\"}) by (namespace)",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,
@@ -173,7 +173,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "avg(contour_httpproxy_orphaned_total{namespace=~\"$Namespace\"}) by (namespace)",
+                        "expr": "avg(contour_httpproxy_orphaned{namespace=~\"$Namespace\"}) by (namespace)",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,
@@ -265,7 +265,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "avg(contour_httpproxy_valid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
+                        "expr": "avg(contour_httpproxy_valid{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,
@@ -357,7 +357,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "avg(contour_httpproxy_invalid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
+                        "expr": "avg(contour_httpproxy_invalid{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,
@@ -449,7 +449,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "avg(contour_httpproxy_root_total{namespace=~\"$Namespace\"}) by (namespace)",
+                        "expr": "avg(contour_httpproxy_root{namespace=~\"$Namespace\"}) by (namespace)",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 1,

--- a/monitoring/base/kube-state-metrics/cluster-role-binding.yaml
+++ b/monitoring/base/kube-state-metrics/cluster-role-binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.0.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/monitoring/base/kube-state-metrics/cluster-role.yaml
+++ b/monitoring/base/kube-state-metrics/cluster-role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.0.0
   name: kube-state-metrics
 rules:
 - apiGroups:
@@ -21,15 +21,6 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
   verbs:
   - list
   - watch

--- a/monitoring/base/kube-state-metrics/deployment.yaml
+++ b/monitoring/base/kube-state-metrics/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.0.0
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.0.0-beta
+        app.kubernetes.io/version: 2.0.0
     spec:
       containers:
-      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-beta
+      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/monitoring/base/kube-state-metrics/service-account.yaml
+++ b/monitoring/base/kube-state-metrics/service-account.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.0.0
   name: kube-state-metrics
   namespace: kube-system

--- a/monitoring/base/kube-state-metrics/service.yaml
+++ b/monitoring/base/kube-state-metrics/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-beta
+    app.kubernetes.io/version: 2.0.0
   name: kube-state-metrics
   namespace: kube-system
 spec:

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -27,7 +27,7 @@ images:
     newTag: 1.4.0.1
   - name: k8s.gcr.io/kube-state-metrics/kube-state-metrics
     newName: quay.io/cybozu/kube-state-metrics
-    newTag: 2.0.0-beta.1
+    newTag: 2.0.0.1
   - name: quay.io/integreatly/grafana-operator
     newName: quay.io/cybozu/grafana-operator
     newTag: 3.8.1.1

--- a/monitoring/base/machines-endpoints/cronjob.yaml
+++ b/monitoring/base/machines-endpoints/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
             - name: machines-endpoints
-              image: quay.io/cybozu/machines-endpoints:0.4.6
+              image: quay.io/cybozu/machines-endpoints:0.4.9
               args:
                 - --monitoring-endpoints
               imagePullPolicy: IfNotPresent

--- a/monitoring/base/patch-kube-state-metrics.yaml
+++ b/monitoring/base/patch-kube-state-metrics.yaml
@@ -10,5 +10,5 @@ spec:
       containers:
       - name: kube-state-metrics
         args:
-        - --labels-metric-allow-list
+        - --metric-labels-allowlist
         - namespaces=[team],nodes=[cke.cybozu.com/rack,cke.cybozu.com/role,cke.cybozu.com/master]

--- a/monitoring/base/victoriametrics/rules/ingress-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/ingress-alertrule.yaml
@@ -63,7 +63,7 @@ spec:
             runbook: Please consider to find root causes, and solve the problems
         - alert: InvalidHTTPProxyExist
           expr: |
-            contour_httpproxy_invalid_total
+            contour_httpproxy_invalid
             * on (namespace) group_left(label_team) kube_namespace_labels{label_team="neco"}
           labels:
             severity: error

--- a/neco-admission/base/kustomization.yaml
+++ b/neco-admission/base/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
       value: neco-admission
 images:
   - name: quay.io/cybozu/neco-admission
-    newTag: 0.9.0
+    newTag: 0.9.2

--- a/test/vmalert_test/ingress.yaml
+++ b/test/vmalert_test/ingress.yaml
@@ -30,7 +30,7 @@ tests:
               summary: Ingress has disappeared from Prometheus target discovery.
   - interval: 1m
     input_series:
-      - series: 'contour_httpproxy_invalid_total{kubernetes_namespace="ingress-global",namespace="ours",vhost="xxx"}'
+      - series: 'contour_httpproxy_invalid{kubernetes_namespace="ingress-global",namespace="ours",vhost="xxx"}'
         values: '1+0x10'
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: '1+0x10'
@@ -49,7 +49,7 @@ tests:
               runbook: Please check the status of HTTPProxy.
   - interval: 1m
     input_series:
-      - series: 'contour_httpproxy_invalid_total{kubernetes_namespace="ingress-global",namespace="others",vhost="xxx"}'
+      - series: 'contour_httpproxy_invalid{kubernetes_namespace="ingress-global",namespace="others",vhost="xxx"}'
         values: '1+0x10'
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: '1+0x10'


### PR DESCRIPTION
This PR updates manifest for k8s 1.20. It includes changes for the breaking changes as follows.

---
## kube-state-metrics

https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0-rc.1

[CHANGE] Rename --labels-metric-allow-list to --metric-labels-allowlist

---
## contour 

https://github.com/projectcontour/contour/releases/tag/v1.14.0

The following Prometheus Gauges have been removed in favor of Gauges added in Contour 1.13.0 with more idiomatic names. Any dashboard and alert queries referring to the old names must be updated to use the new metrics.

```
contour_httpproxy_total -> contour_httpproxy
contour_httpproxy_invalid_total  -> contour_httpproxy_invalid
contour_httpproxy_orphaned_total  -> contour_httpproxy_orphaned
contour_httpproxy_valid_total  -> contour_httpproxy_valid
contour_httpproxy_root_total  -> contour_httpproxy_root
```