### PR TITLE
fix VMPodScrapes for moco

### DIFF
--- a/monitoring/base/victoriametrics/rules/moco-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/moco-scrape.yaml
@@ -24,7 +24,8 @@ spec:
   namespaceSelector:
     any: true
   selector:
-    app.kubernetes.io/name: mysql
+    matchLabels:
+      app.kubernetes.io/name: mysql
   podMetricsEndpoints:
   - port: agent-metrics
     relabelConfigs:
@@ -46,7 +47,8 @@ spec:
   namespaceSelector:
     any: true
   selector:
-    app.kubernetes.io/name: mysql
+    matchLabels:
+      app.kubernetes.io/name: mysql
   podMetricsEndpoints:
   - port: mysqld-metrics
     relabelConfigs:


### PR DESCRIPTION
It seems that the original manifest selects all pods.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>