### PR TITLE
Set accurate template for tenant root namespaces

### DIFF
--- a/argocd-config/base/init-template.yaml
+++ b/argocd-config/base/init-template.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: init-template
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: ..
+    argocd.argoproj.io/sync-wave: "7"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/cybozu-go/neco-apps.git
+    targetRevision: release
+    path: init-template/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: init-template
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd-config/base/kustomization.yaml
+++ b/argocd-config/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - elastic.yaml
 - external-dns.yaml
 - ingress.yaml
+- init-template.yaml
 - kube-metrics-adapter.yaml
 - local-pv-provisioner.yaml
 - logging.yaml

--- a/argocd-config/overlays/stage0/init-template.yaml
+++ b/argocd-config/overlays/stage0/init-template.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: init-template
+  namespace: argocd
+spec:
+  source:
+    targetRevision: stage

--- a/argocd-config/overlays/stage0/kustomization.yaml
+++ b/argocd-config/overlays/stage0/kustomization.yaml
@@ -16,6 +16,7 @@ patchesStrategicMerge:
 - external-dns.yaml
 - meows.yaml
 - ingress.yaml
+- init-template.yaml
 - kube-metrics-adapter.yaml
 - local-pv-provisioner.yaml
 - logging.yaml

--- a/init-template/base/kustomization.yaml
+++ b/init-template/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/init-template/base/namespace.yaml
+++ b/init-template/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: init-template
+  labels:
+    accurate.cybozu.com/type: template

--- a/team-management/base/dbre/dev-dbre.yaml
+++ b/team-management/base/dbre/dev-dbre.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    accurate.cybozu.com/template: init-template
     accurate.cybozu.com/type: root
     development: "true"
   name: dev-dbre

--- a/team-management/base/maneki/app-maneki.yaml
+++ b/team-management/base/maneki/app-maneki.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    accurate.cybozu.com/template: init-template
     accurate.cybozu.com/type: root
   name: app-maneki
 ---

--- a/team-management/base/maneki/dev-maneki.yaml
+++ b/team-management/base/maneki/dev-maneki.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    accurate.cybozu.com/template: init-template
     accurate.cybozu.com/type: root
     development: "true"
   name: dev-maneki

--- a/team-management/base/network/dev-network.yaml
+++ b/team-management/base/network/dev-network.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    accurate.cybozu.com/template: init-template
     accurate.cybozu.com/type: root
     development: "true"
   name: dev-network

--- a/team-management/template/settings.json
+++ b/team-management/template/settings.json
@@ -74,6 +74,7 @@
       "app-cybozu-com-mysql-replica": {},
       "app-cybozu-com-mysql-restore": {},
       "dev-dbre": {
+        "accurate.cybozu.com/template": "init-template",
         "accurate.cybozu.com/type": "root",
         "development": "true"
       }
@@ -96,6 +97,7 @@
       "app-forest-certs": {},
       "app-kodama": {},
       "app-maneki": {
+        "accurate.cybozu.com/template": "init-template",
         "accurate.cybozu.com/type": "root"
       },
       "app-maneki-static-cybozu-com": {},
@@ -105,6 +107,7 @@
       "app-oauth-redirector": {},
       "app-octodns": {},
       "dev-maneki": {
+        "accurate.cybozu.com/template": "init-template",
         "accurate.cybozu.com/type": "root",
         "development": "true"
       },
@@ -115,6 +118,7 @@
     "neco-devusers": {},
     "network": {
       "dev-network": {
+        "accurate.cybozu.com/template": "init-template",
         "accurate.cybozu.com/type": "root",
         "development": "true"
       }

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -72,10 +72,10 @@ func testNamespaceResources(t *testing.T) {
 			return
 		}
 
-		// `sandbox` namespace should not have a team label.
-		if meta.Name == "sandbox" {
+		// `sandbox` and `init-template` namespaces should not have a team label.
+		if meta.Name == "sandbox" || meta.Name == "init-template" {
 			if _, ok := meta.Labels["team"]; ok {
-				t.Errorf("sandbox ns has team label: value=%s", meta.Labels["team"])
+				t.Errorf("%s ns has team label: value=%s", meta.Name, meta.Labels["team"])
 			}
 			return
 		}
@@ -223,6 +223,7 @@ func testApplicationResources(t *testing.T) {
 		"pvc-autoresizer":        "7",
 		"accurate":               "7",
 		"meows":                  "7",
+		"init-template":          "7",
 		"network-policy":         "8",
 	}
 


### PR DESCRIPTION
This PR adds `init-template` Application that deploys `init-template` namespace.
It is annotated as a template namespace of Accurate, that stores common resources.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>