### PR TITLE
VictoriaMetrics: Expand largeset's storage size on dctest

### DIFF
--- a/monitoring/base/victoriametrics/vmcluster-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmcluster-largeset.yaml
@@ -15,7 +15,7 @@ spec:
           storageClassName: ceph-hdd-block
           resources:
             requests:
-              storage: 1Gi # this value is for GCP env. we don't use pvc-autoresizer. see overlays/*/victoriametrics/vmcluster-largeset.yaml too.
+              storage: 3Gi # this value is for GCP env. we don't use pvc-autoresizer. see overlays/*/victoriametrics/vmcluster-largeset.yaml too.
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Expand VictoriaMetrics storage size to 3GB,  since we get no space left error if we don't stop dctest few days.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>