### PR TITLE
Enable and update dctest-runner

### DIFF
--- a/meows/overlays/stage0/kustomization.yaml
+++ b/meows/overlays/stage0/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../gcp
-# The chrony running on placemat is interfering with the host and causing time deviations, so it will not be deployed until the problem is resolved.
-#  - ./runnerpool.yaml
+  - ./runnerpool.yaml
 patchesStrategicMerge:
   - ./deployment.yaml


### PR DESCRIPTION
Enable `dctest-runner` when [dctest: Run chrony on VM](https://github.com/cybozu-go/neco/pull/1850) is on the release branch. 

Signed-off-by: kouki <kouworld0123@gmail.com>