### PR TITLE
add traceable policy which can use perf

### DIFF
--- a/pod-security-admission/base/configmap.yaml
+++ b/pod-security-admission/base/configmap.yaml
@@ -11,4 +11,12 @@ data:
       rootGroups: true
       seccomp: true
       forceRunAsNonRoot: true
+    - name: traceable
+      nonCoreVolumeTypes: true
+      allowPrivilegeEscalation: true
+      rootGroups: true
+      seccomp: true
+      forceRunAsNonRoot: true
+      allowedHostPaths:
+      - pathPrefix: /sys/kernel/tracing
     - name: restricted

--- a/pod-security-admission/base/kustomization.yaml
+++ b/pod-security-admission/base/kustomization.yaml
@@ -7,3 +7,4 @@ patchesStrategicMerge:
   - certificate.yaml
   - configmap.yaml
   - namespace.yaml
+  - webhook.yaml

--- a/pod-security-admission/base/upstream/install.yaml
+++ b/pod-security-admission/base/upstream/install.yaml
@@ -76,7 +76,7 @@ spec:
         - --config-path=/etc/pod-security-admission/config.yaml
         command:
         - /pod-security-admission
-        image: quay.io/cybozu/pod-security-admission:0.1.0
+        image: quay.io/cybozu/pod-security-admission:0.2.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/pod-security-admission/base/webhook.yaml
+++ b/pod-security-admission/base/webhook.yaml
@@ -1,0 +1,82 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: psa-mutating-webhook-configuration
+webhooks:
+- name: baseline.mpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: pod-security.cybozu.com/policy
+      operator: NotIn
+      values:
+      - privileged
+      - traceable
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: psa-webhook-service
+      namespace: psa-system
+      path: /mutate-traceable
+  failurePolicy: Fail
+  name: traceable.mpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: pod-security.cybozu.com/policy
+      operator: In
+      values:
+      - traceable
+  reinvocationPolicy: IfNeeded
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: psa-system/psa-serving-cert
+  name: psa-validating-webhook-configuration
+webhooks:
+- name: baseline.vpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: pod-security.cybozu.com/policy
+      operator: NotIn
+      values:
+      - privileged
+      - traceable
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: psa-webhook-service
+      namespace: psa-system
+      path: /validate-traceable
+  failurePolicy: Fail
+  name: traceable.vpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: pod-security.cybozu.com/policy
+      operator: In
+      values:
+      - traceable
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/test/psa_test.go
+++ b/test/psa_test.go
@@ -7,12 +7,33 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//go:embed testdata/invalid-pod.yaml
-var invalidPodYAML []byte
+//go:embed testdata/psa-hostnetwork-pod.yaml
+var psaHostNetworkPodYAML []byte
+
+//go:embed testdata/psa-hostpath-pod.yaml
+var psaHostPathPodYAML []byte
+
+func preparePodSecurityAdmission() {
+	It("should create namepaces for psa", func() {
+		createNamespaceIfNotExistsWithPolicy("psa-baseline", "baseline")
+		createNamespaceIfNotExistsWithPolicy("psa-traceable", "traceable")
+	})
+}
 
 func testPodSecurityAdmission() {
-	It("should prohibit pod that uses hostNetwork", func() {
-		_, stderr, err := ExecAtWithInput(boot0, invalidPodYAML, "kubectl", "apply", "-f", "-")
+	It("should prohibit pod that uses hostNetwork in baseline policy", func() {
+		_, stderr, err := ExecAtWithInput(boot0, psaHostNetworkPodYAML, "kubectl", "apply", "-n", "psa-baseline", "-f", "-")
+		Expect(err).To(HaveOccurred())
+		Expect(string(stderr)).Should(ContainSubstring(`admission webhook "baseline.vpod.kb.io" denied the request`))
+	})
+
+	It("should accept pod that uses /sys/kernel/tracing hostPath in traceable policy", func() {
+		_, _, err := ExecAtWithInput(boot0, psaHostPathPodYAML, "kubectl", "apply", "-n", "psa-traceable", "-f", "-")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should prohibit pod that uses /sys/kernel/tracing hostPath in baseline policy", func() {
+		_, stderr, err := ExecAtWithInput(boot0, psaHostPathPodYAML, "kubectl", "apply", "-n", "psa-baseline", "-f", "-")
 		Expect(err).To(HaveOccurred())
 		Expect(string(stderr)).Should(ContainSubstring(`admission webhook "baseline.vpod.kb.io" denied the request`))
 	})

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -85,6 +85,7 @@ func prepareTest() {
 	Context("preparing teleport", prepareTeleport)
 	Context("preparing customer-egress", prepareCustomerEgress)
 	Context("preparing sealed-secret", prepareSealedSecret)
+	Context("preparing pod-security-admission", preparePodSecurityAdmission)
 	Context("preparing network-policy", prepareNetworkPolicy) // this must be the last preparation.
 }
 

--- a/test/testdata/psa-hostnetwork-pod.yaml
+++ b/test/testdata/psa-hostnetwork-pod.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: psa-test
-  namespace: default
+  name: psa-test-hostnetwork
 spec:
   hostNetwork: true
   containers:

--- a/test/testdata/psa-hostpath-pod.yaml
+++ b/test/testdata/psa-hostpath-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: psa-test-hostpath
+spec:
+  containers:
+  - name: ubuntu
+    image: quay.io/cybozu/ubuntu:20.04
+    command: ["pause"]
+    volumeMounts:
+    - name: sys-kernel-tracing
+      mountPath: /sys/kernel/tracing
+  securityContext:
+    runAsUser: 10000
+    runAsGroup: 10000
+  volumes:
+  - name: sys-kernel-tracing
+    hostPath:
+      path: /sys/kernel/tracing


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1694

- add "traceable" policy which can use /sys/kernel/tracing hostPath.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>