### PR TITLE
Add node failure alert

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -53,7 +53,7 @@ We have also added one more severity of our own.
 - `info`: No problem is occurred, but just notify.
 - `warning`: Investigate to decide whether any action is required.
 - `error`: Action is required, but the situation is not so serious at this time.
-- `urgent`: Action is required at best effort because the problem might get worse. Note: `urgent` alerts are intended to be sent to pager only during daytime.
+- `urgent`: Action is required. The service is available, but no redundancy, so we need to take action as soon as possible. Note: `urgent` alerts are intended to be sent to pager only during daytime.
 - `critical`: Action is required immediately because the problem gets worse. Investigate and resolve the causes of alert as soon as possible. Note: `critical` alerts are intended to be sent to pager even at midnight.
 
 ### Critical Alerts

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -36,7 +36,7 @@ Each YAML file contains tests for the corresponding application.
 Run the unit test with the following command:
 
 ```console
-$ cd $GOPATH/src/github.com/cybozu-go/neco-apps
+$ cd $GOPATH/src/github.com/cybozu-go/neco-apps/test
 
 # Run all tests
 $ make test-alert-rules
@@ -47,11 +47,13 @@ Severity Levels
 
 All alert rules should have the `severity` labels. This label indicates the level of the severity of the alert.
 
-The severity names and their severity order are consistent with syslog severity. We use just four levels from syslog severity, though.
+The severity names and their severity order are mostly consistent with syslog severity. We use four levels from syslog severity, though.
+We have also added one more severity of our own.
 
 - `info`: No problem is occurred, but just notify.
 - `warning`: Investigate to decide whether any action is required.
 - `error`: Action is required, but the situation is not so serious at this time.
+- `urgent`: Action is required at best effort because the problem might get worse. Note: `urgent` alerts are intended to be sent to pager only during daytime.
 - `critical`: Action is required immediately because the problem gets worse. Investigate and resolve the causes of alert as soon as possible. Note: `critical` alerts are intended to be sent to pager even at midnight.
 
 ### Critical Alerts

--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -41,6 +41,6 @@ spec:
             runbook: "Perform the server retirement procedure."
           expr: |
             sum(sabakan_machine_status{status="unreachable"}) > 0
-          for: 30m
+          for: 60m
           labels:
             severity: urgent

--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -35,3 +35,12 @@ spec:
           for: 30m
           labels:
             severity: error
+        - alert: NodeFailure
+          annotations:
+            summary: "Unhealthy node(s) exist."
+            runbook: "Perform the server retirement procedure."
+          expr: |
+            sum(sabakan_machine_status{status="unhealthy"}) > 0
+          for: 30m
+          labels:
+            severity: urgent

--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -35,12 +35,12 @@ spec:
           for: 30m
           labels:
             severity: error
-        - alert: NodeFailure
+        - alert: NodeUnreachable
           annotations:
-            summary: "Unhealthy node(s) exist."
+            summary: "Unreachable node(s) exist."
             runbook: "Perform the server retirement procedure."
           expr: |
-            sum(sabakan_machine_status{status="unhealthy"}) > 0
+            sum(sabakan_machine_status{status="unreachable"}) > 0
           for: 30m
           labels:
             severity: urgent

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -52,11 +52,11 @@ tests:
   - interval: 1m
     input_series:
       - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="healthy"}
-        values: 0+0x30
+        values: 0+0x60
       - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unreachable"}
-        values: 1+0x30
+        values: 1+0x60
     alert_rule_test:
-      - eval_time: 30m
+      - eval_time: 60m
         alertname: NodeUnreachable
         exp_alerts:
           - exp_labels:

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -49,3 +49,18 @@ tests:
             exp_annotations:
               summary: Not-healthy boot server(s) exist.
               runbook: TBD
+  - interval: 1m
+    input_series:
+      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="healthy"}
+        values: 0+0x30
+      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unhealthy"}
+        values: 1+0x30
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: urgent
+            exp_annotations:
+              summary: Unhealthy node(s) exist.
+              runbook: "Perform the server retirement procedure."

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -53,14 +53,14 @@ tests:
     input_series:
       - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="healthy"}
         values: 0+0x30
-      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unhealthy"}
+      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unreachable"}
         values: 1+0x30
     alert_rule_test:
       - eval_time: 30m
-        alertname: NodeFailure
+        alertname: NodeUnreachable
         exp_alerts:
           - exp_labels:
               severity: urgent
             exp_annotations:
-              summary: Unhealthy node(s) exist.
+              summary: Unreachable node(s) exist.
               runbook: "Perform the server retirement procedure."


### PR DESCRIPTION
- Add node failure alert
  - Generate an alert labeled `severity: urgent` when `sum(sabakan_machine_status{status="unreachable"}) > 0` for 60 minutes.
  - Confirmed that there are no false alerts due to the reboot of all node.
- Add description about the urgent severity

Signed-off-by: kouki <kouworld0123@gmail.com>