### PR TITLE
Rook/Ceph: expand dctest osd size to defer disk full

### DIFF
--- a/rook/overlays/gcp/kustomization.yaml
+++ b/rook/overlays/gcp/kustomization.yaml
@@ -44,7 +44,7 @@ patchesJson6902:
       value: 5
     - op: replace
       path: /spec/storage/storageClassDeviceSets/0/volumeClaimTemplates/0/spec/resources/requests/storage
-      value: 5Gi
+      value: 10Gi
 - target:
     group: ceph.rook.io
     version: v1


### PR DESCRIPTION
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>