### PR TITLE
fix tenant OutOfSync after Argo CD update

### DIFF
--- a/team-management/base/common/project.yaml
+++ b/team-management/base/common/project.yaml
@@ -22,6 +22,15 @@ metadata:
   name: tenant-apps
   namespace: argocd
 spec:
+  clusterResourceWhitelist:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: ""
+      kind: Namespace
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
   destinations:
     - namespace: '*'
       server: '*'

--- a/team-management/template/team-management/base/common/project.libsonnet
+++ b/team-management/template/team-management/base/common/project.libsonnet
@@ -58,6 +58,24 @@ function(teams) [
           kind: 'NetworkPolicy',
         },
       ],
+      clusterResourceWhitelist: [
+        {
+          group: 'apiextensions.k8s.io',
+          kind: 'CustomResourceDefinition',
+        },
+        {
+          group: '',
+          kind: 'Namespace',
+        },
+        {
+          group: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRole',
+        },
+        {
+          group: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRoleBinding',
+        },
+      ],
       orphanedResources: {
         warn: false,
       },


### PR DESCRIPTION
After update of Argo CD (in container regular update), some cluster resources are out of sync. Add them to whitelist.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>