### PR TITLE
Rook: enable PDB for ceph daemons

### DIFF
--- a/rook/base/ceph-hdd/cephobjectstore.yaml
+++ b/rook/base/ceph-hdd/cephobjectstore.yaml
@@ -18,7 +18,7 @@ spec:
   preservePoolsOnDelete: true
   gateway:
     port: 80
-    instances: 2
+    instances: 3 # TODO: current rook implementation requires at least 3 instances to make PDB.
     placement:
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/rook/base/ceph-hdd/cluster.yaml
+++ b/rook/base/ceph-hdd/cluster.yaml
@@ -69,6 +69,10 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  disruptionManagement:
+    managePodBudgets: true
+    osdMaintenanceTimeout: 60 # rebooting worker nodes takes about 60 minutes.
+    pgHealthCheckTimeout: 0
   # extend livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
   healthCheck:
     livenessProbe:

--- a/rook/base/ceph-hdd/kustomization.yaml
+++ b/rook/base/ceph-hdd/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - cluster.yaml
   - configmap.yaml
   - deployment.yaml
+  - mgr-pdb.yaml
   - role.yaml
   - rolebinding.yaml
   - serviceaccount.yaml

--- a/rook/base/ceph-hdd/mgr-pdb.yaml
+++ b/rook/base/ceph-hdd/mgr-pdb.yaml
@@ -1,0 +1,11 @@
+# TODO: current rook does not create PDB for MGR, so we create it manually.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: rook-ceph-mgr-workaround
+  namespace: ceph-hdd
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-mgr

--- a/rook/base/ceph-ssd/cluster.yaml
+++ b/rook/base/ceph-ssd/cluster.yaml
@@ -69,6 +69,10 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  disruptionManagement:
+    managePodBudgets: true
+    osdMaintenanceTimeout: 60 # rebooting worker nodes takes about 60 minutes.
+    pgHealthCheckTimeout: 0
   storage:
     storageClassDeviceSets:
       - name: set1

--- a/rook/base/ceph-ssd/kustomization.yaml
+++ b/rook/base/ceph-ssd/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - cluster.yaml
   - configmap.yaml
   - deployment.yaml
+  - mgr-pdb.yaml
   - role.yaml
   - rolebinding.yaml
   - serviceaccount.yaml

--- a/rook/base/ceph-ssd/mgr-pdb.yaml
+++ b/rook/base/ceph-ssd/mgr-pdb.yaml
@@ -1,0 +1,11 @@
+# TODO: current rook does not create PDB for MGR, so we create it manually.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: rook-ceph-mgr-workaround
+  namespace: ceph-ssd
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-mgr

--- a/rook/poc/ceph-poc/cephobjectstore.yaml
+++ b/rook/poc/ceph-poc/cephobjectstore.yaml
@@ -20,7 +20,7 @@ spec:
   preservePoolsOnDelete: true
   gateway:
     port: 80
-    instances: 2
+    instances: 3 # TODO: current rook implementation requires at least 3 instances to make PDB.
     placement:
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -69,7 +69,7 @@ spec:
   preservePoolsOnDelete: true
   gateway:
     port: 80
-    instances: 2
+    instances: 3 # TODO: current rook implementation requires at least 3 instances to make PDB.
     placement:
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/rook/poc/ceph-poc/cluster.yaml
+++ b/rook/poc/ceph-poc/cluster.yaml
@@ -69,6 +69,10 @@ spec:
     ssl: true
   priorityClassNames:
     osd: node-bound
+  disruptionManagement:
+    managePodBudgets: true
+    osdMaintenanceTimeout: 60 # rebooting worker nodes takes about 60 minutes.
+    pgHealthCheckTimeout: 0
   # extend livenessProve.initialDelaySeconds for osds since an osd's initialize process is so slow.
   healthCheck:
     livenessProbe:

--- a/rook/poc/ceph-poc/kustomization.yaml
+++ b/rook/poc/ceph-poc/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - cluster.yaml
   - configmap.yaml
   - deployment.yaml
+  - mgr-pdb.yaml
   - role.yaml
   - rolebinding.yaml
   - serviceaccount.yaml

--- a/rook/poc/ceph-poc/mgr-pdb.yaml
+++ b/rook/poc/ceph-poc/mgr-pdb.yaml
@@ -1,0 +1,11 @@
+# TODO: current rook does not create PDB for MGR, so we create it manually.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: rook-ceph-mgr-workaround
+  namespace: ceph-poc
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-mgr

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -320,9 +320,9 @@ func testMGRPodsSpreadAll() {
 }
 
 func testRGWPodsSpreadAll() {
-	testDaemonPodsSpread("RGW", "app=rook-ceph-rgw", "ceph-hdd", 2, 1, 1)
-	testDaemonPodsSpread("RGW", "app=rook-ceph-rgw,rook_object_store=ceph-poc-object-store-hdd-index", "ceph-poc", 2, 1, 1)
-	testDaemonPodsSpread("RGW", "app=rook-ceph-rgw,rook_object_store=ceph-poc-object-store-ssd-index", "ceph-poc", 2, 1, 1)
+	testDaemonPodsSpread("RGW", "app=rook-ceph-rgw", "ceph-hdd", 3, 1, 1)
+	testDaemonPodsSpread("RGW", "app=rook-ceph-rgw,rook_object_store=ceph-poc-object-store-hdd-index", "ceph-poc", 3, 1, 1)
+	testDaemonPodsSpread("RGW", "app=rook-ceph-rgw,rook_object_store=ceph-poc-object-store-ssd-index", "ceph-poc", 3, 1, 1)
 }
 
 func testOSDPodsSpread() {


### PR DESCRIPTION
- Rook manages PDB for OSD, MON, RGW.
  - If the number of RGW is two, Rook does not create PDB (BUG?), so we create 3 instances for a workaround.
- Current Rook does not manage PDB for MGR, so we create it manually.

issue: cybozu/csa#3
Signed-off-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>