### PR TITLE
Mount .kube directory by tmpfs

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -23,6 +23,18 @@ git checkout -qf ${CIRCLE_SHA1}
 cd test
 cp /home/cybozu/account.json /home/cybozu/zerossl-secret-resource.json ./
 curl -sfL -o lets.crt https://letsencrypt.org/certs/fakelerootx1.pem
+
+# kubectl caches the results, but it takes time to write
+# To speed up this caching, mount the directory to be cached by tmpfs.
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-0 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-0 'ckecli kubernetes issue >  ./.kube/config'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-1 'mkdir .kube'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-1 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-1 'ckecli kubernetes issue >  ./.kube/config'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-2 'mkdir .kube'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-2 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
+$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-2 'ckecli kubernetes issue >  ./.kube/config'
+
 make setup
 make $TARGET COMMIT_ID=${CIRCLE_SHA1} BASE_BRANCH=${BASE_BRANCH} SUITE=prepare
 make $TARGET COMMIT_ID=${CIRCLE_SHA1} BASE_BRANCH=${BASE_BRANCH} SUITE=run

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -7,6 +7,19 @@ BASE_BRANCH=${BASE_BRANCH:-main}
 
 cat >run.sh <<EOF
 #!/bin/sh -ex
+
+# kubectl caches the results, but it takes time to write
+# To speed up this caching, mount the directory to be cached by tmpfs.
+cd $HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest
+./dcssh boot-0 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
+./dcssh boot-0 'ckecli kubernetes issue >  ./.kube/config'
+./dcssh boot-1 'mkdir .kube'
+./dcssh boot-1 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
+./dcssh boot-1 'ckecli kubernetes issue >  ./.kube/config'
+./dcssh boot-2 'mkdir .kube'
+./dcssh boot-2 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
+./dcsshboot-2 'ckecli kubernetes issue >  ./.kube/config'
+
 # Run test
 GOPATH=\$HOME/go
 export GOPATH
@@ -23,17 +36,6 @@ git checkout -qf ${CIRCLE_SHA1}
 cd test
 cp /home/cybozu/account.json /home/cybozu/zerossl-secret-resource.json ./
 curl -sfL -o lets.crt https://letsencrypt.org/certs/fakelerootx1.pem
-
-# kubectl caches the results, but it takes time to write
-# To speed up this caching, mount the directory to be cached by tmpfs.
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-0 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-0 'ckecli kubernetes issue >  ./.kube/config'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-1 'mkdir .kube'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-1 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-1 'ckecli kubernetes issue >  ./.kube/config'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-2 'mkdir .kube'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-2 'sudo mount -t tmpfs -o size=5M tmpfs ./.kube'
-$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/neco/dctest/dcssh boot-2 'ckecli kubernetes issue >  ./.kube/config'
 
 make setup
 make $TARGET COMMIT_ID=${CIRCLE_SHA1} BASE_BRANCH=${BASE_BRANCH} SUITE=prepare


### PR DESCRIPTION
`kubectl` is sometimes very slow due to its caching.
To speed it up, this PR mounts `.kube` directory by tmpfs.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>