### PR TITLE
insert double dash before remote command of `kubectl exec`

### DIFF
--- a/test/monitoring_test.go
+++ b/test/monitoring_test.go
@@ -383,7 +383,7 @@ func testVMCommonClusterComponents(setType vmSetType) {
 				podName := pod.Name
 
 				_, stderr, err := ExecAt(boot0, "kubectl", "--namespace=monitoring", "exec",
-					podName, "curl", "http://localhost:9093/-/healthy")
+					podName, "--", "curl", "http://localhost:9093/-/healthy")
 				if err != nil {
 					return fmt.Errorf("unable to curl http://%s:9093/-/healthy, stderr: %s, err: %v", podName, stderr, err)
 				}
@@ -471,7 +471,7 @@ func testVMCommonClusterComponents(setType vmSetType) {
 				podName := pod.Name
 
 				stdout, stderr, err := ExecAt(boot0, "kubectl", "--namespace=monitoring", "exec",
-					podName, "curl", "http://localhost:8080/api/v1/groups")
+					podName, "--", "curl", "http://localhost:8080/api/v1/groups")
 				if err != nil {
 					return fmt.Errorf("unable to curl :8080/api/v1/groups, stderr: %s, err: %v", stderr, err)
 				}
@@ -690,7 +690,7 @@ func testVMSmallsetClusterComponents() {
 			podName := podList.Items[0].Name
 
 			_, stderr, err := ExecAt(boot0, "kubectl", "--namespace=monitoring", "exec",
-				podName, "curl", "http://localhost:8429/api/v1/labels")
+				podName, "--", "curl", "http://localhost:8429/api/v1/labels")
 			if err != nil {
 				return fmt.Errorf("unable to curl :8429/api/v1/labels, stderr: %s, err: %v", stderr, err)
 			}
@@ -749,7 +749,7 @@ func testVMLargesetClusterComponents() {
 				podName := pod.Name
 
 				_, stderr, err := ExecAt(boot0, "kubectl", "--namespace=monitoring", "exec",
-					podName, "curl", "http://localhost:8481/select/0/prometheus/api/v1/labels")
+					podName, "--", "curl", "http://localhost:8481/select/0/prometheus/api/v1/labels")
 				if err != nil {
 					return fmt.Errorf("unable to curl http://%s:8429/select/0/prometheus/api/v1/labels, stderr: %s, err: %v", podName, stderr, err)
 				}

--- a/test/team-management_test.go
+++ b/test/team-management_test.go
@@ -472,7 +472,7 @@ func testTeamManagement() {
 		By("creating test pod")
 		stdout, stderr, err := ExecAt(boot0, "kubectl", "run", "-n", "maneki", "neco-ephemeral-test", "--image=quay.io/cybozu/ubuntu-debug:20.04",
 			`--overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"securityContext":{"runAsUser":1000, "runAsGroup":1000}}}'`,
-			"pause")
+			"--", "pause")
 		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 
 		By("waiting the pod become ready")

--- a/test/teleport_test.go
+++ b/test/teleport_test.go
@@ -57,8 +57,8 @@ func teleportNodeServiceTest() {
 
 func teleportSSHConnectionTest() {
 	By("creating user")
-	ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "users", "rm", "cybozu")
-	stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "users", "add", "cybozu", "cybozu,root")
+	ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "--", "tctl", "users", "rm", "cybozu")
+	stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "--", "tctl", "users", "add", "cybozu", "cybozu,root")
 	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 	tctlOutput := string(stdout)
 	fmt.Println("output:")
@@ -198,14 +198,14 @@ func teleportSSHConnectionTest() {
 
 func teleportAuthTest() {
 	By("getting the node list before recreating the teleport-auth pod")
-	stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "get", "nodes")
+	stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "--", "tctl", "get", "nodes")
 	Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 	beforeNodes := decodeNodes(stdout)
 
 	By("recreating the teleport-auth pod")
 	ExecSafeAt(boot0, "kubectl", "-n", "teleport", "delete", "pod", "teleport-auth-0")
 	Eventually(func() error {
-		stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "status")
+		stdout, stderr, err := ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "--", "tctl", "status")
 		if err != nil {
 			return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 		}
@@ -214,7 +214,7 @@ func teleportAuthTest() {
 
 	By("comparing the current node list with the obtained before")
 	Eventually(func() error {
-		stdout, stderr, err = ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "tctl", "get", "nodes")
+		stdout, stderr, err = ExecAt(boot0, "kubectl", "-n", "teleport", "exec", "teleport-auth-0", "--", "tctl", "get", "nodes")
 		if err != nil {
 			return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 		}


### PR DESCRIPTION
Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>