### PR TITLE
change argocd-config's sync-wave to 9999

### DIFF
--- a/argocd-config/overlays/osaka0/argocd-config.yaml
+++ b/argocd-config/overlays/osaka0/argocd-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/manifest-generate-paths: ..
+    argocd.argoproj.io/sync-wave: "9999"
 spec:
   project: default
   source:

--- a/argocd-config/overlays/stage0/argocd-config.yaml
+++ b/argocd-config/overlays/stage0/argocd-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/manifest-generate-paths: ..
+    argocd.argoproj.io/sync-wave: "9999"
 spec:
   project: default
   source:

--- a/argocd-config/overlays/tokyo0/argocd-config.yaml
+++ b/argocd-config/overlays/tokyo0/argocd-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/manifest-generate-paths: ..
+    argocd.argoproj.io/sync-wave: "9999"
 spec:
   project: default
   source:


### PR DESCRIPTION
Change 'argocd-config' Application's sync-wave in order to sync this Application last.

Before this PR, argocd-config's sync-wave is not set (= sync-wave "0"). This may cause syncing other child Applications themselves (such as adding/deleting Applications) stuck.

see also: https://github.com/cybozu-go/neco/issues/1661

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>