### PR TITLE
Relax K8sAPIServersDegraded to 30mins

### DIFF
--- a/monitoring/base/victoriametrics/rules/kubernetes-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/kubernetes-alertrule.yaml
@@ -631,7 +631,7 @@ spec:
           expr: count(up{job="kubernetes-apiservers"} == 1) < 3
           labels:
             severity: warning
-          for: 15m
+          for: 30m
           annotations:
             summary: The number of kube-apiserver is less than 3.
             runbook: Please consider to find root causes, and solve the problems

--- a/test/vmalert_test/kubernetes.yaml
+++ b/test/vmalert_test/kubernetes.yaml
@@ -22,13 +22,13 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.1"}'
-        values: '1+0x15'
+        values: '1+0x30'
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.2"}'
-        values: '1+0x15'
+        values: '1+0x30'
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.3"}'
-        values: '0+0x15'
+        values: '0+0x30'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 30m
         alertname: K8sAPIServersDegraded
         exp_alerts:
           - exp_labels:
@@ -39,13 +39,13 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.1"}'
-        values: '1+0x15'
+        values: '1+0x30'
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.2"}'
-        values: '1+0x15'
+        values: '1+0x30'
       - series: 'up{job="kubernetes-apiservers",instance="10.0.0.3"}'
-        values: '1+0x15'
+        values: '1+0x30'
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 30m
         alertname: K8sAPIServersDegraded
         exp_alerts: []
   - interval: 1m


### PR DESCRIPTION
Currently, `K8sAPIServersDegraded warning` rings on machine reboot, because it takes longer than the alert threshold.
This PR relaxes the time to 30mins, which is equal to that of `NodeExporterDown`.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>