### PR TITLE
Prepare Cilium setup

### DIFF
--- a/network-policy/base/kustomization.yaml
+++ b/network-policy/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - policies/kube-system.yaml
   - policies/monitoring.yaml
   - policies/teleport.yaml
+  - policies/hubble-relay.yaml
   - global-policies/apiserver.yaml
   - global-policies/coil-nat.yaml
   - global-policies/controller-manager.yaml

--- a/network-policy/base/policies/hubble-relay.yaml
+++ b/network-policy/base/policies/hubble-relay.yaml
@@ -1,0 +1,19 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-hubble-relay-node-allow
+  namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  order: 500.0
+  selector: k8s-app == 'hubble-relay'
+  types:
+    - Egress
+  egress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: role == 'node'
+        ports:
+          - 4244

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -29,6 +29,9 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(40 * time.Minute)
 
 	prepare()
+	// If Cilium hasn't been installed, then ignore Cilium CR in testTeamManagement.
+	// This code will be removed once Cilium has been successfully installed on Neco.
+	prepareForCilium()
 
 	log.DefaultLogger().SetOutput(GinkgoWriter)
 

--- a/test/team-management_test.go
+++ b/test/team-management_test.go
@@ -45,6 +45,9 @@ var requiredResources = []string{
 	"challenges.acme.cert-manager.io",
 	"orders.acme.cert-manager.io",
 
+	// Cilium
+	"ciliumnetworkpolicies.cilium.io",
+
 	// ECK
 	"agents.agent.k8s.elastic.co",
 	"apmservers.apm.k8s.elastic.co",
@@ -110,6 +113,13 @@ var viewableResources = []string{
 
 	// Contour
 	"tlscertificatedelegations.projectcontour.io",
+
+	// Cilium
+	"ciliumendpoints.cilium.io",
+	"ciliumclusterwidenetworkpolicies.cilium.io",
+	"ciliumexternalworkloads.cilium.io",
+	"ciliumidentities.cilium.io",
+	"ciliumnodes.cilium.io",
 
 	// Topolvm
 	"logicalvolumes.topolvm.cybozu.com",
@@ -191,6 +201,32 @@ func init() {
 		}
 		requiredResources = removed
 	}
+}
+
+func prepareForCilium() {
+	if isCiliumDisabled() {
+		var requiredResourcesWithoutCilium, viewableResourcesWithoutCilium []string
+		for _, res := range requiredResources {
+			if strings.HasPrefix(res, "cilium") {
+				continue
+			}
+			requiredResourcesWithoutCilium = append(requiredResourcesWithoutCilium, res)
+		}
+		requiredResources = requiredResourcesWithoutCilium
+
+		for _, res := range viewableResources {
+			if strings.HasPrefix(res, "cilium") {
+				continue
+			}
+			viewableResourcesWithoutCilium = append(viewableResourcesWithoutCilium, res)
+		}
+		viewableResources = viewableResourcesWithoutCilium
+	}
+}
+
+func isCiliumDisabled() bool {
+	_, _, err := ExecAt(boot0, "kubectl", "-n", "kube-system", "get", "ds", "cilium")
+	return err != nil
 }
 
 var (

--- a/test/team-management_test.go
+++ b/test/team-management_test.go
@@ -204,7 +204,7 @@ func init() {
 }
 
 func prepareForCilium() {
-	if isCiliumDisabled() {
+	if isCiliumAbsent() {
 		var requiredResourcesWithoutCilium, viewableResourcesWithoutCilium []string
 		for _, res := range requiredResources {
 			if strings.HasPrefix(res, "cilium") {
@@ -224,7 +224,7 @@ func prepareForCilium() {
 	}
 }
 
-func isCiliumDisabled() bool {
+func isCiliumAbsent() bool {
 	_, _, err := ExecAt(boot0, "kubectl", "-n", "kube-system", "get", "ds", "cilium")
 	return err != nil
 }


### PR DESCRIPTION
This PR 

- Modifies team-management_test so that it works both with and without Cilium.
- Adds NetworkPolicy to allow hubble-relay to access cilium-agent running on each node.