### PR TITLE
prometheus-adapter: narrow down metrics retrieval

### DIFF
--- a/argocd-config/base/prometheus-adapter.yaml
+++ b/argocd-config/base/prometheus-adapter.yaml
@@ -49,7 +49,59 @@ spec:
             memory: 128Mi
         
         rules:
-          default: true
+          default: false
+          custom:
+            - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+              seriesFilters: []
+              resources:
+                overrides:
+                  namespace:
+                    resource: namespace
+                  pod:
+                    resource: pod
+              name:
+                matches: ^container_(.*)_seconds_total$
+                as: ""
+              metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
+                by (<<.GroupBy>>)
+            - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+              seriesFilters:
+              - isNot: ^container_.*_seconds_total$
+              resources:
+                overrides:
+                  namespace:
+                    resource: namespace
+                  pod:
+                    resource: pod
+              name:
+                matches: ^container_(.*)_total$
+                as: ""
+              metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
+                by (<<.GroupBy>>)
+            - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+              seriesFilters:
+              - isNot: ^container_.*_total$
+              resources:
+                overrides:
+                  namespace:
+                    resource: namespace
+                  pod:
+                    resource: pod
+              name:
+                matches: ^container_(.*)$
+                as: ""
+              metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
+
+            # this is used for e2e test...
+            - seriesQuery: '{namespace="sandbox",__name__=~"^test_hpa_.*"}'
+              seriesFilters: []
+              resources:
+                template: <<.Resource>>
+              name:
+                matches: ""
+                as: ""
+              metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+
           resource:
             cpu:
               containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[3m])) by (<<.GroupBy>>)
@@ -75,7 +127,7 @@ spec:
                   pod:
                     resource: pod
               containerLabel: container
-            window: 3m        
+            window: 3m
         
         podDisruptionBudget:
           # Specifies if PodDisruptionBudget should be enabled


### PR DESCRIPTION
In order to avoid `__name__!~"^container_.*"` queries, which try to return too much metrics.

The upstream helm chart has no ability to enable `__name__=~"^container_.*"` queries and `__name__!~"^container_.*"` queries separately. We disable all of them and write `__name__=~"^container_.*"` queries as custom queries manually.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>