### PR TITLE
upgrade neco-admission 0.11.1

### DIFF
--- a/neco-admission/base/kustomization.yaml
+++ b/neco-admission/base/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
       value: neco-admission
 images:
   - name: quay.io/cybozu/neco-admission
-    newTag: 0.9.4
+    newTag: 0.11.1

--- a/test/testdata/admission-pod.yaml
+++ b/test/testdata/admission-pod.yaml
@@ -11,3 +11,32 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
     command: ["pause"]
+  - name: ubuntu-ephemeral-overwritten
+    image: quay.io/cybozu/ubuntu:20.04
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    command: ["pause"]
+    resources:
+      requests:
+        ephemeral-storage: 1Gi
+      limits:
+        ephemeral-storage: 10Gi
+  initContainers:
+  - name: ubuntu-init
+    image: quay.io/cybozu/ubuntu:20.04
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    command: ["pause"]
+  - name: ubuntu-init-ephemeral-overwritten
+    image: quay.io/cybozu/ubuntu:20.04
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    command: ["pause"]
+    resources:
+      requests:
+        ephemeral-storage: 1Gi
+      limits:
+        ephemeral-storage: 10Gi


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1647

use neco-admission 0.11.1 to limit local ephemeral storage.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>