### PR TITLE
use commit hash to stabilize test revision

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -11,7 +11,7 @@ SSH_PRIVKEY = $(NECO_DIR)/dctest/dctest_key
 CIRCLE_BUILD_NUM ?= -$(USER)
 TEST_ID := test$(CIRCLE_BUILD_NUM)
 BASE_BRANCH = main
-COMMIT_ID = $(shell git rev-parse --abbrev-ref HEAD)
+COMMIT_ID = $(shell git rev-parse HEAD)
 SUDO = sudo
 WGET=wget --retry-connrefused --no-verbose
 NUM_DASHBOARD = $(shell KUSTOMIZE_ENABLE_ALPHA_COMMANDS=true ./bin/kustomize cfg count ../monitoring/base/grafana-operator/dashboards | \


### PR DESCRIPTION
If the local branch name is "main", argocd sync revision in a test environment refers to remote "main" branch.
If the local branch revision differs from the remote one, the user intended test revision also differs.
To prevent such a situation, use commit hash instead of the branch name.