### PR TITLE
update ceph witch comfigmap to avoid bluefs corruption

### DIFF
--- a/rook/base/ceph-hdd/cluster.yaml
+++ b/rook/base/ceph-hdd/cluster.yaml
@@ -57,7 +57,7 @@ spec:
               app: rook-ceph-mon
           topologyKey: topology.kubernetes.io/zone
   cephVersion:
-    image: quay.io/cybozu/ceph:15.2.8.1
+    image: quay.io/cybozu/ceph:16.2.4.1
   dashboard:
     ssl: true
   priorityClassNames:

--- a/rook/base/ceph-hdd/configmap.yaml
+++ b/rook/base/ceph-hdd/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-config-override
+  namespace: ceph-hdd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  config: |
+    [mon]
+    bluefs_buffered_io = false
+    
+    [osd]
+    bluefs_buffered_io = false

--- a/rook/base/ceph-hdd/deployment.yaml
+++ b/rook/base/ceph-hdd/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: rook-ceph-operator
-        image: "quay.io/cybozu/rook:1.6.3.1"
+        image: "quay.io/cybozu/rook:1.6.3.2"
         imagePullPolicy: IfNotPresent
         args: ["ceph", "operator"]
         env:

--- a/rook/base/ceph-hdd/kustomization.yaml
+++ b/rook/base/ceph-hdd/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - cephblockpool.yaml
   - cephobjectstore.yaml
   - cluster.yaml
+  - configmap.yaml
   - deployment.yaml
   - role.yaml
   - rolebinding.yaml

--- a/rook/base/ceph-ssd/cluster.yaml
+++ b/rook/base/ceph-ssd/cluster.yaml
@@ -57,7 +57,7 @@ spec:
               app: rook-ceph-mon
           topologyKey: topology.kubernetes.io/zone
   cephVersion:
-    image: quay.io/cybozu/ceph:15.2.8.1
+    image: quay.io/cybozu/ceph:16.2.4.1
   dashboard:
     ssl: true
   priorityClassNames:

--- a/rook/base/ceph-ssd/configmap.yaml
+++ b/rook/base/ceph-ssd/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-config-override
+  namespace: ceph-ssd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  config: |
+    [mon]
+    bluefs_buffered_io = false
+    
+    [osd]
+    bluefs_buffered_io = false

--- a/rook/base/ceph-ssd/deployment.yaml
+++ b/rook/base/ceph-ssd/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: rook-ceph-operator
-        image: "quay.io/cybozu/rook:1.6.3.1"
+        image: "quay.io/cybozu/rook:1.6.3.2"
         imagePullPolicy: IfNotPresent
         args: ["ceph", "operator"]
         env:

--- a/rook/base/ceph-ssd/kustomization.yaml
+++ b/rook/base/ceph-ssd/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - clusterrolebinding
   - cephblockpool.yaml
   - cluster.yaml
+  - configmap.yaml
   - deployment.yaml
   - role.yaml
   - rolebinding.yaml

--- a/rook/base/upstream/kustomization.yaml
+++ b/rook/base/upstream/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: rook/ceph
     newName: quay.io/cybozu/rook
-    newTag: 1.6.3.1
+    newTag: 1.6.3.2
 patchesJSON6902:
 - target:
     group: apps

--- a/rook/base/values.yaml
+++ b/rook/base/values.yaml
@@ -9,7 +9,7 @@ csi:
   provisionerPriorityClassName: ""
 image:
   repository: quay.io/cybozu/rook
-  tag: 1.6.3.1
+  tag: 1.6.3.2
   pullPolicy: IfNotPresent
 resources:
   limits:


### PR DESCRIPTION
We found an issue that the prepare job is failed and the osd process does not come up.
The issue is related to bluefs io mode, so to avoid the issue, we set bluefs_buffered_io to alse.