### PR TITLE
Rook: set preserveUnknownFields to false explicitly

### DIFF
--- a/argocd-config/base/rook.yaml
+++ b/argocd-config/base/rook.yaml
@@ -34,3 +34,89 @@ spec:
       namespace: ceph-hdd
       jsonPointers:
         - /spec/storage/storageClassDeviceSets/0/count
+    # We set preserveUnknownFields to false, and if set to false, the value will not be displayed. It causes OutOfSync for ArgoCD.
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephblockpools.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephclients.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephclusters.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephfilesystemmirrors.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephfilesystems.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephnfses.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephobjectrealms.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephobjectstores.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephobjectstoreusers.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephobjectzonegroups.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephobjectzones.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: cephrbdmirrors.ceph.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: objectbucketclaims.objectbucket.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: objectbuckets.objectbucket.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: volumereplicationclasses.replication.storage.openshift.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: volumereplications.replication.storage.openshift.io
+      jsonPointers:
+        - /spec/preserveUnknownFields
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: volumes.rook.io
+      jsonPointers:
+        - /spec/preserveUnknownFields

--- a/rook/base/common/patch.yaml
+++ b/rook/base/common/patch.yaml
@@ -2,89 +2,137 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephblockpools.ceph.rook.io
+# Explicitly override preserveUnknownFields, which was `true` in v1beta1, since v1 only accepts `false`.
+spec:
+  preserveUnknownFields: false
+# The status is defined in upstream, but since the status changes after deploy, the status is deleted to avoid overwriting by argocd.
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephclients.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephclusters.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephfilesystemmirrors.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephfilesystems.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephnfses.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectrealms.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectstores.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectstoreusers.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectzonegroups.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectzones.ceph.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephrbdmirrors.ceph.rook.io
+spec:
+  preserveUnknownFields: false
+status: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbucketclaims.objectbucket.io
+spec:
+  preserveUnknownFields: false
+status: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbuckets.objectbucket.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: volumereplicationclasses.replication.storage.openshift.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: volumereplications.replication.storage.openshift.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: volumes.rook.io
+spec:
+  preserveUnknownFields: false
 status: null
 ---


### PR DESCRIPTION
CRD spec.preserveUnknownFields default is true until v1beta1, but as of v1, it is false and can not be set to true.
When updating API version, we did not set preserveUnknownFields explicitly, so the value is true.
If we update other fields in the CRD, k8s rejects the update because preserveUnknownFields is true.
This PR set preserveUnknownFields to false explicitly and ignore the field by Argocd to avoid sync failure.