### PR TITLE
Rook: use `.spec.resources.osd` to set resource limits for OSD

### DIFF
--- a/rook/base/ceph-hdd/cluster.yaml
+++ b/rook/base/ceph-hdd/cluster.yaml
@@ -14,11 +14,10 @@ spec:
       requests:
         cpu: "500m"
         memory: "1Gi"
-    ## send bug report https://github.com/rook/rook/issues/6789
-    # osd:
-    #   requests:
-    #     cpu: "500m"
-    #     memory: "2Gi"
+    osd:
+      requests:
+        cpu: "500m"
+        memory: "2Gi"
     prepareosd:
       requests:
         cpu: "500m"
@@ -66,11 +65,6 @@ spec:
     storageClassDeviceSets:
       - name: set1
         count: 18
-        ## send bug report https://github.com/rook/rook/issues/6789
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "2Gi"
         tuneDeviceClass: true
         volumeClaimTemplates:
           - metadata:

--- a/rook/base/ceph-ssd/cluster.yaml
+++ b/rook/base/ceph-ssd/cluster.yaml
@@ -14,11 +14,10 @@ spec:
       requests:
         cpu: "500m"
         memory: "1Gi"
-    ## send bug report https://github.com/rook/rook/issues/6789
-    # osd:
-    #   requests:
-    #     cpu: "500m"
-    #     memory: "2Gi"
+    osd:
+      requests:
+        cpu: "500m"
+        memory: "2Gi"
     prepareosd:
       requests:
         cpu: "500m"
@@ -66,11 +65,6 @@ spec:
     storageClassDeviceSets:
       - name: set1
         count: 20
-        ## send bug report https://github.com/rook/rook/issues/6789
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "2Gi"
         volumeClaimTemplates:
           - metadata:
               name: data


### PR DESCRIPTION
The field `.spec.resources.osd` was not worked but it has fixed in Rook
1.6 or lator. Set the resource limits using the `.spec.resources` field in line with other resources.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>