### PR TITLE
fix RunnerPool image for test

### DIFF
--- a/test/testdata/meows-runnerpool.tmpl.yaml
+++ b/test/testdata/meows-runnerpool.tmpl.yaml
@@ -13,4 +13,4 @@ spec:
     metadata:
       annotations:
         egress.coil.cybozu.com/internet-egress: nat
-    image: quay.io/cybozu/meows-runner:latest
+    image: quay.io/cybozu/meows-runner:0.3.1


### PR DESCRIPTION
- The image of the RunnerPool resource used for testing was specified with the latest tag.
  - In connection with the release of meows, only the Image version of runner has been increased and is no longer executable.
- Fixed to explicitly specify the version.

Signed-off-by: kouki <kouworld0123@gmail.com>