### PR TITLE
Rook/Ceph: disable warning by MANY_OBJECTS_PER_PG for ceph-ssd

### DIFF
--- a/rook/base/ceph-hdd/configmap.yaml
+++ b/rook/base/ceph-hdd/configmap.yaml
@@ -7,4 +7,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   # this is patched by overlays, please check overlays if you update it.
-  config: ""
+  config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0

--- a/rook/base/ceph-object-store/configmap.yaml
+++ b/rook/base/ceph-object-store/configmap.yaml
@@ -7,4 +7,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   # this is patched by overlays, please check overlays if you update it.
-  config: ""
+  config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0

--- a/rook/base/ceph-ssd/configmap.yaml
+++ b/rook/base/ceph-ssd/configmap.yaml
@@ -7,4 +7,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   # this is patched by overlays, please check overlays if you update it.
-  config: ""
+  config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0

--- a/rook/overlays/gcp/ceph-hdd/debug.yaml
+++ b/rook/overlays/gcp/ceph-hdd/debug.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: ceph-hdd
 data:
   config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0
     [client]
     rgw enable ops log = true
     debug rgw = 20/20

--- a/rook/overlays/gcp/ceph-object-store/debug.yaml
+++ b/rook/overlays/gcp/ceph-object-store/debug.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: ceph-object-store
 data:
   config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0
     [client]
     rgw enable ops log = true
     debug rgw = 20/20

--- a/rook/poc/ceph-poc-2/configmap.yaml
+++ b/rook/poc/ceph-poc-2/configmap.yaml
@@ -7,5 +7,13 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0
     [rgw]
     rgw_dynamic_resharding = false

--- a/rook/poc/ceph-poc/configmap.yaml
+++ b/rook/poc/ceph-poc/configmap.yaml
@@ -7,5 +7,13 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   config: |
+    [mon]
+    ; Suppress the folowing warning.
+    ;
+    ; ```
+    ; health: HEALTH_WARN
+    ;        1 pools have many more objects per pg than average
+    ; ```
+    mon_pg_warn_max_object_skew = 0
     [rgw]
     rgw_dynamic_resharding = false


### PR DESCRIPTION
Suppress the folowing warning.

```
health: HEALTH_WARN
        1 pools have many more objects per pg than average
```

The definition of this parameter is as follows.

https://github.com/ceph/ceph/blob/d31130d4516a36c585b1224c193ec720f31c649c/src/common/options/mgr.yaml.in#L237-L247
```
- name: mon_pg_warn_max_object_skew
  type: float
  level: advanced
  desc: max skew few average in objects per pg
  fmt_desc: Raise ``HEALTH_WARN`` if the average RADOS object count per PG
    of any pool is greater than ``mon_pg_warn_max_object_skew`` times
    the average RADOS object count per PG of all pools. Zero or a non-positive
    number disables this. Note that this option applies to ``ceph-mgr`` daemons.
  default: 10
  services:
  - mgr
```

This warning is harmless in Neco's Ceph clusters because we don't care the difference of the number of objects per pgs between pools. For example, we hit this problem because there is a big pool and there are many almost empty pools.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>