### PR TITLE
Rook/Ceph: expand livenessProbe.initialDelaySeconds for osd pod

### DIFF
--- a/rook/base/ceph-hdd/cluster.yaml
+++ b/rook/base/ceph-hdd/cluster.yaml
@@ -61,6 +61,12 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  # expand livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
+  healthCheck:
+    livenessProbe:
+      osd:
+        probe:
+          initialDelaySeconds: 180
   storage:
     storageClassDeviceSets:
       - name: set1

--- a/rook/poc/ceph-poc/cluster.yaml
+++ b/rook/poc/ceph-poc/cluster.yaml
@@ -61,6 +61,12 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  # expand livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
+  healthCheck:
+    livenessProbe:
+      osd:
+        probe:
+          initialDelaySeconds: 180
   storage:
     storageClassDeviceSets:
       - name: hdd


### PR DESCRIPTION
We observed that an osd is crash looping because of its livenessProbe. With our investigation, the startup process is successful but too slow.
This PR extends the initialDelaySeconds to survive in such a case.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>