### PR TITLE
Alert if clock skew is detected

### DIFF
--- a/monitoring/base/victoriametrics/rules/node-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/node-alertrule.yaml
@@ -62,3 +62,19 @@ spec:
           annotations:
             summary: Available filesystem is low at `{{ $labels.instance }}` on `{{ $labels.mountpoint }}`.
             runbook: Please check filesystem consumption.
+        - alert: ChronyMetricsMissing
+          expr: sum(sabakan_machine_status{status!="retired",role!="boot"} == 1) by (address) unless sum(chrony_monitor_tracking_system_time_seconds) by (address)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: The chrony metrics is missing at `{{ $labels.address }}`.
+            runbook: Please check the node.
+        - alert: NodeClockSkew
+          expr: abs(chrony_monitor_tracking_system_time_seconds) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: The system clock on `{{ $labels.address }}` is fastened or delayed by 0.05 seconds.
+            runbook: Please check the node.

--- a/test/vmalert_test/node.yaml
+++ b/test/vmalert_test/node.yaml
@@ -257,3 +257,43 @@ tests:
       - eval_time: 10m
         alertname: AvailableFileSystemLow
         exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'sabakan_machine_status{status="healthy", role="cs", address="192.168.0.1"}'
+        values: '1+0x30'
+      - series: 'sabakan_machine_status{status="retired", role="cs", address="192.168.0.1"}'
+        values: '0+0x30'
+      - series: 'sabakan_machine_status{status="healthy", role="cs", address="192.168.0.2"}'
+        values: '0+0x30'
+      - series: 'sabakan_machine_status{status="retired", role="cs", address="192.168.0.2"}'
+        values: '1+0x30'
+      - series: 'sabakan_machine_status{status="healthy", role="boot", address="192.168.0.3"}'
+        values: '1+0x30'
+      - series: 'sabakan_machine_status{status="retired", role="boot", address="192.168.0.3"}'
+        values: '0+0x30'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: ChronyMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              address: "192.168.0.1"
+              severity: "warning"
+            exp_annotations:
+              runbook: "Please check the node."
+              summary: "The chrony metrics is missing at `192.168.0.1`."
+
+  - interval: 1m
+    input_series:
+      - series: 'chrony_monitor_tracking_system_time_seconds{address="192.168.0.1"}'
+        values: '0.1+0x30'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodeClockSkew
+        exp_alerts:
+          - exp_labels:
+              address: "192.168.0.1"
+              severity: "warning"
+            exp_annotations:
+              runbook: "Please check the node."
+              summary: "The system clock on `192.168.0.1` is fastened or delayed by 0.05 seconds."


### PR DESCRIPTION
This PR adds two alerts.
- ChronyMetricsMissing: alert if chrony metrics is missing on machines that are visible to sabakan.
  It is expected to find failure when node_exporter is running but chrony_monitor is not rendering metrics correctly.
- NodeClockSkew: alert if node's system time is fastened or delayed by a certain amount.

The severity is set to warning for a while.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>