### PR TITLE
add moco controller alert rule

### DIFF
--- a/monitoring/base/victoriametrics/kustomization.yaml
+++ b/monitoring/base/victoriametrics/kustomization.yaml
@@ -55,6 +55,7 @@ resources:
   - rules/metallb-alertrule.yaml
   - rules/metallb-scrape.yaml
   - rules/moco-scrape.yaml
+  - rules/moco-alertrule.yaml
   - rules/monitoring-scrape.yaml
   - rules/monitoring-alertrule.yaml
   - rules/neco-admission-alertrule.yaml

--- a/monitoring/base/victoriametrics/rules/moco-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/moco-alertrule.yaml
@@ -1,0 +1,18 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: moco
+  namespace: monitoring
+spec:
+  groups:
+    - name: moco
+      rules:
+        - alert: MocoControllerDown
+          expr: |
+            absent(up{job="moco-controller"} == 1)
+          labels:
+            severity: error
+          for: 15m
+          annotations:
+            summary: moco controller is down.
+            runbook: TBD

--- a/test/vmalert_test/moco.yaml
+++ b/test/vmalert_test/moco.yaml
@@ -1,0 +1,17 @@
+rule_files:
+  - ../../monitoring/base/victoriametrics/rules/converted/moco-alertrule.yaml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="moco-controller"}'
+        values: '0+0x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: MocoControllerDown
+        exp_alerts:
+          - exp_labels:
+              severity: error
+            exp_annotations:
+              runbook: TBD
+              summary: moco controller is down.


### PR DESCRIPTION
This PR adds an alert rule to check `moco-controller` metrics is scraped

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>