### PR TITLE
Add a command to maintain tenant repositories

### DIFF
--- a/team-management/template/add_repo.sh
+++ b/team-management/template/add_repo.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# usage: ./add_repo.sh team repo
+yq eval ". * {\"repos\": {\"$2\": \"$1\"}}" settings.json -j > /tmp/settings.json
+mv /tmp/settings.json settings.json
+make format-settings > /dev/null

--- a/team-management/template/neco-admission/base/config.libsonnet
+++ b/team-management/template/neco-admission/base/config.libsonnet
@@ -21,21 +21,17 @@ function(settings) [{
             'default',
           ],
         },
-        {
-          repository: 'https://github.com/garoon-private/static-deployment.git',
-          projects: [
-            'garoon',
-            'maneki',
-            'tenant-app-of-apps',
-          ],
-        },
       ] + std.map(function(x) {
         repository: utility.get_app(settings, x).repo,
         projects: if x == 'tenant-apps' then [
           'tenant-apps',
           'tenant-app-of-apps',
         ] else std.set([utility.get_app(settings, x).team, 'maneki', 'tenant-app-of-apps']),
-      }, utility.get_apps(settings)),
+      }, utility.get_apps(settings)) +
+      std.map(function(x) {
+        repository: x,
+        projects: std.set([utility.get_repo(settings, x), 'maneki', 'tenant-app-of-apps']),
+      }, utility.get_repos(settings)),
       function(x) x.repository
     ),
   },

--- a/team-management/template/settings.json
+++ b/team-management/template/settings.json
@@ -88,5 +88,8 @@
       "app-octodns",
       "maneki"
     ]
+  },
+  "repos": {
+    "https://github.com/garoon-private/static-deployment.git": "garoon"
   }
 }

--- a/team-management/template/utility.libsonnet
+++ b/team-management/template/utility.libsonnet
@@ -61,4 +61,12 @@
   // get_app retrieves a tenant app settings.
   get_app(settings, name)::
     settings.apps[name],
+
+  // get_repos retrieves the array of tenant repos.
+  get_repos(settings)::
+    std.objectFields(settings.repos),
+
+  // get_repo retrieves a tenant repository settings.
+  get_repo(settings, name)::
+    settings.repos[name],
 }


### PR DESCRIPTION
This PR adds a command to add tenant repositories for ArgoCD.
It should be rebased and merged after the PR for `es-cluster-allocator` being completed. 

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>