### PR TITLE
fix reboot count query

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
+++ b/monitoring/base/grafana-operator/dashboards/all-nodes.yaml
@@ -719,7 +719,7 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "changes(node_boot_time_seconds[15m]) > 0",
+                        "expr": "sum_over_time((delta(node_boot_time_seconds) > bool 5)[15m:])",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"


### PR DESCRIPTION
Sometimes, `node_boot_time_seconds` fluctuates in a small range especially when its node is up.
Such fluctuations are nothing related to rebooting, so fix the query for detecting rebooting nodes to ignore them.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>