### PR TITLE
Add development label to sandbox namespace

### DIFF
--- a/team-management/base/sandbox/sandbox.yaml
+++ b/team-management/base/sandbox/sandbox.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sandbox
   labels:
     app.kubernetes.io/name: sandbox
+    development: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This PR adds `development: "true"` to the sandbox namespace.
It applies to all the clusters (incl. tokyo0 and osaka0).

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>