### PR TITLE
Remove ETCDCTL_API variable

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/etcd.yaml
+++ b/monitoring/base/grafana-operator/dashboards/etcd.yaml
@@ -530,7 +530,7 @@ spec:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "etcd_debugging_mvcc_db_total_size_in_bytes{job='$Job'}",
+                                "expr": "etcd_mvcc_db_total_size_in_bytes{job='$Job'}",
                                 "format": "time_series",
                                 "hide": false,
                                 "interval": "",

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -126,7 +126,7 @@ func testSetup() {
 			createNamespaceIfNotExists("sandbox", false)
 
 			By("creating namespace and secrets for teleport")
-			stdout, stderr, err := ExecAt(boot0, "env", "ETCDCTL_API=3", "etcdctl", "--cert=/etc/etcd/backup.crt", "--key=/etc/etcd/backup.key",
+			stdout, stderr, err := ExecAt(boot0, "etcdctl", "--cert=/etc/etcd/backup.crt", "--key=/etc/etcd/backup.key",
 				"get", "--print-value-only", "/neco/teleport/auth-token")
 			Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
 			teleportToken := strings.TrimSpace(string(stdout))


### PR DESCRIPTION
This PR removes `ETCDCTL_API=3`, that becomes default on etcd 3.4.
Also, it replaces `etcd_debugging_mvcc_db_total_size_in_bytes` with `etcd_mvcc_db_total_size_in_bytes`.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>