### PR TITLE
add relable_configs for session and sshd

### DIFF
--- a/logging/base/promtail/config/promtail.yaml
+++ b/logging/base/promtail/config/promtail.yaml
@@ -109,6 +109,14 @@ scrape_configs:
     relabel_configs:
       - source_labels: ["__journal__systemd_unit"]
         target_label: "unit"
+      - source_labels: ["__journal__systemd_unit"]
+        regex: ^session-\d+\.scope$
+        target_label: "unit"
+        replacement: session.scope
+      - source_labels: ["__journal__systemd_unit"]
+        regex: ^sshd@\d+-\d+\.\d+\.\d+\.\d+:\d+-\d+\.\d+\.\d+\.\d+:\d+\.service$
+        target_label: "unit"
+        replacement: sshd.service
       - source_labels: ["__journal_syslog_identifier"]
         target_label: "syslog_identifier"
       - source_labels: ["__journal_container_name"]


### PR DESCRIPTION
- Each start and end of the ssh session was given a unique label value.
- The value of `session-1.scope` etc. at the beginning of ssh is converted to `session.scope`.
- The value of `sshd@231-10.69.0.4:22-10.72.48.0:41850.service` etc. at the end of ssh is converted to `sshd.service`

Signed-off-by: kouki <kouworld0123@gmail.com>