### PR TITLE
Add application manifests for argocd-config

### DIFF
--- a/argocd-config/base/argocd-config.yaml
+++ b/argocd-config/base/argocd-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: ..
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
+    targetRevision: release
+    path: argocd-config/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true

--- a/argocd-config/base/kustomization.yaml
+++ b/argocd-config/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- argocd-config.yaml
 - argocd-ingress.yaml
 - argocd.yaml
 - bmc-reverse-proxy.yaml

--- a/argocd-config/overlays/osaka0/argocd-config.yaml
+++ b/argocd-config/overlays/osaka0/argocd-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+spec:
+  source:
+    path: argocd-config/overlays/osaka0

--- a/argocd-config/overlays/osaka0/kustomization.yaml
+++ b/argocd-config/overlays/osaka0/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - tenants
 patchesStrategicMerge:
+- argocd-config.yaml
 - argocd-ingress.yaml
 - argocd.yaml
 - bmc-reverse-proxy.yaml

--- a/argocd-config/overlays/stage0/argocd-config.yaml
+++ b/argocd-config/overlays/stage0/argocd-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+spec:
+  source:
+    path: argocd-config/overlays/stage0
+    targetRevision: stage

--- a/argocd-config/overlays/stage0/kustomization.yaml
+++ b/argocd-config/overlays/stage0/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - tenants
 patchesStrategicMerge:
+- argocd-config.yaml
 - argocd-ingress.yaml
 - argocd.yaml
 - bmc-reverse-proxy.yaml

--- a/argocd-config/overlays/tokyo0/argocd-config.yaml
+++ b/argocd-config/overlays/tokyo0/argocd-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+spec:
+  source:
+    path: argocd-config/overlays/tokyo0

--- a/argocd-config/overlays/tokyo0/kustomization.yaml
+++ b/argocd-config/overlays/tokyo0/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - tenants
 patchesStrategicMerge:
+- argocd-config.yaml
 - argocd-ingress.yaml
 - argocd.yaml
 - bmc-reverse-proxy.yaml


### PR DESCRIPTION
If you rewrite argocd-config application resource manually, it does not automatically revert back.
So, we will use ArgoCD to manage the resource.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>