### PR TITLE
admission: use repositoryPrefix for repository validation

### DIFF
--- a/neco-admission/base/config.yaml
+++ b/neco-admission/base/config.yaml
@@ -2,52 +2,23 @@
 ArgoCDApplicationValidator:
   rules:
     - projects:
+        - cydec
+        - dbre
+        - default
+        - ept
+        - garoon
+        - maneki
+        - tenant-app-of-apps
+        - tenant-apps
+      repositoryPrefix: https://github.com/cybozu-private
+    - projects:
+        - garoon
+        - maneki
+        - tenant-app-of-apps
+      repositoryPrefix: https://github.com/garoon-private
+    - projects:
         - default
       repository: https://github.com/cybozu-go/neco-apps.git
-    - projects:
-        - cydec
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/cydec-apps.git
-    - projects:
-        - dbre
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/dbre-apps
-    - projects:
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/elasticsearch-apps.git
-    - projects:
-        - ept
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/ept-apps.git
-    - projects:
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/es-cluster-allocator.git
-    - projects:
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/maneki-apps.git
-    - projects:
-        - default
-      repository: https://github.com/cybozu-private/neco-apps-secret.git
-    - projects:
-        - tenant-apps
-        - tenant-app-of-apps
-      repository: https://github.com/cybozu-private/neco-tenant-apps.git
-    - projects:
-        - garoon
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/garoon-private/garoon-apps.git
-    - projects:
-        - garoon
-        - maneki
-        - tenant-app-of-apps
-      repository: https://github.com/garoon-private/static-deployment.git
     - projects:
         - default
       repository: https://prometheus-community.github.io/helm-charts

--- a/team-management/template/neco-admission/base/config.libsonnet
+++ b/team-management/template/neco-admission/base/config.libsonnet
@@ -16,34 +16,23 @@ function(settings) [{
           ],
         },
         {
-          repository: 'https://github.com/cybozu-private/neco-apps-secret.git',
-          projects: [
+          repositoryPrefix: 'https://github.com/cybozu-private',
+          projects: std.setDiff(std.set(utility.get_teams(settings) + [
             'default',
-          ],
+            'tenant-apps',
+            'tenant-app-of-apps',
+          ]), ['neco-devusers']),
         },
         {
-          repository: 'https://github.com/garoon-private/static-deployment.git',
+          repositoryPrefix: 'https://github.com/garoon-private',
           projects: [
             'garoon',
             'maneki',
             'tenant-app-of-apps',
           ],
         },
-        {
-          repository: 'https://github.com/cybozu-private/es-cluster-allocator.git',
-          projects: [
-            'maneki',
-            'tenant-app-of-apps',
-          ],
-        },
-      ] + std.map(function(x) {
-        repository: utility.get_app(settings, x).repo,
-        projects: if x == 'tenant-apps' then [
-          'tenant-apps',
-          'tenant-app-of-apps',
-        ] else std.set([utility.get_app(settings, x).team, 'maneki', 'tenant-app-of-apps']),
-      }, utility.get_apps(settings)),
-      function(x) x.repository
+      ],
+      function(x) if std.objectHas(x, 'repositoryPrefix') then 'A' + x.repositoryPrefix else 'B' + x.repository
     ),
   },
 }]

--- a/test/admission_test.go
+++ b/test/admission_test.go
@@ -91,9 +91,9 @@ func testAdmission() {
 		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 		ExecSafeAt(boot0, "kubectl", "delete", "application", "valid")
 
-		By("denying to create Application which points to maneki-apps repo and belongs to default project")
+		By("denying to create Application which points to invalid repo and belongs to default project")
 		buf.Reset()
-		err = tmpl.Execute(buf, tmplParams{"invalid", "default", "https://github.com/cybozu-private/maneki-apps.git"})
+		err = tmpl.Execute(buf, tmplParams{"invalid", "default", "https://github.com/cybozu-go/invalid-apps.git"})
 		Expect(err).NotTo(HaveOccurred())
 		stdout, stderr, err = ExecAtWithInput(boot0, buf.Bytes(), "kubectl", "apply", "-f", "-")
 		Expect(err).To(HaveOccurred(), "stdout: %s, stderr: %s, err: %v", stdout, stderr, err)


### PR DESCRIPTION
This PR uses `repositoryPrefix` to validate ArgoCD Applications.
All teams in `settings.json` except `neco-devusers` will be able to deploy Applications from `cybozu-private` organization.

I think this PR can be reviewed and merged now because the [fix of neco-admission](https://github.com/cybozu/neco-containers/pull/632) is not urgent and can be deployed later.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>