### PR TITLE
monitoring: lengthen the retention period for smallset.

### DIFF
--- a/monitoring/base/victoriametrics/vmsingle-smallset.yaml
+++ b/monitoring/base/victoriametrics/vmsingle-smallset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vmsingle-smallset
   namespace: monitoring
 spec:
-  retentionPeriod: "15d"
+  retentionPeriod: "2"
   extraArgs:
     dedup.minScrapeInterval: 30s # should be equal to VMAgent's scrapeInterval (default 30s)
   storage:


### PR DESCRIPTION
The previous value 15d was a bit shorter for post-investigation.
I assume 2 months is sufficient and expect it consumes about 20GB
of disk space but it could not exhaust all space.

Signed-off-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>