### PR TITLE
Add traceable policy to team-dbre namespace

### DIFF
--- a/team-management/base/dbre/team-dbre.yaml
+++ b/team-management/base/dbre/team-dbre.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     accurate.cybozu.com/template: init-template
     accurate.cybozu.com/type: root
+    pod-security.cybozu.com/policy: traceable
   name: team-dbre
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/team-management/template/settings.json
+++ b/team-management/template/settings.json
@@ -172,7 +172,8 @@
       },
       "team-dbre": {
         "accurate.cybozu.com/template": "init-template",
-        "accurate.cybozu.com/type": "root"
+        "accurate.cybozu.com/type": "root",
+        "pod-security.cybozu.com/policy": "traceable"
       }
     },
     "ept": {


### PR DESCRIPTION
Add `pod-security.cybozu.com/policy: traceable` to `team-dbre` namespace.
This is required to convert DBRE namespaces into subnamespaces of `team-dbre`.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>