### PR TITLE
topolvm: add new storageclasses

### DIFF
--- a/topolvm/base/kustomization.yaml
+++ b/topolvm/base/kustomization.yaml
@@ -12,13 +12,14 @@ resources:
 - upstream/overlays/daemonset-scheduler/scheduler.yaml
 - pdb.yaml
 - priorityclass.yaml
+- storageclass.yaml
 
 patchesStrategicMerge:
 - crd.yaml
 - lvmd.yaml
 - node.yaml
 - scheduler.yaml
-- storageclass.yaml
+- provisioner.yaml
 
 configMapGenerator:
   - name: lvmd

--- a/topolvm/base/provisioner.yaml
+++ b/topolvm/base/provisioner.yaml
@@ -1,0 +1,6 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: topolvm-provisioner
+  annotations:
+    resize.topolvm.io/enabled: "true"

--- a/topolvm/base/storageclass.yaml
+++ b/topolvm/base/storageclass.yaml
@@ -1,6 +1,24 @@
+---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: topolvm-provisioner
+  name: topolvm-flash1-xfs
   annotations:
     resize.topolvm.io/enabled: "true"
+provisioner: topolvm.cybozu.com
+parameters:
+  "csi.storage.k8s.io/fstype": "xfs"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: topolvm-flash1-ext4
+  annotations:
+    resize.topolvm.io/enabled: "true"
+provisioner: topolvm.cybozu.com
+parameters:
+  "csi.storage.k8s.io/fstype": "ext4"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
This introduces two new storageclasses to provide ext4 and xfs using topolvm.
Previously, a SC with xfs using topolvm is provided as topolvm-provisioner,
but its name is not user friendly, so we add a more sophisticated one and
retain topolvm-provisioner for compatibility.