### PR TITLE
Move confirmOsdPrepare() to testSetup().

### DIFF
--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -296,6 +296,10 @@ func testSetup() {
 		applyAndWaitForApplications(commitID)
 	})
 
+	It("should wait for rook stable", func() {
+		confirmOsdPrepare()
+	})
+
 	It("should add a credential to access to cybozu-private repositories", func() {
 		if doUpgrade {
 			Skip("No need to create it when upgrading")


### PR DESCRIPTION
When restarting the node, the pods are not created and confirmOsdPrepare() falls into an error.

This is a problem with the point where confirmOsdPrepare() is called.

Therefore, we changed the location of the call to confirmOsdPrepare().

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>