### PR TITLE
Update applications sync policy

### DIFF
--- a/argocd-config/base/namespaces.yaml
+++ b/argocd-config/base/namespaces.yaml
@@ -16,4 +16,5 @@ spec:
     namespace: kube-system
   syncPolicy:
     automated:
+      prune: true
       selfHeal: true

--- a/argocd-config/base/team-management.yaml
+++ b/argocd-config/base/team-management.yaml
@@ -18,4 +18,5 @@ spec:
     namespace: sandbox
   syncPolicy:
     automated:
+      prune: true
       selfHeal: true

--- a/argocd-config/overlays/osaka0/argocd-config.yaml
+++ b/argocd-config/overlays/osaka0/argocd-config.yaml
@@ -17,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: false

--- a/argocd-config/overlays/stage0/argocd-config.yaml
+++ b/argocd-config/overlays/stage0/argocd-config.yaml
@@ -17,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: false

--- a/argocd-config/overlays/tokyo0/argocd-config.yaml
+++ b/argocd-config/overlays/tokyo0/argocd-config.yaml
@@ -17,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: false


### PR DESCRIPTION
- Enable auto-prune for `namespaces`  app and `team-management` app.
- Set default setting of sync policy explicitly for `argocd-config` app.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>