### PR TITLE
Rook/Ceph: extend livenessProve.initialDelaySeconds

### DIFF
--- a/rook/base/ceph-hdd/cluster.yaml
+++ b/rook/base/ceph-hdd/cluster.yaml
@@ -61,6 +61,12 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  # extend livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
+  healthCheck:
+    livenessProbe:
+      osd:
+        probe:
+          initialDelaySeconds: 180
   storage:
     storageClassDeviceSets:
       - name: set1

--- a/rook/base/ceph-hdd/deployment.yaml
+++ b/rook/base/ceph-hdd/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: rook-ceph-operator
-        image: "quay.io/cybozu/rook:1.6.3.2"
+        image: "quay.io/cybozu/rook:1.6.3.3"
         imagePullPolicy: IfNotPresent
         args: ["ceph", "operator"]
         env:

--- a/rook/base/ceph-ssd/deployment.yaml
+++ b/rook/base/ceph-ssd/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: rook-ceph-operator
-        image: "quay.io/cybozu/rook:1.6.3.2"
+        image: "quay.io/cybozu/rook:1.6.3.3"
         imagePullPolicy: IfNotPresent
         args: ["ceph", "operator"]
         env:

--- a/rook/base/upstream/kustomization.yaml
+++ b/rook/base/upstream/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: rook/ceph
     newName: quay.io/cybozu/rook
-    newTag: 1.6.3.2
+    newTag: 1.6.3.3
 patchesJSON6902:
 - target:
     group: apps

--- a/rook/base/values.yaml
+++ b/rook/base/values.yaml
@@ -9,7 +9,7 @@ csi:
   provisionerPriorityClassName: ""
 image:
   repository: quay.io/cybozu/rook
-  tag: 1.6.3.2
+  tag: 1.6.3.3
   pullPolicy: IfNotPresent
 resources:
   limits:

--- a/rook/poc/ceph-poc/cluster.yaml
+++ b/rook/poc/ceph-poc/cluster.yaml
@@ -61,6 +61,12 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  # extend livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
+  healthCheck:
+    livenessProbe:
+      osd:
+        probe:
+          initialDelaySeconds: 180
   storage:
     storageClassDeviceSets:
       - name: hdd

--- a/rook/poc/ceph-poc/deployment.yaml
+++ b/rook/poc/ceph-poc/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: rook-ceph-operator
-        image: "quay.io/cybozu/rook:1.6.3.2"
+        image: "quay.io/cybozu/rook:1.6.3.3"
         imagePullPolicy: IfNotPresent
         args: ["ceph", "operator"]
         env:


### PR DESCRIPTION
Avoid the problem of OSDs that take a long time to initialize being terminated by livenessProbe.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>