### PR TITLE
Container regular update (ArgoCD, Calico, cert-manager, Contour, ExternalDNS and neco-admission)

### DIFF
--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -9,8 +9,8 @@ patchesStrategicMerge:
   - service.yaml
 images:
   - name: quay.io/cybozu/argocd
-    newTag: 2.1.2.2
+    newTag: 2.1.8.1
   - name: quay.io/cybozu/dex
-    newTag: 2.27.0.4
+    newTag: 2.27.0.5
   - name: quay.io/cybozu/redis
-    newTag: 6.2.5.1
+    newTag: 6.2.5.2

--- a/argocd/base/upstream/install.yaml
+++ b/argocd/base/upstream/install.yaml
@@ -2847,7 +2847,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  ssh_known_hosts: |
+  ssh_known_hosts: |-
     bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
     github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
     gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
@@ -2855,6 +2855,8 @@ data:
     gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
     ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
     vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
+    github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+    github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
 kind: ConfigMap
 metadata:
   labels:
@@ -3049,7 +3051,7 @@ spec:
         - -n
         - /usr/local/bin/argocd
         - /shared/argocd-dex
-        image: quay.io/argoproj/argocd:v2.1.2
+        image: quay.io/argoproj/argocd:v2.1.8
         imagePullPolicy: Always
         name: copyutil
         volumeMounts:
@@ -3224,7 +3226,13 @@ spec:
               key: reposerver.default.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        image: quay.io/argoproj/argocd:v2.1.2
+        - name: HELM_CACHE_HOME
+          value: /helm-working-dir
+        - name: HELM_CONFIG_HOME
+          value: /helm-working-dir
+        - name: HELM_DATA_HOME
+          value: /helm-working-dir
+        image: quay.io/argoproj/argocd:v2.1.8
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
@@ -3263,6 +3271,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /tmp
           name: tmp
+        - mountPath: /helm-working-dir
+          name: helm-working-dir
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm
@@ -3277,6 +3287,8 @@ spec:
         name: gpg-keyring
       - emptyDir: {}
         name: tmp
+      - emptyDir: {}
+        name: helm-working-dir
       - name: argocd-repo-server-tls
         secret:
           items:
@@ -3469,7 +3481,7 @@ spec:
               key: server.default.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        image: quay.io/argoproj/argocd:v2.1.2
+        image: quay.io/argoproj/argocd:v2.1.8
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -3659,7 +3671,7 @@ spec:
               key: controller.default.cache.expiration
               name: argocd-cmd-params-cm
               optional: true
-        image: quay.io/argoproj/argocd:v2.1.2
+        image: quay.io/argoproj/argocd:v2.1.8
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/cert-manager/base/kustomization.yaml
+++ b/cert-manager/base/kustomization.yaml
@@ -9,4 +9,4 @@ patchesStrategicMerge:
   - validatingwebhookconfiguration.yaml
 images:
   - name: quay.io/cybozu/cert-manager
-    newTag: 1.5.4.1
+    newTag: 1.6.1.1

--- a/cert-manager/base/upstream/cert-manager.yaml
+++ b/cert-manager/base/upstream/cert-manager.yaml
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   group: cert-manager.io
   names:
@@ -227,7 +227,7 @@ spec:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
                   type: string
                   format: date-time
-      served: true
+      served: false
       storage: false
     - name: v1alpha3
       subresources:
@@ -396,7 +396,7 @@ spec:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
                   type: string
                   format: date-time
-      served: true
+      served: false
       storage: false
     - name: v1beta1
       subresources:
@@ -567,7 +567,7 @@ spec:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
                   type: string
                   format: date-time
-      served: true
+      served: false
       storage: false
     - name: v1
       subresources:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   group: cert-manager.io
   names:
@@ -1103,7 +1103,7 @@ spec:
                 revision:
                   description: "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field."
                   type: integer
-      served: true
+      served: false
       storage: false
     - name: v1alpha3
       subresources:
@@ -1420,7 +1420,7 @@ spec:
                 revision:
                   description: "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field."
                   type: integer
-      served: true
+      served: false
       storage: false
     - name: v1beta1
       subresources:
@@ -1739,7 +1739,7 @@ spec:
                 revision:
                   description: "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field."
                   type: integer
-      served: true
+      served: false
       storage: false
     - name: v1
       subresources:
@@ -2074,7 +2074,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   group: acme.cert-manager.io
   names:
@@ -2273,6 +2273,7 @@ spec:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                             environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
                               type: string
                               enum:
                                 - AzurePublicCloud
@@ -2280,10 +2281,23 @@ spec:
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
                             hostedZoneName:
+                              description: name of the DNS zone that should be used
                               type: string
+                            managedIdentity:
+                              description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                              type: object
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: resource ID of the managed identity, can not be used at the same time as clientID
+                                  type: string
                             resourceGroupName:
+                              description: resource group the DNS zone is located in
                               type: string
                             subscriptionID:
+                              description: ID of the Azure subscription
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
@@ -2679,7 +2693,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -2760,7 +2774,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -2848,7 +2862,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -2929,7 +2943,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -3060,7 +3074,7 @@ spec:
                     - invalid
                     - expired
                     - errored
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -3230,6 +3244,7 @@ spec:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                             environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
                               type: string
                               enum:
                                 - AzurePublicCloud
@@ -3237,10 +3252,23 @@ spec:
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
                             hostedZoneName:
+                              description: name of the DNS zone that should be used
                               type: string
+                            managedIdentity:
+                              description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                              type: object
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: resource ID of the managed identity, can not be used at the same time as clientID
+                                  type: string
                             resourceGroupName:
+                              description: resource group the DNS zone is located in
                               type: string
                             subscriptionID:
+                              description: ID of the Azure subscription
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
@@ -3636,7 +3664,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -3717,7 +3745,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -3805,7 +3833,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -3886,7 +3914,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -4017,7 +4045,7 @@ spec:
                     - invalid
                     - expired
                     - errored
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -4188,6 +4216,7 @@ spec:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                             environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
                               type: string
                               enum:
                                 - AzurePublicCloud
@@ -4195,10 +4224,23 @@ spec:
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
                             hostedZoneName:
+                              description: name of the DNS zone that should be used
                               type: string
+                            managedIdentity:
+                              description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                              type: object
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: resource ID of the managed identity, can not be used at the same time as clientID
+                                  type: string
                             resourceGroupName:
+                              description: resource group the DNS zone is located in
                               type: string
                             subscriptionID:
+                              description: ID of the Azure subscription
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
@@ -4594,7 +4636,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -4675,7 +4717,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -4763,7 +4805,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -4844,7 +4886,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -4975,7 +5017,7 @@ spec:
                     - invalid
                     - expired
                     - errored
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -5146,6 +5188,7 @@ spec:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                             environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
                               type: string
                               enum:
                                 - AzurePublicCloud
@@ -5153,10 +5196,23 @@ spec:
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
                             hostedZoneName:
+                              description: name of the DNS zone that should be used
                               type: string
+                            managedIdentity:
+                              description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                              type: object
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: resource ID of the managed identity, can not be used at the same time as clientID
+                                  type: string
                             resourceGroupName:
+                              description: resource group the DNS zone is located in
                               type: string
                             subscriptionID:
+                              description: ID of the Azure subscription
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
@@ -5552,7 +5608,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -5633,7 +5689,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -5721,7 +5777,7 @@ spec:
                                                             additionalProperties:
                                                               type: string
                                                       namespaceSelector:
-                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                         type: object
                                                         properties:
                                                           matchExpressions:
@@ -5802,7 +5858,7 @@ spec:
                                                         additionalProperties:
                                                           type: string
                                                   namespaceSelector:
-                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -5950,7 +6006,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   group: cert-manager.io
   names:
@@ -6183,6 +6239,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -6190,10 +6247,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -6589,7 +6659,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -6670,7 +6740,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -6758,7 +6828,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -6839,7 +6909,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -7149,7 +7219,7 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
-      served: true
+      served: false
       storage: false
     - name: v1alpha3
       subresources:
@@ -7352,6 +7422,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -7359,10 +7430,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -7758,7 +7842,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -7839,7 +7923,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -7927,7 +8011,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -8008,7 +8092,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -8318,7 +8402,7 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
-      served: true
+      served: false
       storage: false
     - name: v1beta1
       subresources:
@@ -8523,6 +8607,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -8530,10 +8615,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -8929,7 +9027,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -9010,7 +9108,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -9098,7 +9196,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -9179,7 +9277,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -9489,7 +9587,7 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
-      served: true
+      served: false
       storage: false
     - name: v1
       subresources:
@@ -9694,6 +9792,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -9701,10 +9800,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -10100,7 +10212,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -10181,7 +10293,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -10269,7 +10381,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -10350,7 +10462,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -10675,7 +10787,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   group: cert-manager.io
   names:
@@ -10908,6 +11020,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -10915,10 +11028,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -11314,7 +11440,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -11395,7 +11521,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -11483,7 +11609,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -11564,7 +11690,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -11874,7 +12000,7 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
-      served: true
+      served: false
       storage: false
     - name: v1alpha3
       subresources:
@@ -12077,6 +12203,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -12084,10 +12211,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -12483,7 +12623,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -12564,7 +12704,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -12652,7 +12792,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -12733,7 +12873,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -13043,7 +13183,7 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
-      served: true
+      served: false
       storage: false
     - name: v1beta1
       subresources:
@@ -13248,6 +13388,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -13255,10 +13396,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -13654,7 +13808,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -13735,7 +13889,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -13823,7 +13977,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -13904,7 +14058,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -14214,7 +14368,7 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
-      served: true
+      served: false
       storage: false
     - name: v1
       subresources:
@@ -14419,6 +14573,7 @@ spec:
                                         description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                   environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
                                     type: string
                                     enum:
                                       - AzurePublicCloud
@@ -14426,10 +14581,23 @@ spec:
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
                                   hostedZoneName:
+                                    description: name of the DNS zone that should be used
                                     type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
                                   resourceGroupName:
+                                    description: resource group the DNS zone is located in
                                     type: string
                                   subscriptionID:
+                                    description: ID of the Azure subscription
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
@@ -14825,7 +14993,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -14906,7 +15074,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -14994,7 +15162,7 @@ spec:
                                                                   additionalProperties:
                                                                     type: string
                                                             namespaceSelector:
-                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                               type: object
                                                               properties:
                                                                 matchExpressions:
@@ -15075,7 +15243,7 @@ spec:
                                                               additionalProperties:
                                                                 type: string
                                                         namespaceSelector:
-                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
@@ -15400,7 +15568,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   group: acme.cert-manager.io
   names:
@@ -15588,7 +15756,7 @@ spec:
                 url:
                   description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
                   type: string
-      served: true
+      served: false
       storage: false
     - name: v1alpha3
       subresources:
@@ -15745,7 +15913,7 @@ spec:
                 url:
                   description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
                   type: string
-      served: true
+      served: false
       storage: false
     - name: v1beta1
       subresources:
@@ -15903,7 +16071,7 @@ spec:
                 url:
                   description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
                   type: string
-      served: true
+      served: false
       storage: false
     - name: v1
       subresources:
@@ -16081,7 +16249,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -16095,7 +16263,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -16109,7 +16277,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16121,7 +16289,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -16156,7 +16324,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -16182,7 +16350,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -16208,7 +16376,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -16243,7 +16411,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -16281,7 +16449,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -16341,7 +16509,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -16378,7 +16546,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -16400,7 +16568,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -16422,7 +16590,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -16442,7 +16610,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -16468,7 +16636,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -16484,7 +16652,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16504,7 +16672,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16524,7 +16692,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16544,7 +16712,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16564,7 +16732,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16584,7 +16752,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16604,7 +16772,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16624,7 +16792,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16644,7 +16812,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16664,7 +16832,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16687,7 +16855,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -16721,7 +16889,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
   # Used for leader election by the controller
   # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
@@ -16751,7 +16919,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -16776,7 +16944,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16799,7 +16967,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16821,7 +16989,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16843,7 +17011,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   type: ClusterIP
   ports:
@@ -16867,7 +17035,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   type: ClusterIP
   ports:
@@ -16891,7 +17059,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   replicas: 1
   selector:
@@ -16906,14 +17074,14 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.5.4"
+        app.kubernetes.io/version: "v1.6.1"
     spec:
       serviceAccountName: cert-manager-cainjector
       securityContext:
         runAsNonRoot: true
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.5.4"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.6.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -16937,7 +17105,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   replicas: 1
   selector:
@@ -16952,7 +17120,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.5.4"
+        app.kubernetes.io/version: "v1.6.1"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -16963,7 +17131,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v1.5.4"
+          image: "quay.io/jetstack/cert-manager-controller:v1.6.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -16991,7 +17159,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
 spec:
   replicas: 1
   selector:
@@ -17006,14 +17174,14 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.5.4"
+        app.kubernetes.io/version: "v1.6.1"
     spec:
       serviceAccountName: cert-manager-webhook
       securityContext:
         runAsNonRoot: true
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v1.5.4"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.6.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -17063,7 +17231,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
@@ -17112,7 +17280,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.4"
+    app.kubernetes.io/version: "v1.6.1"
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -180,7 +180,6 @@ $ diff -u ingress/base/contour/03-envoy.yaml ingress/base/template/deployment-en
 Note that:
 - We do not use contour's certificate issuance feature, but use cert-manager to issue certificates required for gRPC.
 - We change Envoy manifest from DaemonSet to Deployment.
-  - We do not create `envoy` service account, and therefore `serviceAccountName: envoy` is removed from Envoy Deployment.
   - We replace or add probes with our custom one bundled in our Envoy container image.
 - Not all manifests inherit the upstream. Please check `kustomization.yaml` which manifest inherits or not.
   - If the manifest in the upstream is usable as is, use it from `ingress/base/kustomization.yaml`.

--- a/external-dns/base/deployment.yaml
+++ b/external-dns/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: quay.io/cybozu/external-dns:0.9.0.1
+        image: quay.io/cybozu/external-dns:0.10.2.1
         ports:
         - containerPort: 7979
           name: metrics

--- a/external-dns/base/rbac.yaml
+++ b/external-dns/base/rbac.yaml
@@ -9,24 +9,25 @@ kind: ClusterRole
 metadata:
   name: external-dns
 rules:
-- apiGroups: [""]
-  resources: ["services","endpoints","pods"]
-  verbs: ["get","watch","list"]
-- apiGroups: ["extensions","networking.k8s.io"]
-  resources: ["ingresses"]
-  verbs: ["get","watch","list"]
+# Setting for Service source (`--source=service`). See the following template.
+# https://github.com/kubernetes-sigs/external-dns/blob/v0.10.2/charts/external-dns/templates/clusterrole.yaml
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list"]
+  verbs: ["list","watch"]
 - apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["list"]
+  resources: ["pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["services","endpoints"]
+  verbs: ["get","watch","list"]
+# Setting for CRD source (`--source=crd`). See the following document.
+# https://github.com/kubernetes-sigs/external-dns/blob/v0.10.2/docs/contributing/crd-source.md#rbac-configuration
 - apiGroups: ["externaldns.k8s.io"]
   resources: ["dnsendpoints"]
   verbs: ["get","watch","list"]
 - apiGroups: ["externaldns.k8s.io"]
   resources: ["dnsendpoints/status"]
-  verbs: ["update"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ingress/base/contour/01-contour-config.yaml
+++ b/ingress/base/contour/01-contour-config.yaml
@@ -14,8 +14,6 @@ data:
     # Specify the Gateway API configuration.
     # gateway:
     #   controllerName: projectcontour.io/projectcontour/contour
-    #   name: contour
-    #   namespace: projectcontour
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
@@ -57,7 +55,11 @@ data:
     # This is not recommended without understanding the security implications.
     # Please see the advisory at https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc for the details.
     # enableExternalNameService: false
-    ## 
+    ##
+    # Address to be placed in status.loadbalancer field of Ingress objects.
+    # May be either a literal IP address or a host name.
+    # The value will be placed directly into the relevant field inside the status.loadBalancer struct.
+    # ingress-status-address: local.projectcontour.io
     ### Logging options
     # Default setting
     accesslog-format: envoy

--- a/ingress/base/contour/01-crds.yaml
+++ b/ingress/base/contour/01-crds.yaml
@@ -3,7 +3,1839 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
+  creationTimestamp: null
+  name: contourconfigurations.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ContourConfiguration
+    listKind: ContourConfigurationList
+    plural: contourconfigurations
+    shortNames:
+    - contourconfig
+    singular: contourconfiguration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContourConfiguration is the schema for a Contour instance.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContourConfigurationSpec represents a configuration of a
+              Contour controller. It contains most of all the options that can be
+              customized, the other remaining options being command line flags.
+            properties:
+              debug:
+                default:
+                  kubernetesLogLevel: 0
+                  logLevel: info
+                description: Debug contains parameters to enable debug logging and
+                  debug interfaces inside Contour.
+                properties:
+                  address:
+                    description: Defines the Contour debug address interface.
+                    type: string
+                  kubernetesLogLevel:
+                    default: 0
+                    description: "KubernetesDebugLogLevel defines the log level which
+                      Contour will use when outputting Kubernetes specific log information.
+                      \n Details: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md"
+                    maximum: 9
+                    minimum: 0
+                    type: integer
+                  logLevel:
+                    description: DebugLogLevel defines the log level which Contour
+                      will use when outputting log information.
+                    enum:
+                    - info
+                    - debug
+                    type: string
+                  port:
+                    description: Defines the Contour debug address port.
+                    type: integer
+                required:
+                - logLevel
+                type: object
+              enableExternalNameService:
+                default: false
+                description: EnableExternalNameService allows processing of ExternalNameServices
+                  Defaults to disabled for security reasons.
+                type: boolean
+              envoy:
+                default:
+                  cluster:
+                    dnsLookupFamily: auto
+                  defaultHTTPVersions:
+                  - HTTP/1.1
+                  - HTTP/2
+                  http:
+                    accessLog: /dev/stdout
+                    address: 0.0.0.0
+                    port: 8080
+                  https:
+                    accessLog: /dev/stdout
+                    address: 0.0.0.0
+                    port: 8443
+                  listener:
+                    connectionBalancer: ""
+                    disableAllowChunkedLength: false
+                    tls:
+                      cipherSuites:
+                      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      minimumProtocolVersion: "1.2"
+                    useProxyProtocol: false
+                  logging:
+                    accessLogFormat: envoy
+                  metrics:
+                    address: 0.0.0.0
+                    port: 8002
+                  network:
+                    adminPort: 9001
+                  service:
+                    name: envoy
+                    namespace: projectcontour
+                description: Envoy contains parameters for Envoy as well as how to
+                  optionally configure a managed Envoy fleet.
+                properties:
+                  clientCertificate:
+                    description: ClientCertificate defines the namespace/name of the
+                      Kubernetes secret containing the client certificate and private
+                      key to be used when establishing TLS connection to upstream
+                      cluster.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  cluster:
+                    description: Cluster holds various configurable Envoy cluster
+                      values that can be set in the config file.
+                    properties:
+                      dnsLookupFamily:
+                        default: auto
+                        description: "DNSLookupFamily defines how external names are
+                          looked up When configured as V4, the DNS resolver will only
+                          perform a lookup for addresses in the IPv4 family. If V6
+                          is configured, the DNS resolver will only perform a lookup
+                          for addresses in the IPv6 family. If AUTO is configured,
+                          the DNS resolver will first perform a lookup for addresses
+                          in the IPv6 family and fallback to a lookup for addresses
+                          in the IPv4 family. Note: This only applies to externalName
+                          clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information."
+                        enum:
+                        - auto
+                        - v4
+                        - v6
+                        type: string
+                    required:
+                    - dnsLookupFamily
+                    type: object
+                  defaultHTTPVersions:
+                    description: DefaultHTTPVersions defines the default set of HTTPS
+                      versions the proxy should accept. HTTP versions are strings
+                      of the form "HTTP/xx". Supported versions are "HTTP/1.1" and
+                      "HTTP/2".
+                    items:
+                      description: HTTPVersionType is the name of a supported HTTP
+                        version.
+                      enum:
+                      - HTTP/1.1
+                      - HTTP/2
+                      type: string
+                    type: array
+                  http:
+                    default:
+                      accessLog: /dev/stdout
+                      address: 0.0.0.0
+                      port: 8080
+                    description: Defines the HTTP Listener for Envoy.
+                    properties:
+                      accessLog:
+                        description: AccessLog defines where Envoy logs are outputted
+                          for this listener.
+                        type: string
+                      address:
+                        description: Defines an Envoy Listener Address.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines an Envoy listener Port.
+                        type: integer
+                    required:
+                    - accessLog
+                    - address
+                    - port
+                    type: object
+                  https:
+                    default:
+                      accessLog: /dev/stdout
+                      address: 0.0.0.0
+                      port: 8443
+                    description: Defines the HTTP Listener for Envoy.
+                    properties:
+                      accessLog:
+                        description: AccessLog defines where Envoy logs are outputted
+                          for this listener.
+                        type: string
+                      address:
+                        description: Defines an Envoy Listener Address.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines an Envoy listener Port.
+                        type: integer
+                    required:
+                    - accessLog
+                    - address
+                    - port
+                    type: object
+                  listener:
+                    description: Listener hold various configurable Envoy listener
+                      values.
+                    properties:
+                      connectionBalancer:
+                        description: ConnectionBalancer. If the value is exact, the
+                          listener will use the exact connection balancer See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                          for more information.
+                        enum:
+                        - ""
+                        - exact
+                        type: string
+                      disableAllowChunkedLength:
+                        description: 'DisableAllowChunkedLength disables the RFC-compliant
+                          Envoy behavior to strip the "Content-Length" header if "Transfer-Encoding:
+                          chunked" is also set. This is an emergency off-switch to
+                          revert back to Envoy''s default behavior in case of failures.
+                          Please file an issue if failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
+                        type: boolean
+                      tls:
+                        description: TLS holds various configurable Envoy TLS listener
+                          values.
+                        properties:
+                          cipherSuites:
+                            description: "CipherSuites defines the TLS ciphers to
+                              be supported by Envoy TLS listeners when negotiating
+                              TLS 1.2. Ciphers are validated against the set that
+                              Envoy supports by default. This parameter should only
+                              be used by advanced users. Note that these will be ignored
+                              when TLS 1.3 is in use. \n See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                              Note: This list is a superset of what is valid for stock
+                              Envoy builds and those using BoringSSL FIPS."
+                            items:
+                              enum:
+                              - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                              - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                              - ECDHE-ECDSA-AES128-GCM-SHA256
+                              - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES128-SHA
+                              - ECDHE-RSA-AES128-SHA
+                              - AES128-GCM-SHA256
+                              - AES128-SHA
+                              - ECDHE-ECDSA-AES256-GCM-SHA384
+                              - ECDHE-RSA-AES256-GCM-SHA384
+                              - ECDHE-ECDSA-AES256-SHA
+                              - ECDHE-RSA-AES256-SHA
+                              - AES256-GCM-SHA384
+                              - AES256-SHA
+                              type: string
+                            type: array
+                          minimumProtocolVersion:
+                            description: MinimumProtocolVersion is the minimum TLS
+                              version this vhost should negotiate. Valid options are
+                              `1.2` (default) and `1.3`.
+                            enum:
+                            - "1.2"
+                            - "1.3"
+                            type: string
+                        required:
+                        - cipherSuites
+                        - minimumProtocolVersion
+                        type: object
+                      useProxyProtocol:
+                        description: Use PROXY protocol for all listeners.
+                        type: boolean
+                    required:
+                    - connectionBalancer
+                    - disableAllowChunkedLength
+                    - tls
+                    - useProxyProtocol
+                    type: object
+                  logging:
+                    description: Logging defines how Envoy's logs can be configured.
+                    properties:
+                      accessLogFormat:
+                        description: AccessLogFormat sets the global access log format.
+                          Valid options are 'envoy' or 'json'
+                        enum:
+                        - envoy
+                        - json
+                        type: string
+                      accessLogFormatString:
+                        description: AccessLogFormatString sets the access log format
+                          when format is set to `envoy`. When empty, Envoy's default
+                          format is used.
+                        type: string
+                      jsonFields:
+                        description: AccessLogFields sets the fields that JSON logging
+                          will output when AccessLogFormat is json.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - accessLogFormat
+                    type: object
+                  metrics:
+                    default:
+                      address: 0.0.0.0
+                      port: 8002
+                    description: Metrics defines the endpoints Envoy use to serve
+                      to metrics.
+                    properties:
+                      address:
+                        description: Defines the metrics address interface.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the metrics port.
+                        type: integer
+                    required:
+                    - address
+                    - port
+                    type: object
+                  network:
+                    description: Network holds various configurable Envoy network
+                      values.
+                    properties:
+                      adminPort:
+                        default: 9001
+                        description: Configure the port used to access the Envoy Admin
+                          interface. If configured to port "0" then the admin interface
+                          is disabled.
+                        type: integer
+                      numTrustedHops:
+                        description: "XffNumTrustedHops defines the number of additional
+                          ingress proxy hops from the right side of the x-forwarded-for
+                          HTTP header to trust when determining the origin client’s
+                          IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                          for more information."
+                        format: int32
+                        type: integer
+                    required:
+                    - adminPort
+                    type: object
+                  service:
+                    default:
+                      name: envoy
+                      namespace: projectcontour
+                    description: Service holds Envoy service parameters for setting
+                      Ingress status.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  timeouts:
+                    description: Timeouts holds various configurable timeouts that
+                      can be set in the config file.
+                    properties:
+                      connectionIdleTimeout:
+                        description: "ConnectionIdleTimeout defines how long the proxy
+                          should wait while there are no active requests (for HTTP/1.1)
+                          or streams (for HTTP/2) before terminating an HTTP connection.
+                          Set to \"infinity\" to disable the timeout entirely. \n
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+                          for more information."
+                        type: string
+                      connectionShutdownGracePeriod:
+                        description: "ConnectionShutdownGracePeriod defines how long
+                          the proxy will wait between sending an initial GOAWAY frame
+                          and a second, final GOAWAY frame when terminating an HTTP/2
+                          connection. During this grace period, the proxy will continue
+                          to respond to new streams. After the final GOAWAY frame
+                          has been sent, the proxy will refuse new streams. \n See
+                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+                          for more information."
+                        type: string
+                      delayedCloseTimeout:
+                        description: "DelayedCloseTimeout defines how long envoy will
+                          wait, once connection close processing has been initiated,
+                          for the downstream peer to close the connection before Envoy
+                          closes the socket associated with the connection. \n Setting
+                          this timeout to 'infinity' will disable it, equivalent to
+                          setting it to '0' in Envoy. Leaving it unset will result
+                          in the Envoy default value being used. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
+                          for more information."
+                        type: string
+                      maxConnectionDuration:
+                        description: "MaxConnectionDuration defines the maximum period
+                          of time after an HTTP connection has been established from
+                          the client to the proxy before it is closed by the proxy,
+                          regardless of whether there has been activity or not. Omit
+                          or set to \"infinity\" for no max duration. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+                          for more information."
+                        type: string
+                      requestTimeout:
+                        description: "RequestTimeout sets the client request timeout
+                          globally for Contour. Note that this is a timeout for the
+                          entire request, not an idle timeout. Omit or set to \"infinity\"
+                          to disable the timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
+                          for more information."
+                        type: string
+                      streamIdleTimeout:
+                        description: "StreamIdleTimeout defines how long the proxy
+                          should wait while there is no request activity (for HTTP/1.1)
+                          or stream activity (for HTTP/2) before terminating the HTTP
+                          request or stream. Set to \"infinity\" to disable the timeout
+                          entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+                          for more information."
+                        type: string
+                    type: object
+                required:
+                - cluster
+                - defaultHTTPVersions
+                - http
+                - https
+                - listener
+                - logging
+                - metrics
+                - network
+                - service
+                type: object
+              gateway:
+                description: Gateway contains parameters for the gateway-api Gateway
+                  that Contour is configured to serve traffic.
+                properties:
+                  controllerName:
+                    default: projectcontour.io/projectcontour/contour
+                    description: ControllerName is used to determine whether Contour
+                      should reconcile a GatewayClass. The string takes the form of
+                      "projectcontour.io/<namespace>/contour". If unset, the gatewayclass
+                      controller will not be started.
+                    type: string
+                required:
+                - controllerName
+                type: object
+              health:
+                default:
+                  address: 0.0.0.0
+                  port: 8000
+                description: Health contains parameters to configure endpoints which
+                  Contour exposes to respond to Kubernetes health checks.
+                properties:
+                  address:
+                    description: Defines the Contour health address interface.
+                    minLength: 1
+                    type: string
+                  port:
+                    description: Defines the Contour health port.
+                    type: integer
+                required:
+                - address
+                - port
+                type: object
+              httpproxy:
+                default:
+                  disablePermitInsecure: false
+                description: HTTPProxy defines parameters on HTTPProxy.
+                properties:
+                  disablePermitInsecure:
+                    description: DisablePermitInsecure disables the use of the permitInsecure
+                      field in HTTPProxy.
+                    type: boolean
+                  fallbackCertificate:
+                    description: FallbackCertificate defines the namespace/name of
+                      the Kubernetes secret to use as fallback when a non-SNI request
+                      is received.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  rootNamespaces:
+                    description: Restrict Contour to searching these namespaces for
+                      root ingress routes.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - disablePermitInsecure
+                type: object
+              ingress:
+                description: Ingress contains parameters for ingress options.
+                properties:
+                  className:
+                    description: Ingress Class Name Contour should use.
+                    type: string
+                  statusAddress:
+                    description: Address to set in Ingress object status.
+                    type: string
+                type: object
+              leaderElection:
+                default:
+                  configmap:
+                    name: leader-elect
+                    namespace: projectcontour
+                  disableLeaderElection: false
+                  leaseDuration: 15s
+                  renewDeadline: 10s
+                  retryPeriod: 2s
+                description: LeaderElection contains leader election parameters.
+                properties:
+                  configmap:
+                    description: NamespacedName defines the namespace/name of the
+                      Kubernetes resource referred from the config file. Used for
+                      Contour config YAML file parsing, otherwise we could use K8s
+                      types.NamespacedName.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  disableLeaderElection:
+                    type: boolean
+                  leaseDuration:
+                    type: string
+                  renewDeadline:
+                    type: string
+                  retryPeriod:
+                    type: string
+                required:
+                - disableLeaderElection
+                type: object
+              metrics:
+                default:
+                  address: 0.0.0.0
+                  port: 8000
+                description: Metrics defines the endpoints Contour uses to serve to
+                  metrics.
+                properties:
+                  address:
+                    description: Defines the metrics address interface.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  port:
+                    description: Defines the metrics port.
+                    type: integer
+                required:
+                - address
+                - port
+                type: object
+              policy:
+                description: Policy specifies default policy applied if not overridden
+                  by the user
+                properties:
+                  applyToIngress:
+                    description: ApplyToIngress determines if the Policies will apply
+                      to ingress objects
+                    type: boolean
+                  requestHeaders:
+                    description: RequestHeadersPolicy defines the request headers
+                      set/removed on all routes
+                    properties:
+                      remove:
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  responseHeaders:
+                    description: ResponseHeadersPolicy defines the response headers
+                      set/removed on all routes
+                    properties:
+                      remove:
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              rateLimitService:
+                description: RateLimitService optionally holds properties of the Rate
+                  Limit Service to be used for global rate limiting.
+                properties:
+                  domain:
+                    description: Domain is passed to the Rate Limit Service.
+                    type: string
+                  enableXRateLimitHeaders:
+                    description: "EnableXRateLimitHeaders defines whether to include
+                      the X-RateLimit headers X-RateLimit-Limit, X-RateLimit-Remaining,
+                      and X-RateLimit-Reset (as defined by the IETF Internet-Draft
+                      linked below), on responses to clients when the Rate Limit Service
+                      is consulted for a request. \n ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html"
+                    type: boolean
+                  extensionService:
+                    description: ExtensionService identifies the extension service
+                      defining the RLS.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  failOpen:
+                    description: FailOpen defines whether to allow requests to proceed
+                      when the Rate Limit Service fails to respond with a valid rate
+                      limit decision within the timeout defined on the extension service.
+                    type: boolean
+                required:
+                - domain
+                - enableXRateLimitHeaders
+                - failOpen
+                type: object
+              xdsServer:
+                default:
+                  address: 0.0.0.0
+                  port: 8001
+                  tls:
+                    caFile: /certs/ca.crt
+                    certFile: /certs/tls.crt
+                    insecure: false
+                    keyFile: /certs/tls.key
+                  type: contour
+                description: XDSServer contains parameters for the xDS server.
+                properties:
+                  address:
+                    description: Defines the xDS gRPC API address which Contour will
+                      serve.
+                    minLength: 1
+                    type: string
+                  port:
+                    description: Defines the xDS gRPC API port which Contour will
+                      serve.
+                    type: integer
+                  tls:
+                    description: TLS holds TLS file config details.
+                    properties:
+                      caFile:
+                        description: CA filename.
+                        type: string
+                      certFile:
+                        description: Client certificate filename.
+                        type: string
+                      insecure:
+                        description: Allow serving the xDS gRPC API without TLS.
+                        type: boolean
+                      keyFile:
+                        description: Client key filename.
+                        type: string
+                    required:
+                    - insecure
+                    type: object
+                  type:
+                    description: Defines the XDSServer to use for `contour serve`.
+                    enum:
+                    - contour
+                    - envoy
+                    type: string
+                required:
+                - address
+                - port
+                - type
+                type: object
+            type: object
+          status:
+            description: ContourConfigurationStatus defines the observed state of
+              a ContourConfiguration resource.
+            properties:
+              conditions:
+                description: "Conditions contains the current status of the Contour
+                  resource. \n Contour will update a single condition, `Valid`, that
+                  is in normal-true polarity. \n Contour will not modify any other
+                  Conditions set in this block, in case some other controller wants
+                  to add a Condition."
+                items:
+                  description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour.  The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
+                  properties:
+                    errors:
+                      description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
+                      items:
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                        properties:
+                          message:
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    warnings:
+                      description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
+                      items:
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                        properties:
+                          message:
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
+  creationTimestamp: null
+  name: contourdeployments.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ContourDeployment
+    listKind: ContourDeploymentList
+    plural: contourdeployments
+    shortNames:
+    - contourdeploy
+    singular: contourdeployment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContourDeployment is the schema for a Contour Deployment.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContourDeploymentSpec defines the parameters of how a Contour
+              instance should be configured.
+            properties:
+              config:
+                description: Config is the config that the instances of Contour are
+                  to utilize.
+                properties:
+                  debug:
+                    default:
+                      kubernetesLogLevel: 0
+                      logLevel: info
+                    description: Debug contains parameters to enable debug logging
+                      and debug interfaces inside Contour.
+                    properties:
+                      address:
+                        description: Defines the Contour debug address interface.
+                        type: string
+                      kubernetesLogLevel:
+                        default: 0
+                        description: "KubernetesDebugLogLevel defines the log level
+                          which Contour will use when outputting Kubernetes specific
+                          log information. \n Details: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md"
+                        maximum: 9
+                        minimum: 0
+                        type: integer
+                      logLevel:
+                        description: DebugLogLevel defines the log level which Contour
+                          will use when outputting log information.
+                        enum:
+                        - info
+                        - debug
+                        type: string
+                      port:
+                        description: Defines the Contour debug address port.
+                        type: integer
+                    required:
+                    - logLevel
+                    type: object
+                  enableExternalNameService:
+                    default: false
+                    description: EnableExternalNameService allows processing of ExternalNameServices
+                      Defaults to disabled for security reasons.
+                    type: boolean
+                  envoy:
+                    default:
+                      cluster:
+                        dnsLookupFamily: auto
+                      defaultHTTPVersions:
+                      - HTTP/1.1
+                      - HTTP/2
+                      http:
+                        accessLog: /dev/stdout
+                        address: 0.0.0.0
+                        port: 8080
+                      https:
+                        accessLog: /dev/stdout
+                        address: 0.0.0.0
+                        port: 8443
+                      listener:
+                        connectionBalancer: ""
+                        disableAllowChunkedLength: false
+                        tls:
+                          cipherSuites:
+                          - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                          - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                          - ECDHE-ECDSA-AES256-GCM-SHA384
+                          - ECDHE-RSA-AES256-GCM-SHA384
+                          minimumProtocolVersion: "1.2"
+                        useProxyProtocol: false
+                      logging:
+                        accessLogFormat: envoy
+                      metrics:
+                        address: 0.0.0.0
+                        port: 8002
+                      network:
+                        adminPort: 9001
+                      service:
+                        name: envoy
+                        namespace: projectcontour
+                    description: Envoy contains parameters for Envoy as well as how
+                      to optionally configure a managed Envoy fleet.
+                    properties:
+                      clientCertificate:
+                        description: ClientCertificate defines the namespace/name
+                          of the Kubernetes secret containing the client certificate
+                          and private key to be used when establishing TLS connection
+                          to upstream cluster.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      cluster:
+                        description: Cluster holds various configurable Envoy cluster
+                          values that can be set in the config file.
+                        properties:
+                          dnsLookupFamily:
+                            default: auto
+                            description: "DNSLookupFamily defines how external names
+                              are looked up When configured as V4, the DNS resolver
+                              will only perform a lookup for addresses in the IPv4
+                              family. If V6 is configured, the DNS resolver will only
+                              perform a lookup for addresses in the IPv6 family. If
+                              AUTO is configured, the DNS resolver will first perform
+                              a lookup for addresses in the IPv6 family and fallback
+                              to a lookup for addresses in the IPv4 family. Note:
+                              This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information."
+                            enum:
+                            - auto
+                            - v4
+                            - v6
+                            type: string
+                        required:
+                        - dnsLookupFamily
+                        type: object
+                      defaultHTTPVersions:
+                        description: DefaultHTTPVersions defines the default set of
+                          HTTPS versions the proxy should accept. HTTP versions are
+                          strings of the form "HTTP/xx". Supported versions are "HTTP/1.1"
+                          and "HTTP/2".
+                        items:
+                          description: HTTPVersionType is the name of a supported
+                            HTTP version.
+                          enum:
+                          - HTTP/1.1
+                          - HTTP/2
+                          type: string
+                        type: array
+                      http:
+                        default:
+                          accessLog: /dev/stdout
+                          address: 0.0.0.0
+                          port: 8080
+                        description: Defines the HTTP Listener for Envoy.
+                        properties:
+                          accessLog:
+                            description: AccessLog defines where Envoy logs are outputted
+                              for this listener.
+                            type: string
+                          address:
+                            description: Defines an Envoy Listener Address.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines an Envoy listener Port.
+                            type: integer
+                        required:
+                        - accessLog
+                        - address
+                        - port
+                        type: object
+                      https:
+                        default:
+                          accessLog: /dev/stdout
+                          address: 0.0.0.0
+                          port: 8443
+                        description: Defines the HTTP Listener for Envoy.
+                        properties:
+                          accessLog:
+                            description: AccessLog defines where Envoy logs are outputted
+                              for this listener.
+                            type: string
+                          address:
+                            description: Defines an Envoy Listener Address.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines an Envoy listener Port.
+                            type: integer
+                        required:
+                        - accessLog
+                        - address
+                        - port
+                        type: object
+                      listener:
+                        description: Listener hold various configurable Envoy listener
+                          values.
+                        properties:
+                          connectionBalancer:
+                            description: ConnectionBalancer. If the value is exact,
+                              the listener will use the exact connection balancer
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                              for more information.
+                            enum:
+                            - ""
+                            - exact
+                            type: string
+                          disableAllowChunkedLength:
+                            description: 'DisableAllowChunkedLength disables the RFC-compliant
+                              Envoy behavior to strip the "Content-Length" header
+                              if "Transfer-Encoding: chunked" is also set. This is
+                              an emergency off-switch to revert back to Envoy''s default
+                              behavior in case of failures. Please file an issue if
+                              failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
+                            type: boolean
+                          tls:
+                            description: TLS holds various configurable Envoy TLS
+                              listener values.
+                            properties:
+                              cipherSuites:
+                                description: "CipherSuites defines the TLS ciphers
+                                  to be supported by Envoy TLS listeners when negotiating
+                                  TLS 1.2. Ciphers are validated against the set that
+                                  Envoy supports by default. This parameter should
+                                  only be used by advanced users. Note that these
+                                  will be ignored when TLS 1.3 is in use. \n See:
+                                  https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                                  Note: This list is a superset of what is valid for
+                                  stock Envoy builds and those using BoringSSL FIPS."
+                                items:
+                                  enum:
+                                  - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                                  - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                                  - ECDHE-ECDSA-AES128-GCM-SHA256
+                                  - ECDHE-RSA-AES128-GCM-SHA256
+                                  - ECDHE-ECDSA-AES128-SHA
+                                  - ECDHE-RSA-AES128-SHA
+                                  - AES128-GCM-SHA256
+                                  - AES128-SHA
+                                  - ECDHE-ECDSA-AES256-GCM-SHA384
+                                  - ECDHE-RSA-AES256-GCM-SHA384
+                                  - ECDHE-ECDSA-AES256-SHA
+                                  - ECDHE-RSA-AES256-SHA
+                                  - AES256-GCM-SHA384
+                                  - AES256-SHA
+                                  type: string
+                                type: array
+                              minimumProtocolVersion:
+                                description: MinimumProtocolVersion is the minimum
+                                  TLS version this vhost should negotiate. Valid options
+                                  are `1.2` (default) and `1.3`.
+                                enum:
+                                - "1.2"
+                                - "1.3"
+                                type: string
+                            required:
+                            - cipherSuites
+                            - minimumProtocolVersion
+                            type: object
+                          useProxyProtocol:
+                            description: Use PROXY protocol for all listeners.
+                            type: boolean
+                        required:
+                        - connectionBalancer
+                        - disableAllowChunkedLength
+                        - tls
+                        - useProxyProtocol
+                        type: object
+                      logging:
+                        description: Logging defines how Envoy's logs can be configured.
+                        properties:
+                          accessLogFormat:
+                            description: AccessLogFormat sets the global access log
+                              format. Valid options are 'envoy' or 'json'
+                            enum:
+                            - envoy
+                            - json
+                            type: string
+                          accessLogFormatString:
+                            description: AccessLogFormatString sets the access log
+                              format when format is set to `envoy`. When empty, Envoy's
+                              default format is used.
+                            type: string
+                          jsonFields:
+                            description: AccessLogFields sets the fields that JSON
+                              logging will output when AccessLogFormat is json.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - accessLogFormat
+                        type: object
+                      metrics:
+                        default:
+                          address: 0.0.0.0
+                          port: 8002
+                        description: Metrics defines the endpoints Envoy use to serve
+                          to metrics.
+                        properties:
+                          address:
+                            description: Defines the metrics address interface.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines the metrics port.
+                            type: integer
+                        required:
+                        - address
+                        - port
+                        type: object
+                      network:
+                        description: Network holds various configurable Envoy network
+                          values.
+                        properties:
+                          adminPort:
+                            default: 9001
+                            description: Configure the port used to access the Envoy
+                              Admin interface. If configured to port "0" then the
+                              admin interface is disabled.
+                            type: integer
+                          numTrustedHops:
+                            description: "XffNumTrustedHops defines the number of
+                              additional ingress proxy hops from the right side of
+                              the x-forwarded-for HTTP header to trust when determining
+                              the origin client’s IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                              for more information."
+                            format: int32
+                            type: integer
+                        required:
+                        - adminPort
+                        type: object
+                      service:
+                        default:
+                          name: envoy
+                          namespace: projectcontour
+                        description: Service holds Envoy service parameters for setting
+                          Ingress status.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      timeouts:
+                        description: Timeouts holds various configurable timeouts
+                          that can be set in the config file.
+                        properties:
+                          connectionIdleTimeout:
+                            description: "ConnectionIdleTimeout defines how long the
+                              proxy should wait while there are no active requests
+                              (for HTTP/1.1) or streams (for HTTP/2) before terminating
+                              an HTTP connection. Set to \"infinity\" to disable the
+                              timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+                              for more information."
+                            type: string
+                          connectionShutdownGracePeriod:
+                            description: "ConnectionShutdownGracePeriod defines how
+                              long the proxy will wait between sending an initial
+                              GOAWAY frame and a second, final GOAWAY frame when terminating
+                              an HTTP/2 connection. During this grace period, the
+                              proxy will continue to respond to new streams. After
+                              the final GOAWAY frame has been sent, the proxy will
+                              refuse new streams. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+                              for more information."
+                            type: string
+                          delayedCloseTimeout:
+                            description: "DelayedCloseTimeout defines how long envoy
+                              will wait, once connection close processing has been
+                              initiated, for the downstream peer to close the connection
+                              before Envoy closes the socket associated with the connection.
+                              \n Setting this timeout to 'infinity' will disable it,
+                              equivalent to setting it to '0' in Envoy. Leaving it
+                              unset will result in the Envoy default value being used.
+                              \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
+                              for more information."
+                            type: string
+                          maxConnectionDuration:
+                            description: "MaxConnectionDuration defines the maximum
+                              period of time after an HTTP connection has been established
+                              from the client to the proxy before it is closed by
+                              the proxy, regardless of whether there has been activity
+                              or not. Omit or set to \"infinity\" for no max duration.
+                              \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+                              for more information."
+                            type: string
+                          requestTimeout:
+                            description: "RequestTimeout sets the client request timeout
+                              globally for Contour. Note that this is a timeout for
+                              the entire request, not an idle timeout. Omit or set
+                              to \"infinity\" to disable the timeout entirely. \n
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
+                              for more information."
+                            type: string
+                          streamIdleTimeout:
+                            description: "StreamIdleTimeout defines how long the proxy
+                              should wait while there is no request activity (for
+                              HTTP/1.1) or stream activity (for HTTP/2) before terminating
+                              the HTTP request or stream. Set to \"infinity\" to disable
+                              the timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+                              for more information."
+                            type: string
+                        type: object
+                    required:
+                    - cluster
+                    - defaultHTTPVersions
+                    - http
+                    - https
+                    - listener
+                    - logging
+                    - metrics
+                    - network
+                    - service
+                    type: object
+                  gateway:
+                    description: Gateway contains parameters for the gateway-api Gateway
+                      that Contour is configured to serve traffic.
+                    properties:
+                      controllerName:
+                        default: projectcontour.io/projectcontour/contour
+                        description: ControllerName is used to determine whether Contour
+                          should reconcile a GatewayClass. The string takes the form
+                          of "projectcontour.io/<namespace>/contour". If unset, the
+                          gatewayclass controller will not be started.
+                        type: string
+                    required:
+                    - controllerName
+                    type: object
+                  health:
+                    default:
+                      address: 0.0.0.0
+                      port: 8000
+                    description: Health contains parameters to configure endpoints
+                      which Contour exposes to respond to Kubernetes health checks.
+                    properties:
+                      address:
+                        description: Defines the Contour health address interface.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the Contour health port.
+                        type: integer
+                    required:
+                    - address
+                    - port
+                    type: object
+                  httpproxy:
+                    default:
+                      disablePermitInsecure: false
+                    description: HTTPProxy defines parameters on HTTPProxy.
+                    properties:
+                      disablePermitInsecure:
+                        description: DisablePermitInsecure disables the use of the
+                          permitInsecure field in HTTPProxy.
+                        type: boolean
+                      fallbackCertificate:
+                        description: FallbackCertificate defines the namespace/name
+                          of the Kubernetes secret to use as fallback when a non-SNI
+                          request is received.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      rootNamespaces:
+                        description: Restrict Contour to searching these namespaces
+                          for root ingress routes.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - disablePermitInsecure
+                    type: object
+                  ingress:
+                    description: Ingress contains parameters for ingress options.
+                    properties:
+                      className:
+                        description: Ingress Class Name Contour should use.
+                        type: string
+                      statusAddress:
+                        description: Address to set in Ingress object status.
+                        type: string
+                    type: object
+                  leaderElection:
+                    default:
+                      configmap:
+                        name: leader-elect
+                        namespace: projectcontour
+                      disableLeaderElection: false
+                      leaseDuration: 15s
+                      renewDeadline: 10s
+                      retryPeriod: 2s
+                    description: LeaderElection contains leader election parameters.
+                    properties:
+                      configmap:
+                        description: NamespacedName defines the namespace/name of
+                          the Kubernetes resource referred from the config file. Used
+                          for Contour config YAML file parsing, otherwise we could
+                          use K8s types.NamespacedName.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      disableLeaderElection:
+                        type: boolean
+                      leaseDuration:
+                        type: string
+                      renewDeadline:
+                        type: string
+                      retryPeriod:
+                        type: string
+                    required:
+                    - disableLeaderElection
+                    type: object
+                  metrics:
+                    default:
+                      address: 0.0.0.0
+                      port: 8000
+                    description: Metrics defines the endpoints Contour uses to serve
+                      to metrics.
+                    properties:
+                      address:
+                        description: Defines the metrics address interface.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the metrics port.
+                        type: integer
+                    required:
+                    - address
+                    - port
+                    type: object
+                  policy:
+                    description: Policy specifies default policy applied if not overridden
+                      by the user
+                    properties:
+                      applyToIngress:
+                        description: ApplyToIngress determines if the Policies will
+                          apply to ingress objects
+                        type: boolean
+                      requestHeaders:
+                        description: RequestHeadersPolicy defines the request headers
+                          set/removed on all routes
+                        properties:
+                          remove:
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      responseHeaders:
+                        description: ResponseHeadersPolicy defines the response headers
+                          set/removed on all routes
+                        properties:
+                          remove:
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                    type: object
+                  rateLimitService:
+                    description: RateLimitService optionally holds properties of the
+                      Rate Limit Service to be used for global rate limiting.
+                    properties:
+                      domain:
+                        description: Domain is passed to the Rate Limit Service.
+                        type: string
+                      enableXRateLimitHeaders:
+                        description: "EnableXRateLimitHeaders defines whether to include
+                          the X-RateLimit headers X-RateLimit-Limit, X-RateLimit-Remaining,
+                          and X-RateLimit-Reset (as defined by the IETF Internet-Draft
+                          linked below), on responses to clients when the Rate Limit
+                          Service is consulted for a request. \n ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html"
+                        type: boolean
+                      extensionService:
+                        description: ExtensionService identifies the extension service
+                          defining the RLS.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      failOpen:
+                        description: FailOpen defines whether to allow requests to
+                          proceed when the Rate Limit Service fails to respond with
+                          a valid rate limit decision within the timeout defined on
+                          the extension service.
+                        type: boolean
+                    required:
+                    - domain
+                    - enableXRateLimitHeaders
+                    - failOpen
+                    type: object
+                  xdsServer:
+                    default:
+                      address: 0.0.0.0
+                      port: 8001
+                      tls:
+                        caFile: /certs/ca.crt
+                        certFile: /certs/tls.crt
+                        insecure: false
+                        keyFile: /certs/tls.key
+                      type: contour
+                    description: XDSServer contains parameters for the xDS server.
+                    properties:
+                      address:
+                        description: Defines the xDS gRPC API address which Contour
+                          will serve.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the xDS gRPC API port which Contour will
+                          serve.
+                        type: integer
+                      tls:
+                        description: TLS holds TLS file config details.
+                        properties:
+                          caFile:
+                            description: CA filename.
+                            type: string
+                          certFile:
+                            description: Client certificate filename.
+                            type: string
+                          insecure:
+                            description: Allow serving the xDS gRPC API without TLS.
+                            type: boolean
+                          keyFile:
+                            description: Client key filename.
+                            type: string
+                        required:
+                        - insecure
+                        type: object
+                      type:
+                        description: Defines the XDSServer to use for `contour serve`.
+                        enum:
+                        - contour
+                        - envoy
+                        type: string
+                    required:
+                    - address
+                    - port
+                    - type
+                    type: object
+                type: object
+              replicas:
+                default: 2
+                description: Replicas is the desired number of Contour replicas. If
+                  unset, defaults to 2.
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - config
+            type: object
+          status:
+            description: ContourDeploymentStatus defines the observed state of a ContourDeployment
+              resource.
+            properties:
+              conditions:
+                description: "Conditions contains the current status of the Contour
+                  resource. \n Contour will update a single condition, `Valid`, that
+                  is in normal-true polarity. \n Contour will not modify any other
+                  Conditions set in this block, in case some other controller wants
+                  to add a Condition."
+                items:
+                  description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour.  The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
+                  properties:
+                    errors:
+                      description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
+                      items:
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                        properties:
+                          message:
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    warnings:
+                      description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
+                      items:
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
+                        properties:
+                          message:
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: extensionservices.projectcontour.io
 spec:
@@ -141,11 +1973,12 @@ spec:
                 description: The timeout policy for requests to the services.
                 properties:
                   idle:
-                    description: Timeout after which, if there are no active requests
-                      for this route, the connection between Envoy and the backend
-                      or Envoy and the external client will be closed. If not specified,
-                      there is no per-route idle timeout, though a connection manager-wide
-                      stream_idle_timeout default of 5m still applies.
+                    description: Timeout for how long the proxy should wait while
+                      there is no activity during single request/response (for HTTP/1.1)
+                      or stream (for HTTP/2). Timeout will not trigger while HTTP/1.1
+                      connection is idle between two consecutive requests. If not
+                      specified, there is no per-route idle timeout, though a connection
+                      manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
                   response:
@@ -403,7 +2236,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: httpproxies.projectcontour.io
 spec:
@@ -619,6 +2452,64 @@ spec:
                           prefix:
                             description: Prefix defines a prefix match for a request.
                             type: string
+                        type: object
+                      type: array
+                    cookieRewritePolicies:
+                      description: The policies for rewriting Set-Cookie header attributes.
+                        Note that rewritten cookie names must be unique in this list.
+                        Order rewrite policies are specified in does not matter.
+                      items:
+                        properties:
+                          domainRewrite:
+                            description: DomainRewrite enables rewriting the Set-Cookie
+                              Domain element. If not set, Domain will not be rewritten.
+                            properties:
+                              value:
+                                description: Value is the value to rewrite the Domain
+                                  attribute to. For now this is required.
+                                maxLength: 4096
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          name:
+                            description: Name is the name of the cookie for which
+                              attributes will be rewritten.
+                            maxLength: 4096
+                            minLength: 1
+                            pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                            type: string
+                          pathRewrite:
+                            description: PathRewrite enables rewriting the Set-Cookie
+                              Path element. If not set, Path will not be rewritten.
+                            properties:
+                              value:
+                                description: Value is the value to rewrite the Path
+                                  attribute to. For now this is required.
+                                maxLength: 4096
+                                minLength: 1
+                                pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          sameSite:
+                            description: SameSite enables rewriting the Set-Cookie
+                              SameSite element. If not set, SameSite attribute will
+                              not be rewritten.
+                            enum:
+                            - Strict
+                            - Lax
+                            - None
+                            type: string
+                          secure:
+                            description: Secure enables rewriting the Set-Cookie Secure
+                              element. If not set, Secure attribute will not be rewritten.
+                            type: boolean
+                        required:
+                        - name
                         type: object
                       type: array
                     enableWebsockets:
@@ -1041,10 +2932,13 @@ spec:
                       description: The retry policy for this route.
                       properties:
                         count:
+                          default: 1
                           description: NumRetries is maximum allowed number of retries.
-                            If not supplied, the number of retries is one.
+                            If set to -1, then retries are disabled. If set to 0 or
+                            not supplied, the value is set to the Envoy default of
+                            1.
                           format: int64
-                          minimum: 0
+                          minimum: -1
                           type: integer
                         perTryTimeout:
                           description: PerTryTimeout specifies the timeout per retry
@@ -1094,6 +2988,65 @@ spec:
                         description: Service defines an Kubernetes Service to proxy
                           traffic.
                         properties:
+                          cookieRewritePolicies:
+                            description: The policies for rewriting Set-Cookie header
+                              attributes.
+                            items:
+                              properties:
+                                domainRewrite:
+                                  description: DomainRewrite enables rewriting the
+                                    Set-Cookie Domain element. If not set, Domain
+                                    will not be rewritten.
+                                  properties:
+                                    value:
+                                      description: Value is the value to rewrite the
+                                        Domain attribute to. For now this is required.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                name:
+                                  description: Name is the name of the cookie for
+                                    which attributes will be rewritten.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                  type: string
+                                pathRewrite:
+                                  description: PathRewrite enables rewriting the Set-Cookie
+                                    Path element. If not set, Path will not be rewritten.
+                                  properties:
+                                    value:
+                                      description: Value is the value to rewrite the
+                                        Path attribute to. For now this is required.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                sameSite:
+                                  description: SameSite enables rewriting the Set-Cookie
+                                    SameSite element. If not set, SameSite attribute
+                                    will not be rewritten.
+                                  enum:
+                                  - Strict
+                                  - Lax
+                                  - None
+                                  type: string
+                                secure:
+                                  description: Secure enables rewriting the Set-Cookie
+                                    Secure element. If not set, Secure attribute will
+                                    not be rewritten.
+                                  type: boolean
+                              required:
+                              - name
+                              type: object
+                            type: array
                           mirror:
                             description: If Mirror is true the Service will receive
                               a read only mirror of the traffic for this route.
@@ -1223,11 +3176,12 @@ spec:
                       description: The timeout policy for this route.
                       properties:
                         idle:
-                          description: Timeout after which, if there are no active
-                            requests for this route, the connection between Envoy
-                            and the backend or Envoy and the external client will
-                            be closed. If not specified, there is no per-route idle
-                            timeout, though a connection manager-wide stream_idle_timeout
+                          description: Timeout for how long the proxy should wait
+                            while there is no activity during single request/response
+                            (for HTTP/1.1) or stream (for HTTP/2). Timeout will not
+                            trigger while HTTP/1.1 connection is idle between two
+                            consecutive requests. If not specified, there is no per-route
+                            idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
@@ -1353,6 +3307,64 @@ spec:
                       description: Service defines an Kubernetes Service to proxy
                         traffic.
                       properties:
+                        cookieRewritePolicies:
+                          description: The policies for rewriting Set-Cookie header
+                            attributes.
+                          items:
+                            properties:
+                              domainRewrite:
+                                description: DomainRewrite enables rewriting the Set-Cookie
+                                  Domain element. If not set, Domain will not be rewritten.
+                                properties:
+                                  value:
+                                    description: Value is the value to rewrite the
+                                      Domain attribute to. For now this is required.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                - value
+                                type: object
+                              name:
+                                description: Name is the name of the cookie for which
+                                  attributes will be rewritten.
+                                maxLength: 4096
+                                minLength: 1
+                                pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                type: string
+                              pathRewrite:
+                                description: PathRewrite enables rewriting the Set-Cookie
+                                  Path element. If not set, Path will not be rewritten.
+                                properties:
+                                  value:
+                                    description: Value is the value to rewrite the
+                                      Path attribute to. For now this is required.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                    type: string
+                                required:
+                                - value
+                                type: object
+                              sameSite:
+                                description: SameSite enables rewriting the Set-Cookie
+                                  SameSite element. If not set, SameSite attribute
+                                  will not be rewritten.
+                                enum:
+                                - Strict
+                                - Lax
+                                - None
+                                type: string
+                              secure:
+                                description: Secure enables rewriting the Set-Cookie
+                                  Secure element. If not set, Secure attribute will
+                                  not be rewritten.
+                                type: boolean
+                            required:
+                            - name
+                            type: object
+                          type: array
                         mirror:
                           description: If Mirror is true the Service will receive
                             a read only mirror of the traffic for this route.
@@ -1604,6 +3616,7 @@ spec:
                     description: The fully qualified domain name of the root of the
                       ingress tree all leaves of the DAG rooted at this object relate
                       to the fqdn.
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   rateLimitPolicy:
                     description: The policy for rate limiting on the virtual host.
@@ -2187,7 +4200,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: tlscertificatedelegations.projectcontour.io
 spec:

--- a/ingress/base/contour/02-job-certgen.yaml
+++ b/ingress/base/contour/02-job-certgen.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.18.1
+  name: contour-certgen-v1.19.1
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: contour
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: ghcr.io/projectcontour/contour:v1.19.1
         imagePullPolicy: Always
         command:
         - contour

--- a/ingress/base/contour/02-role-contour.yaml
+++ b/ingress/base/contour/02-role-contour.yaml
@@ -50,12 +50,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - list
-- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses
@@ -82,7 +76,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies
   - gatewayclasses
   - gateways
   - httproutes
@@ -96,7 +89,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies/status
   - gatewayclasses/status
   - gateways/status
   - httproutes/status
@@ -104,6 +96,22 @@ rules:
   - tlsroutes/status
   - udproutes/status
   verbs:
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations/status
+  verbs:
+  - create
+  - get
   - update
 - apiGroups:
   - projectcontour.io

--- a/ingress/base/contour/03-contour.yaml
+++ b/ingress/base/contour/03-contour.yaml
@@ -45,7 +45,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: ghcr.io/projectcontour/contour:v1.19.1
         imagePullPolicy: Always
         name: contour
         ports:

--- a/ingress/base/contour/03-envoy.yaml
+++ b/ingress/base/contour/03-envoy.yaml
@@ -29,7 +29,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: ghcr.io/projectcontour/contour:v1.19.1
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -113,7 +113,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: ghcr.io/projectcontour/contour:v1.19.1
         imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:
@@ -139,3 +139,7 @@ spec:
           secret:
             secretName: envoycert
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534

--- a/ingress/base/kustomization.yaml
+++ b/ingress/base/kustomization.yaml
@@ -9,8 +9,8 @@ resources:
   - bastion
 images:
   - name: quay.io/cybozu/contour
-    newTag: 1.18.1.1
-  - name: quay.io/cybozu/contour-plus
-    newTag: 0.6.5
-  - name: quay.io/cybozu/envoy
     newTag: 1.19.1.1
+  - name: quay.io/cybozu/contour-plus
+    newTag: 0.6.6
+  - name: quay.io/cybozu/envoy
+    newTag: 1.19.1.2

--- a/ingress/base/template/common.yaml
+++ b/ingress/base/template/common.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: contour
   namespace: projectcontour
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy
+  namespace: projectcontour

--- a/ingress/base/template/deployment-contour.yaml
+++ b/ingress/base/template/deployment-contour.yaml
@@ -92,6 +92,10 @@ spec:
         name: contour-plus
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
       volumes:
         - name: contourcert
           secret:
@@ -99,7 +103,7 @@ spec:
         - name: contour-config
           configMap:
             name: contour
-            defaultMode: 420
+            defaultMode: 0644
             items:
             - key: contour.yaml
               path: contour.yaml

--- a/ingress/base/template/deployment-envoy.yaml
+++ b/ingress/base/template/deployment-envoy.yaml
@@ -148,6 +148,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       automountServiceAccountToken: false
+      serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:
         - name: envoy-admin
@@ -158,3 +159,7 @@ spec:
           secret:
             secretName: envoycert
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534

--- a/neco-admission/base/kustomization.yaml
+++ b/neco-admission/base/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
       value: neco-admission
 images:
   - name: quay.io/cybozu/neco-admission
-    newTag: 0.15.0
+    newTag: 0.15.1

--- a/network-policy/base/kustomization.yaml
+++ b/network-policy/base/kustomization.yaml
@@ -3,10 +3,10 @@ kind: Kustomization
 images:
   - name: docker.io/calico/node
     newName: quay.io/cybozu/calico
-    newTag: 3.20.0.2
+    newTag: 3.20.0.3
   - name: docker.io/calico/typha
     newName: quay.io/cybozu/calico
-    newTag: 3.20.0.2
+    newTag: 3.20.0.3
 resources:
   - calico/upstream/calico-policy-only.yaml
   - calico/rbac.yaml

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,12 +19,12 @@ NUM_DASHBOARD = $(shell KUSTOMIZE_ENABLE_ALPHA_COMMANDS=true ./bin/kustomize cfg
 export BOOT0 BOOT1 BOOT2 GINKGO SSH_PRIVKEY TEST_ID COMMIT_ID NUM_DASHBOARD SUDO
 
 # Follow Argo CD installed kustomize version
-# https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L22
+# https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L11
 KUSTOMIZE_VERSION := 4.2.0
 PROMTOOL_VERSION := 2.30.0
 TELEPORT_VERSION := 7.3.3
 KUBERNETES_VERSION := 1.21.5
-ARGOCD_VERSION := 2.1.2
+ARGOCD_VERSION := 2.1.8
 
 # Cache
 ROOT_DIR := $(shell git rev-parse --show-toplevel)

--- a/test/team-management_test.go
+++ b/test/team-management_test.go
@@ -122,8 +122,9 @@ var viewableResources = []string{
 // prohibitedResources is a list of namespace resources that are not allowed to be created or viewed by unprivileged teams.
 var prohibitedResources = []string{
 	// Contour
-	// This resource is classified as prohibitedResources, but that is not intentionally done by Neco team.
-	"extensionservices.projectcontour.io",
+	"contourconfigurations.projectcontour.io",
+	"contourdeployments.projectcontour.io",
+	"extensionservices.projectcontour.io", // This resource is classified as prohibitedResources, but that is not intentionally done by Neco team.
 
 	// Rook
 	"cephblockpools.ceph.rook.io",


### PR DESCRIPTION
https://github.com/cybozu/neco-containers/pull/710

Update ArgoCD to v2.1.8 
Update Calico image to 3.20.0.3 
Update cert-manager to v1.6.1 
Update exteral-dns to v0.10.2 
Update neco-admission to v0.15.1 
Update Contour to v1.19.1 

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>