### PR TITLE
Rook/Ceph: revert manifest to remove livenessProbe.initialDelaySeconds for osd pod

### DIFF
--- a/rook/base/ceph-hdd/cluster.yaml
+++ b/rook/base/ceph-hdd/cluster.yaml
@@ -61,12 +61,6 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
-  # expand livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
-  healthCheck:
-    livenessProbe:
-      osd:
-        probe:
-          initialDelaySeconds: 180
   storage:
     storageClassDeviceSets:
       - name: set1

--- a/rook/poc/ceph-poc/cluster.yaml
+++ b/rook/poc/ceph-poc/cluster.yaml
@@ -61,12 +61,6 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
-  # expand livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
-  healthCheck:
-    livenessProbe:
-      osd:
-        probe:
-          initialDelaySeconds: 180
   storage:
     storageClassDeviceSets:
       - name: hdd


### PR DESCRIPTION
livenessProve is incorrectly configured, so undo the PR.