### PR TITLE
Fix CPU Usage panal for kube-apiserver

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/kube-apiserver.yaml
+++ b/monitoring/base/grafana-operator/dashboards/kube-apiserver.yaml
@@ -781,7 +781,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "rate(process_cpu_seconds_total{job=\"kubernetes-apiservers\",instance=~\"$instance\"}[5m]) / on(instance) machine_cpu_cores",
+                        "expr": "rate(process_cpu_seconds_total{job=\"kubernetes-apiservers\",instance=~\"$instance\"}[5m])",
                         "format": "time_series",
                         "interval": "",
                         "intervalFactor": 2,


### PR DESCRIPTION
The current query for the CPU Usage panel is not working because the instance label of `process_cpu_seconds_total` metrics contains port numbers and that of `machine_cpu_cores` does not.

This PR omits the division by `machine_cpu_cores` and let CPU Usage panal show the total usage of CPUs in kube-apiserver.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>