### PR TITLE
team-management: add CSA team having the same permission as neco team

### DIFF
--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -70,6 +70,7 @@ metadata:
 data:
   # Specify the team's slug.
   policy.csv: |
+    g, cybozu-private:csa, role:admin
     g, cybozu-private:neco, role:admin
     g, cybozu-private:neco-readonly, role:readonly
   # Drop default privileges. So unauthenticated users cannot see the app, projects, etc...

--- a/team-management/base/common/project.yaml
+++ b/team-management/base/common/project.yaml
@@ -93,6 +93,7 @@ spec:
     warn: false
   roles:
     - groups:
+        - cybozu-private:csa
         - cybozu-private:cydec
         - cybozu-private:dbre
         - cybozu-private:ept

--- a/team-management/template/team-management/base/common/project.libsonnet
+++ b/team-management/template/team-management/base/common/project.libsonnet
@@ -100,6 +100,7 @@ function(apps, teams) [
         {
           name: 'admin',
           groups: std.set([
+            'cybozu-private:csa',
             'cybozu-private:neco',
           ] + std.map(function(x) 'cybozu-private:' + x, teams)),
           policies: [


### PR DESCRIPTION
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>