### PR TITLE
deploy neco-tenant-apps to tokyo0 and osaka0

### DIFF
--- a/argocd-config/overlays/osaka0/kustomization.yaml
+++ b/argocd-config/overlays/osaka0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - maneki-apps.yaml
+- tenant-apps.yaml
 patchesStrategicMerge:
 - argocd-ingress.yaml
 - argocd.yaml

--- a/argocd-config/overlays/tokyo0/kustomization.yaml
+++ b/argocd-config/overlays/tokyo0/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - maneki-apps.yaml
+- tenant-apps.yaml
 patchesStrategicMerge:
 - argocd-ingress.yaml
 - argocd.yaml


### PR DESCRIPTION
This PR fixes a bug: `neco-tenant-apps` has not been deployed to tokyo0 and osaka0.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>