### PR TITLE
Disable hash suffix for VMAlertmanager ConfigMaps to stabilize update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ update-victoriametrics:
 	$(call get-latest-tag,alertmanager)
 	sed -i -E '/name: VM_VMALERTMANAGER_ALERTMANAGERVERSION$$/!b;n;s/value:.*$$/value: "$(latest_tag)"/' monitoring/base/victoriametrics/operator.yaml
 	$(call get-latest-tag,configmap-reload)
-	sed -i -E 's,quay.io/cybozu/configmap-reload:.*$$,quay.io/cybozu/configmap-reload:$(latest_tag),' monitoring/base/victoriametrics/operator.yaml
+	sed -i -E 's,quay.io/cybozu/configmap-reload:.*$$,quay.io/cybozu/configmap-reload:$(latest_tag),' monitoring/base/victoriametrics/operator.yaml monitoring/base/victoriametrics/vmalertmanager-largeset.yaml monitoring/base/victoriametrics/vmalertmanager-smallset.yaml
 	$(call get-latest-tag,prometheus-config-reloader)
 	sed -i -E 's,quay.io/cybozu/prometheus-config-reloader:.*$$,quay.io/cybozu/prometheus-config-reloader:$(latest_tag),' monitoring/base/victoriametrics/operator.yaml
 

--- a/monitoring/base/victoriametrics/kustomization.yaml
+++ b/monitoring/base/victoriametrics/kustomization.yaml
@@ -86,5 +86,7 @@ configMapGenerator:
   - name: vmalertmanager-settype-smallset
     literals:
       - 'settype.template={{ define "neco.settype" }}smallset{{ end }}'
+generatorOptions:
+  disableNameSuffixHash: true
 configurations:
 - kustomizeconfig.yaml

--- a/monitoring/base/victoriametrics/vmalertmanager-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmalertmanager-largeset.yaml
@@ -8,20 +8,41 @@ spec:
   # VMAlertmanager is able to detect configSecret content change and to reload alertmanager.
   # We don't need to use secretGenerator for alertmanager.yaml unlike monitoring/base/alertmanager/deployment.yaml
   configSecret: vmalertmanager-config
+  # However, it is not able to detect configMap content change. So use another configmap-reload container.
+  # Note that we don't use VMAlertmanager.spec.configMaps because they use name of ConfigMap as mount point.
+  # We need a common mount point for largeset and smallset.
   volumeMounts:
     - name: alertmanager-config-volume
       mountPath: /etc/vm/configs/vmalertmanager
     - name: vmalertmanager-settype
       mountPath: /etc/vm/configs/vmalertmanager-settype
   volumes:
-    # However, it is not able to detect this configMap content change. So use configMapGenerator.
-    # Note that we don't use VMAlertmanager.spec.configMaps because they use name of ConfigMap (which is changed any time) as mount point.
     - name: alertmanager-config-volume
       configMap:
         name: vmalertmanager
     - name: vmalertmanager-settype
       configMap:
         name: vmalertmanager-settype-largeset
+  containers:
+    - name: configmap-reloader
+      image: quay.io/cybozu/configmap-reload:0.5.0.1
+      imagePullPolicy: IfNotPresent
+      args:
+        - -webhook-url=http://127.0.0.1:9093/-/reload
+        - -volume-dir=/etc/vm/configs/vmalertmanager
+        - -volume-dir=/etc/vm/configs/vmalertmanager-settype
+        - -web.listen-address=:9534
+      volumeMounts:
+        - name: alertmanager-config-volume
+          mountPath: /etc/vm/configs/vmalertmanager
+          readOnly: true
+        - name: vmalertmanager-settype
+          mountPath: /etc/vm/configs/vmalertmanager-settype
+          readOnly: true
+      resources:
+        limits:
+          cpu: 100m
+          memory: 25Mi
   resources:
     requests:
       cpu: 100m

--- a/monitoring/base/victoriametrics/vmalertmanager-smallset.yaml
+++ b/monitoring/base/victoriametrics/vmalertmanager-smallset.yaml
@@ -18,6 +18,26 @@ spec:
     - name: vmalertmanager-settype
       configMap:
         name: vmalertmanager-settype-smallset
+  containers:
+    - name: configmap-reloader
+      image: quay.io/cybozu/configmap-reload:0.5.0.1
+      imagePullPolicy: IfNotPresent
+      args:
+        - -webhook-url=http://127.0.0.1:9093/-/reload
+        - -volume-dir=/etc/vm/configs/vmalertmanager
+        - -volume-dir=/etc/vm/configs/vmalertmanager-settype
+        - -web.listen-address=:9534
+      volumeMounts:
+        - name: alertmanager-config-volume
+          mountPath: /etc/vm/configs/vmalertmanager
+          readOnly: true
+        - name: vmalertmanager-settype
+          mountPath: /etc/vm/configs/vmalertmanager-settype
+          readOnly: true
+      resources:
+        limits:
+          cpu: 100m
+          memory: 25Mi
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
This commit disables the hash suffix functionality for the ConfigMaps
used in VMAlertmanager CRs.
The update of ConfigMap contents is detected by the configmap-reload
sidecar containers instead.
With this commit we can avoild the early deletion of old ConfigMaps
by Argo CD, the instability of the VMAlertmanager StatefulSets, and
the hang-up of VictoriaMetrics operator's reconciliation.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>