### PR TITLE
Modify reboot count query

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
+++ b/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
@@ -719,7 +719,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "deriv(time() - node_boot_time_seconds{}) < bool 0.1",
+                        "expr": "changes(node_boot_time_seconds{}[15m:]) > 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -729,7 +729,7 @@ spec:
                 "timeFrom": null,
                 "timeRegions": [],
                 "timeShift": null,
-                "title": "Node Reboot Time",
+                "title": "Node Reboot Count",
                 "tooltip": {
                     "shared": true,
                     "sort": 0,
@@ -751,7 +751,7 @@ spec:
                         "label": "",
                         "logBase": 1,
                         "max": null,
-                        "min": null,
+                        "min": "0",
                         "show": true
                     },
                     {

--- a/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
+++ b/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
@@ -719,7 +719,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "changes(node_boot_time_seconds{}[15m:]) > 0",
+                        "expr": "changes(node_boot_time_seconds[15m]) > 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"


### PR DESCRIPTION
I saw [this webpage](https://tips.weseek.co.jp/Tips/Prometheus/Kubernetes%28GKE%29%20%E3%81%A7%E4%BE%BF%E5%88%A9%E3%81%AA%20Prometheus%20%E5%B0%8F%E3%83%8D%E3%82%BF%E9%9B%86#Node%20%E3%81%AE%E5%86%8D%E8%B5%B7%E5%8B%95%E3%82%92%E6%A4%9C%E7%9F%A5%E3%81%99%E3%82%8B) and thought that using [this changes() function](https://prometheus.io/docs/prometheus/latest/querying/functions/) would show the reboot count more properly.
Therefore, this PR modified the current query to show each nodes' reboot timing by using `changes()` function.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>