### PR TITLE
Updates for k8s 1.20

### DIFF
--- a/bmc-reverse-proxy/base/bmc-reverse-proxy/service.yaml
+++ b/bmc-reverse-proxy/base/bmc-reverse-proxy/service.yaml
@@ -20,3 +20,4 @@ spec:
       targetPort: 5900
   selector:
     app.kubernetes.io/name: bmc-reverse-proxy
+  allocateLoadBalancerNodePorts: false

--- a/customer-egress/base/neco/squid.yaml
+++ b/customer-egress/base/neco/squid.yaml
@@ -178,6 +178,8 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: CriticalAddonsOnly
           operator: Exists
       dnsPolicy: "None"

--- a/customer-egress/base/squid.yaml
+++ b/customer-egress/base/squid.yaml
@@ -178,6 +178,8 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: CriticalAddonsOnly
           operator: Exists
       dnsPolicy: "None"

--- a/ingress/base/template/service.yaml
+++ b/ingress/base/template/service.yaml
@@ -17,6 +17,7 @@ spec:
     app.kubernetes.io/name: envoy
   type: LoadBalancer
   externalTrafficPolicy: Local
+  allocateLoadBalancerNodePorts: false
 ---
 apiVersion: v1
 kind: Service

--- a/teleport/base/service.yaml
+++ b/teleport/base/service.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     app.kubernetes.io/name: teleport
     app.kubernetes.io/component: auth
+  allocateLoadBalancerNodePorts: false
 ---
 apiVersion: v1
 kind: Service
@@ -51,3 +52,4 @@ spec:
   selector:
     app.kubernetes.io/name: teleport
     app.kubernetes.io/component: proxy
+  allocateLoadBalancerNodePorts: false

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,9 +21,9 @@ export BOOT0 BOOT1 BOOT2 GINKGO SSH_PRIVKEY TEST_ID COMMIT_ID NUM_DASHBOARD SUDO
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L22
 KUSTOMIZE_VERSION := 3.7.0
-PROMTOOL_VERSION := 2.24.1
+PROMTOOL_VERSION := 2.27.1
 TELEPORT_VERSION := 6.2.0
-KUBERNETES_VERSION := 1.19.7
+KUBERNETES_VERSION := 1.20.7
 ARGOCD_VERSION := 1.8.3
 
 # Cache

--- a/test/reboot_test.go
+++ b/test/reboot_test.go
@@ -104,7 +104,7 @@ func testRebootAllNodes() {
 	})
 
 	It("should stop all kube-controller-manager and delete all Pod", func() {
-		stdout, stderr, err := ExecAt(boot0, "kubectl", "get", "nodes", "-l", "node-role.kubernetes.io/master=true", "-ojsonpath='{.items..metadata.name}'")
+		stdout, stderr, err := ExecAt(boot0, "kubectl", "get", "nodes", "-l", "node-role.kubernetes.io/control-plane=true", "-ojsonpath='{.items..metadata.name}'")
 		Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
 		cpAddrs := strings.Split(string(stdout), " ")
 		for _, a := range cpAddrs {

--- a/test/vmalert_test/kube-state-metrics.yaml
+++ b/test/vmalert_test/kube-state-metrics.yaml
@@ -10,6 +10,7 @@ tests:
         values: '0+9x30'
     alert_rule_test:
       - eval_time: 15m
+        alertname: KubeStateMetricsListErrors
         exp_alerts: []
       - eval_time: 16m
         alertname: KubeStateMetricsListErrors
@@ -29,6 +30,7 @@ tests:
         values: '0+9x30'
     alert_rule_test:
       - eval_time: 15m
+        alertname: KubeStateMetricsWatchErrors
         exp_alerts: []
       - eval_time: 16m
         alertname: KubeStateMetricsWatchErrors


### PR DESCRIPTION
- Upgrade tools' versions in test/Makefile
- Use `node-role.kubernetes.io/control-plane` instead of `node-role.kubernetes.io/master` that is referred to test and squid.yaml
- Set Service.spec.allocateLoadBalancerNodePorts=false to Load Balancer Services that don't need node port.