### PR TITLE
loki: enlarge disk size to avoid disk full for querier

### DIFF
--- a/logging/base/loki/main.jsonnet
+++ b/logging/base/loki/main.jsonnet
@@ -14,7 +14,13 @@ loki {
     boltdb_shipper_shared_store: 's3',
 
     ingester_pvc_class: 'ceph-ssd-block',
+
     querier_pvc_class: 'ceph-ssd-block',
+    // current index size is ~500MiB per day.
+    // by default 10Gi, querier becames disk full if searchs are executed for 20 days.
+    // I assume 100Gi is sufficient, it allows us to run query for 200 days.
+    querier_pvc_size: '100Gi',
+
     compactor_pvc_class: 'ceph-ssd-block',
 
     commonArgs+: {

--- a/logging/base/loki/upstream/apps-v1.StatefulSet-querier.yaml
+++ b/logging/base/loki/upstream/apps-v1.StatefulSet-querier.yaml
@@ -76,5 +76,5 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: 100Gi
       storageClassName: ceph-ssd-block

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -176,6 +176,15 @@ func testSetup() {
 			applyMutatingWebhooks()
 		}
 
+		// temporary code for #1428
+		// TODO: delete this block after #1428 is released
+		if doUpgrade {
+			ExecSafeAt(boot0, "argocd", "app", "set", "argocd-config", "--sync-policy", "none")
+			ExecSafeAt(boot0, "argocd", "app", "set", "logging", "--sync-policy", "none")
+			ExecSafeAt(boot0, "kubectl", "delete", "sts", "-n", "logging", "querier")
+			ExecSafeAt(boot0, "kubectl", "delete", "pvc", "-n", "logging", "-lname=querier")
+		}
+
 		ExecSafeAt(boot0, "sed", "-i", "s/release/"+commitID+"/", "./neco-apps/argocd-config/base/*.yaml")
 		ExecSafeAt(boot0, "sed", "-i", "s/release/"+commitID+"/", "./neco-apps/argocd-config/overlays/"+overlayName+"/*.yaml")
 		applyAndWaitForApplications(commitID)


### PR DESCRIPTION
querier caches index whose size is 500Mi per day.
If searches are executed for 20 days, querier requires 10Gi, this makes it disk full.
To prevent such a situation, I enlarge disk space to 100Gi.
Signed-off-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>