### PR TITLE
Refine meows and pod-security-admission webhooks

### DIFF
--- a/argocd-config/base/pod-security-admission.yaml
+++ b/argocd-config/base/pod-security-admission.yaml
@@ -16,7 +16,7 @@ spec:
     path: pod-security-admission/base
   destination:
     server: https://kubernetes.default.svc
-    namespace: psa-system
+    namespace: kube-system
   syncPolicy:
     automated:
       prune: true

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -10,11 +10,10 @@ How to write Kubernetes application manifests
 ### Labels
 
 - All namespaces should have `team=xxx` labels to clarify their owner.
-- To skip validation/mutation webhook, administrators can use the following special labels.
+- To skip validation/mutation webhook, administrators can use the following special annotations
   - `admission.cybozu.com/pod: ignore`: With this label, [PodMutator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podmutator) and [PodValidator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podvalidator) are ignored. This label is necessary when the pods in the namespace are required to start without neco-admission webhooks.
   - `vnetworkpolicy.kb.io/ignore: "true"`: This label enables to ignore [CalicoNetworkPolicyValidator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#caliconetworkpolicyvalidator). Using this label makes it possible for administrators to set high prioritized network policies for namespaces.
   - `topolvm.cybozu.com/webhook: ignore`: This label disables using the Topolvm webhook used for persistent volumes provided by Topolvm. Administrators should use this label for the namespaces which should be independent of Topolvm. See more details about the label [here](https://github.com/topolvm/topolvm/blob/main/deploy/README.md#protect-system-namespaces-from-topolvm-webhook).
-  - `meows.cybozu.com/pod-mutate: ignore`: The Meows webhook ignores the namespaces with this label.  This label is necessary when the pods in the namespace are required to start without Meows webhooks.
 
 ### Annotations
 

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -10,10 +10,11 @@ How to write Kubernetes application manifests
 ### Labels
 
 - All namespaces should have `team=xxx` labels to clarify their owner.
-- To skip validation/mutation webhook, administrators can use the following special annotations
+- To skip validation/mutation webhook, administrators can use the following special labels.
   - `admission.cybozu.com/pod: ignore`: With this label, [PodMutator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podmutator) and [PodValidator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#podvalidator) are ignored. This label is necessary when the pods in the namespace are required to start without neco-admission webhooks.
   - `vnetworkpolicy.kb.io/ignore: "true"`: This label enables to ignore [CalicoNetworkPolicyValidator](https://github.com/cybozu/neco-containers/blob/main/admission/README.md#caliconetworkpolicyvalidator). Using this label makes it possible for administrators to set high prioritized network policies for namespaces.
   - `topolvm.cybozu.com/webhook: ignore`: This label disables using the Topolvm webhook used for persistent volumes provided by Topolvm. Administrators should use this label for the namespaces which should be independent of Topolvm. See more details about the label [here](https://github.com/topolvm/topolvm/blob/main/deploy/README.md#protect-system-namespaces-from-topolvm-webhook).
+  - `pod-security.cybozu.com/policy: privileged`: This label indicates that the Pods in the namespace with this label should be created under the unrestricted policy.  This implies that pod-security-admission webhook is not called for the Pods in the namespace.  This label is necessary when the pods in the namespace are required to start without pod-security-admission webhooks.
 
 ### Annotations
 

--- a/meows/overlays/gcp/kustomization.yaml
+++ b/meows/overlays/gcp/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 patchesStrategicMerge:
   - ./crd.yaml
   - ./deployment.yaml
+  - ./webhook.yaml

--- a/meows/overlays/gcp/namespace.yaml
+++ b/meows/overlays/gcp/namespace.yaml
@@ -4,7 +4,6 @@ metadata:
   name: meows
   labels:
     team: neco
-    meows.cybozu.com/pod-mutate: ignore
 ---
 apiVersion: v1
 kind: Namespace
@@ -13,3 +12,4 @@ metadata:
   labels:
     team: neco
     pod-security.cybozu.com/policy: privileged
+    meows.cybozu.com/pod-mutate: "true"

--- a/meows/overlays/gcp/webhook.yaml
+++ b/meows/overlays/gcp/webhook.yaml
@@ -1,0 +1,12 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: pod-hook.meows.cybozu.com
+  namespaceSelector:
+    matchExpressions:
+    - key: meows.cybozu.com/pod-mutate
+      operator: In
+      values:
+      - "true"

--- a/namespaces/base/cert-manager.yaml
+++ b/namespaces/base/cert-manager.yaml
@@ -7,4 +7,3 @@ metadata:
     topolvm.cybozu.com/webhook: ignore
     admission.cybozu.com/pod: ignore
     pod-security.cybozu.com/policy: privileged
-    meows.cybozu.com/pod-mutate: ignore

--- a/namespaces/base/internet-egress.yaml
+++ b/namespaces/base/internet-egress.yaml
@@ -9,4 +9,3 @@ metadata:
     topolvm.cybozu.com/webhook: ignore
     admission.cybozu.com/pod: ignore
     pod-security.cybozu.com/policy: privileged
-    meows.cybozu.com/pod-mutate: ignore

--- a/namespaces/base/kube-system.yaml
+++ b/namespaces/base/kube-system.yaml
@@ -8,4 +8,3 @@ metadata:
     topolvm.cybozu.com/webhook: ignore
     admission.cybozu.com/pod: ignore
     pod-security.cybozu.com/policy: privileged
-    meows.cybozu.com/pod-mutate: ignore

--- a/pod-security-admission/base/certificate.yaml
+++ b/pod-security-admission/base/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: psa-serving-cert
-  namespace: psa-system
+  namespace: kube-system
 spec:
   secretName: webhook-server-cert
   duration: 8760h0m0s # 1y
@@ -11,8 +11,8 @@ spec:
     name: psa-selfsigned-issuer
   dnsNames:
     - psa-webhook-service
-    - psa-webhook-service.psa-system
-    - psa-webhook-service.psa-system.svc
+    - psa-webhook-service.kube-system
+    - psa-webhook-service.kube-system.svc
   usages:
     - digital signature
     - key encipherment

--- a/pod-security-admission/base/configmap.yaml
+++ b/pod-security-admission/base/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: psa-pod-security-admission-config
-  namespace: psa-system
+  namespace: kube-system
 data:
   config.yaml: |
     - name: baseline

--- a/pod-security-admission/base/kustomization.yaml
+++ b/pod-security-admission/base/kustomization.yaml
@@ -1,10 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: psa-system
+namespace: kube-system
 resources:
   - upstream/install.yaml
 patchesStrategicMerge:
   - certificate.yaml
   - configmap.yaml
-  - namespace.yaml
   - webhook.yaml

--- a/pod-security-admission/base/namespace.yaml
+++ b/pod-security-admission/base/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: psa-system
-  labels:
-    team: neco
-    pod-security.cybozu.com/policy: privileged

--- a/pod-security-admission/base/upstream/install.yaml
+++ b/pod-security-admission/base/upstream/install.yaml
@@ -1,12 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    pod-security.cybozu.com/policy: privileged
-  name: psa-system
----
-apiVersion: v1
 data:
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
@@ -23,7 +15,7 @@ data:
 kind: ConfigMap
 metadata:
   name: psa-manager-config
-  namespace: psa-system
+  namespace: kube-system
 ---
 apiVersion: v1
 data:
@@ -39,13 +31,13 @@ data:
 kind: ConfigMap
 metadata:
   name: psa-pod-security-admission-config
-  namespace: psa-system
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: psa-webhook-service
-  namespace: psa-system
+  namespace: kube-system
 spec:
   ports:
   - port: 443
@@ -59,7 +51,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: psa-controller-manager
-  namespace: psa-system
+  namespace: kube-system
 spec:
   replicas: 1
   selector:
@@ -76,7 +68,7 @@ spec:
         - --config-path=/etc/pod-security-admission/config.yaml
         command:
         - /pod-security-admission
-        image: quay.io/cybozu/pod-security-admission:0.2.0
+        image: quay.io/cybozu/pod-security-admission:0.2.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -133,11 +125,11 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: psa-serving-cert
-  namespace: psa-system
+  namespace: kube-system
 spec:
   dnsNames:
-  - psa-webhook-service.psa-system.svc
-  - psa-webhook-service.psa-system.svc.cluster.local
+  - psa-webhook-service.kube-system.svc
+  - psa-webhook-service.kube-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: psa-selfsigned-issuer
@@ -147,7 +139,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: psa-selfsigned-issuer
-  namespace: psa-system
+  namespace: kube-system
 spec:
   selfSigned: {}
 ---
@@ -155,7 +147,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: psa-system/psa-serving-cert
+    cert-manager.io/inject-ca-from: kube-system/psa-serving-cert
   name: psa-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -164,7 +156,7 @@ webhooks:
   clientConfig:
     service:
       name: psa-webhook-service
-      namespace: psa-system
+      namespace: kube-system
       path: /mutate-baseline
   failurePolicy: Fail
   name: baseline.mpod.kb.io
@@ -191,7 +183,7 @@ webhooks:
   clientConfig:
     service:
       name: psa-webhook-service
-      namespace: psa-system
+      namespace: kube-system
       path: /mutate-restricted
   failurePolicy: Fail
   name: restricted.mpod.kb.io
@@ -217,7 +209,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: psa-system/psa-serving-cert
+    cert-manager.io/inject-ca-from: kube-system/psa-serving-cert
   name: psa-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -226,7 +218,7 @@ webhooks:
   clientConfig:
     service:
       name: psa-webhook-service
-      namespace: psa-system
+      namespace: kube-system
       path: /validate-baseline
   failurePolicy: Fail
   name: baseline.vpod.kb.io
@@ -252,7 +244,7 @@ webhooks:
   clientConfig:
     service:
       name: psa-webhook-service
-      namespace: psa-system
+      namespace: kube-system
       path: /validate-restricted
   failurePolicy: Fail
   name: restricted.vpod.kb.io

--- a/pod-security-admission/base/webhook.yaml
+++ b/pod-security-admission/base/webhook.yaml
@@ -17,7 +17,7 @@ webhooks:
   clientConfig:
     service:
       name: psa-webhook-service
-      namespace: psa-system
+      namespace: kube-system
       path: /mutate-traceable
   failurePolicy: Fail
   name: traceable.mpod.kb.io
@@ -43,7 +43,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: psa-system/psa-serving-cert
+    cert-manager.io/inject-ca-from: kube-system/psa-serving-cert
   name: psa-validating-webhook-configuration
 webhooks:
 - name: baseline.vpod.kb.io
@@ -60,7 +60,7 @@ webhooks:
   clientConfig:
     service:
       name: psa-webhook-service
-      namespace: psa-system
+      namespace: kube-system
       path: /validate-traceable
   failurePolicy: Fail
   name: traceable.vpod.kb.io

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -403,6 +403,12 @@ func applyAndWaitForApplications(commitID string) {
 				continue
 			}
 
+			// TODO: remove this block after release
+			if doUpgrade && app.Name == "pod-security-admission" {
+				ExecAt(boot0, "kubectl", "annotate", "namespace", "psa-system", "admission.cybozu.com/i-am-sure-to-delete=psa-system")
+				// ignore error
+			}
+
 			// TODO: remove this block after release the PR bellow
 			// https://github.com/cybozu-go/neco-apps/pull/1714
 			if doUpgrade && app.Name == "pvc-autoresizer" {

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -409,16 +409,6 @@ func applyAndWaitForApplications(commitID string) {
 				// ignore error
 			}
 
-			// TODO: remove this block after release the PR bellow
-			// https://github.com/cybozu-go/neco-apps/pull/1714
-			if doUpgrade && app.Name == "pvc-autoresizer" {
-				_, _, err := ExecAt(boot0, "argocd", "app", "sync", "pvc-autoresizer", "--force", "--timeout", "300")
-				if err != nil {
-					ExecAt(boot0, "argocd", "app", "terminate-op", "pvc-autoresizer")
-					return err
-				}
-			}
-
 			// In upgrade test, syncing network-policy app may cause temporal network disruption.
 			// It leads to ArgoCD's improper behavior. In spite of the network-policy app becomes Synced/Healthy, the operation does not end.
 			// So terminate the unexpected operation manually in upgrade test.


### PR DESCRIPTION
This PR refines the following webhooks.
* meows
  * Limit the target namespaces of the webhook
* pod-security-admission
  * Import the latest manifests from the upstream
    * The PSA objects are deployed into kube-system namespace instead of psa-system namespace
    * This prevents the PSA Pods from being blocked by webhooks