### PR TITLE
Container reguler update (2021-12)

### DIFF
--- a/argocd-config/base/prometheus-adapter.yaml
+++ b/argocd-config/base/prometheus-adapter.yaml
@@ -34,7 +34,7 @@ spec:
       values: |
         image:
           repository: quay.io/cybozu/prometheus-adapter
-          tag: 0.9.0.1
+          tag: 0.9.1.1
           pullPolicy: IfNotPresent
         
         # Url to access prometheus

--- a/metallb/base/kustomization.yaml
+++ b/metallb/base/kustomization.yaml
@@ -7,7 +7,7 @@ patchesStrategicMerge:
 images:
 - name: quay.io/metallb/speaker
   newName: quay.io/cybozu/metallb
-  newTag: 0.10.3.1
+  newTag: 0.11.0.1
 - name: quay.io/metallb/controller
   newName: quay.io/cybozu/metallb
-  newTag: 0.10.3.1
+  newTag: 0.11.0.1

--- a/metallb/base/upstream/example-config.yaml
+++ b/metallb/base/upstream/example-config.yaml
@@ -18,6 +18,9 @@ data:
       # (optional) the TCP port to talk to. Defaults to 179, you shouldn't
       # need to set this in production.
       peer-port: 179
+      # (optional) The source IP address to use when establishing the BGP
+      # session. The address must be configured on a local network interface.
+      source-address: 10.0.0.2
       # (optional) The proposed value of the BGP Hold Time timer. Refer to
       # BGP reference material to understand what setting this implies.
       hold-time: 120s

--- a/metallb/base/upstream/metallb.yaml
+++ b/metallb/base/upstream/metallb.yaml
@@ -338,6 +338,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
+        - --log-level=info
         env:
         - name: METALLB_NODE_NAME
           valueFrom:
@@ -363,7 +364,7 @@ spec:
             secretKeyRef:
               name: memberlist
               key: secretkey
-        image: quay.io/metallb/speaker:v0.10.3
+        image: quay.io/metallb/speaker:v0.11.0
         name: speaker
         ports:
         - containerPort: 7472
@@ -418,12 +419,13 @@ spec:
       - args:
         - --port=7472
         - --config=config
+        - --log-level=info
         env:
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT
           value: controller
-        image: quay.io/metallb/controller:v0.10.3
+        image: quay.io/metallb/controller:v0.11.0
         name: controller
         ports:
         - containerPort: 7472

--- a/metallb/base/upstream/prometheus-operator.yaml
+++ b/metallb/base/upstream/prometheus-operator.yaml
@@ -1,0 +1,58 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metallb-controller
+spec:
+  selector:
+    matchLabels:
+      component: controller
+  namespaceSelector:
+    matchNames:
+      - metallb-system
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metallb-speaker
+spec:
+  selector:
+    matchLabels:
+      component: speaker
+  namespaceSelector:
+    matchNames:
+      - metallb-system
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: metallb-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -27,7 +27,7 @@ images:
     newName: quay.io/cybozu/cadvisor
     newTag: 0.43.0.2
   - name: quay.io/cybozu/pushgateway
-    newTag: 1.4.1.1
+    newTag: 1.4.2.1
   - name: k8s.gcr.io/kube-state-metrics/kube-state-metrics
     newName: quay.io/cybozu/kube-state-metrics
     newTag: 2.2.4.1

--- a/monitoring/base/victoriametrics/operator.yaml
+++ b/monitoring/base/victoriametrics/operator.yaml
@@ -77,7 +77,7 @@ spec:
           value: "0.23.0.2"
         - name: VM_VMALERTMANAGER_CONFIGRELOADERIMAGE
           value: quay.io/cybozu/configmap-reload:0.5.0.1
-        image: quay.io/cybozu/victoriametrics-operator:0.20.3.1
+        image: quay.io/cybozu/victoriametrics-operator:0.21.0.1
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/monitoring/base/victoriametrics/operator.yaml
+++ b/monitoring/base/victoriametrics/operator.yaml
@@ -46,31 +46,31 @@ spec:
         - name: VM_VMALERTDEFAULT_IMAGE
           value: quay.io/cybozu/victoriametrics-vmalert
         - name: VM_VMALERTDEFAULT_VERSION
-          value: "1.65.0.2"
+          value: "1.70.0.1"
         - name: VM_VMALERTDEFAULT_CONFIGRELOADIMAGE
           value: quay.io/cybozu/configmap-reload:0.5.0.1
         - name: VM_VMAGENTDEFAULT_IMAGE
           value: quay.io/cybozu/victoriametrics-vmagent
         - name: VM_VMAGENTDEFAULT_VERSION
-          value: "1.65.0.2"
+          value: "1.70.0.1"
         - name: VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE
-          value: quay.io/cybozu/prometheus-config-reloader:0.50.0.1
+          value: quay.io/cybozu/prometheus-config-reloader:0.53.0.1
         - name: VM_VMSINGLEDEFAULT_IMAGE
           value: quay.io/cybozu/victoriametrics-vmsingle
         - name: VM_VMSINGLEDEFAULT_VERSION
-          value: "1.65.0.2"
+          value: "1.70.0.1"
         - name: VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_IMAGE
           value: quay.io/cybozu/victoriametrics-vmselect
         - name: VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_VERSION
-          value: "1.65.0.2"
+          value: "1.70.0.1"
         - name: VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_IMAGE
           value: quay.io/cybozu/victoriametrics-vmstorage
         - name: VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VERSION
-          value: "1.65.0.2"
+          value: "1.70.0.1"
         - name: VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_IMAGE
           value: quay.io/cybozu/victoriametrics-vminsert
         - name: VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_VERSION
-          value: "1.65.0.2"
+          value: "1.70.0.1"
         - name: VM_VMALERTMANAGER_ALERTMANAGERDEFAULTBASEIMAGE
           value: quay.io/cybozu/alertmanager
         - name: VM_VMALERTMANAGER_ALERTMANAGERVERSION

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -314,12 +314,14 @@ spec:
                       type: string
                     value:
                       description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
+                        the previously defined environment variables in the container
                         and any service environment variables. If a variable cannot
                         be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
                       type: string
                   required:
                   - name
@@ -508,9 +510,9 @@ spec:
               nodeScrapeNamespaceSelector:
                 description: NodeScrapeNamespaceSelector defines Namespaces to be
                   selected for VMNodeScrape discovery. Works in combination with Selector.
-                  If both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  NamespaceSelector nil - only objects at VMAgent namespace. Selector
+                  nil - only objects at NamespaceSelector namespaces. If both nil
+                  - behaviour controlled by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -615,10 +617,10 @@ spec:
                 type: array
               nodeScrapeSelector:
                 description: NodeScrapeSelector defines VMNodeScrape to be selected
-                  for scraping. Works in combination with NamespaceSelector. If both
-                  nil - match everything. NamespaceSelector nil - only objects at
-                  VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  for scraping. Works in combination with NamespaceSelector. NamespaceSelector
+                  nil - only objects at VMAgent namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -730,10 +732,10 @@ spec:
                 type: object
               podScrapeNamespaceSelector:
                 description: PodScrapeNamespaceSelector defines Namespaces to be selected
-                  for VMPodScrape discovery. Works in combination with Selector. If
-                  both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  for VMPodScrape discovery. Works in combination with Selector. NamespaceSelector
+                  nil - only objects at VMAgent namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -838,10 +840,10 @@ spec:
                 type: array
               podScrapeSelector:
                 description: PodScrapeSelector defines PodScrapes to be selected for
-                  target discovery. Works in combination with NamespaceSelector. If
-                  both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  target discovery. Works in combination with NamespaceSelector. NamespaceSelector
+                  nil - only objects at VMAgent namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -896,10 +898,10 @@ spec:
                 type: string
               probeNamespaceSelector:
                 description: ProbeNamespaceSelector defines Namespaces to be selected
-                  for VMProbe discovery. Works in combination with Selector. If both
-                  nil - match everything. NamespaceSelector nil - only objects at
-                  VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  for VMProbe discovery. Works in combination with Selector. NamespaceSelector
+                  nil - only objects at VMAgent namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1004,9 +1006,10 @@ spec:
                 type: array
               probeSelector:
                 description: ProbeSelector defines VMProbe to be selected for target
-                  probing. Works in combination with NamespaceSelector. If both nil
-                  - match everything. NamespaceSelector nil - only objects at VMAgent
-                  namespace. Selector nil - only objects at NamespaceSelector namespaces.
+                  probing. Works in combination with NamespaceSelector. NamespaceSelector
+                  nil - only objects at VMAgent namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1582,6 +1585,13 @@ spec:
                   common container settings. This defaults to the default PodSecurityContext.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              selectAllByDefault:
+                description: 'SelectAllByDefault changes default behavior for empty
+                  CRD selectors, such ServiceScrapeSelector. with selectAllScrapes:
+                  true and empty serviceScrapeSelector and ServiceScrapeNamespaceSelector
+                  Operator selects all exist serviceScrapes with selectAllScrapes:
+                  false - selects nothing'
+                type: boolean
               serviceAccountName:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use to run the VMAgent Pods.
@@ -1589,9 +1599,9 @@ spec:
               serviceScrapeNamespaceSelector:
                 description: ServiceScrapeNamespaceSelector Namespaces to be selected
                   for VMServiceScrape discovery. Works in combination with Selector.
-                  If both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  NamespaceSelector nil - only objects at VMAgent namespace. Selector
+                  nil - only objects at NamespaceSelector namespaces. If both nil
+                  - behaviour controlled by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1697,9 +1707,9 @@ spec:
               serviceScrapeSelector:
                 description: ServiceScrapeSelector defines ServiceScrapes to be selected
                   for target discovery. Works in combination with NamespaceSelector.
-                  If both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  NamespaceSelector nil - only objects at VMAgent namespace. Selector
+                  nil - only objects at NamespaceSelector namespaces. If both nil
+                  - behaviour controlled by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1795,9 +1805,9 @@ spec:
               staticScrapeNamespaceSelector:
                 description: StaticScrapeNamespaceSelector defines Namespaces to be
                   selected for VMStaticScrape discovery. Works in combination with
-                  NamespaceSelector. If both nil - match everything. NamespaceSelector
-                  nil - only objects at VMAgent namespace. Selector nil - only objects
-                  at NamespaceSelector namespaces.
+                  NamespaceSelector. NamespaceSelector nil - only objects at VMAgent
+                  namespace. Selector nil - only objects at NamespaceSelector namespaces.
+                  If both nil - behaviour controlled by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -72,10 +72,10 @@ spec:
                 type: array
               configNamespaceSelector:
                 description: ' ConfigNamespaceSelector defines namespace selector
-                  for VMAlertmanagerConfig. Works in combination with Selector. If
-                  both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAlertmanager namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.'
+                  for VMAlertmanagerConfig. Works in combination with Selector. NamespaceSelector
+                  nil - only objects at VMAlertmanager namespace. Selector nil - only
+                  objects at NamespaceSelector namespaces. If both nil - behaviour
+                  controlled by selectAllByDefault'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -134,9 +134,10 @@ spec:
               configSelector:
                 description: ConfigSelector defines selector for VMAlertmanagerConfig,
                   result config will be merged with with Raw or Secret config. Works
-                  in combination with NamespaceSelector. If both nil - match everything.
-                  NamespaceSelector nil - only objects at VMAlertmanager namespace.
-                  Selector nil - only objects at NamespaceSelector namespaces.
+                  in combination with NamespaceSelector. NamespaceSelector nil - only
+                  objects at VMAlertmanager namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -216,12 +217,14 @@ spec:
                       type: string
                     value:
                       description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
+                        the previously defined environment variables in the container
                         and any service environment variables. If a variable cannot
                         be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
                       type: string
                   required:
                   - name
@@ -437,6 +440,13 @@ spec:
                   common container settings. This defaults to the default PodSecurityContext.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              selectAllByDefault:
+                description: 'SelectAllByDefault changes default behavior for empty
+                  CRD selectors, such ConfigSelector. with selectAllScrapes: true
+                  and undefined ConfigSelector and ConfigNamespaceSelector Operator
+                  selects all exist alertManagerConfigs with selectAllScrapes: false
+                  - selects nothing'
+                type: boolean
               serviceAccountName:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use
@@ -579,14 +589,51 @@ spec:
                           dataSource:
                             description: 'This field can be used to specify either:
                               * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim) * An existing
-                              custom resource that implements data population (Alpha)
-                              In order to use custom resource types that implement
-                              data population, the AnyVolumeDataSource feature gate
-                              must be enabled. If the provisioner or an external controller
-                              can support the specified data source, it will create
-                              a new volume based on the contents of the specified
-                              data source.'
+                              * An existing PVC (PersistentVolumeClaim) If the provisioner
+                              or an external controller can support the specified
+                              data source, it will create a new volume based on the
+                              contents of the specified data source. If the AnyVolumeDataSource
+                              feature gate is enabled, this field will always have
+                              the same contents as the DataSourceRef field.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          dataSourceRef:
+                            description: 'Specifies the object from which to populate
+                              the volume with data, if a non-empty volume is desired.
+                              This may be any local object from a non-empty API group
+                              (non core object) or a PersistentVolumeClaim object.
+                              When this field is specified, volume binding will only
+                              succeed if the type of the specified object matches
+                              some installed volume populator or dynamic provisioner.
+                              This field will replace the functionality of the DataSource
+                              field and as such if both fields are non-empty, they
+                              must have the same value. For backwards compatibility,
+                              both fields (DataSource and DataSourceRef) will be set
+                              to the same value automatically if one of them is empty
+                              and the other is non-empty. There are two important
+                              differences between DataSource and DataSourceRef: *
+                              While DataSource only allows two specific types of objects,
+                              DataSourceRef   allows any non-core object, as well
+                              as PersistentVolumeClaim objects. * While DataSource
+                              ignores disallowed values (dropping them), DataSourceRef   preserves
+                              all values, and generates an error if a disallowed value
+                              is   specified. (Alpha) Using this field requires the
+                              AnyVolumeDataSource feature gate to be enabled.'
                             properties:
                               apiGroup:
                                 description: APIGroup is the group for the resource

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -279,12 +279,14 @@ spec:
                       type: string
                     value:
                       description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
+                        the previously defined environment variables in the container
                         and any service environment variables. If a variable cannot
                         be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
                       type: string
                   required:
                   - name
@@ -946,9 +948,10 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               remoteRead:
-                description: RemoteRead victoria metrics address for loading state
-                  This configuration makes sense only if remoteWrite was configured
-                  before and has been successfully persisted its state.
+                description: RemoteRead Optional URL to read vmalert state (persisted
+                  via RemoteWrite) This configuration only makes sense if alerts state
+                  has been successfully persisted (via RemoteWrite) before. see -remoteRead.url
+                  docs in vmalerts for details. E.g. http://127.0.0.1:8428
                 properties:
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
@@ -1140,7 +1143,10 @@ spec:
                 type: object
               remoteWrite:
                 description: RemoteWrite Optional URL to remote-write compatible storage
-                  where to write timeseriesbased on active alerts. E.g. http://127.0.0.1:8428
+                  to persist vmalert state and rule results to. Rule results will
+                  be persisted according to each rule. Alerts state will be persisted
+                  in the form of time series named ALERTS and ALERTS_FOR_STATE see
+                  -remoteWrite.url docs in vmalerts for details. E.g. http://127.0.0.1:8428
                 properties:
                   basicAuth:
                     description: BasicAuth allow an endpoint to authenticate over
@@ -1413,8 +1419,9 @@ spec:
                 type: object
               ruleNamespaceSelector:
                 description: RuleNamespaceSelector to be selected for VMRules discovery.
-                  Works in combination with Selector. If both nil - match everything.
-                  NamespaceSelector nil - only objects at VMAlert namespace.
+                  Works in combination with Selector. If both nil - behaviour controlled
+                  by selectAllByDefault NamespaceSelector nil - only objects at VMAlert
+                  namespace.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1469,8 +1476,8 @@ spec:
               ruleSelector:
                 description: RuleSelector selector to select which VMRules to mount
                   for loading alerting rules from. Works in combination with NamespaceSelector.
-                  If both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAlert namespace.
+                  If both nil - behaviour controlled by selectAllByDefault NamespaceSelector
+                  nil - only objects at VMAlert namespace.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1532,6 +1539,13 @@ spec:
                   common container settings. This defaults to the default PodSecurityContext.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              selectAllByDefault:
+                description: 'SelectAllByDefault changes default behavior for empty
+                  CRD selectors, such RuleSelector. with selectAllByDefault: true
+                  and empty serviceScrapeSelector and RuleNamespaceSelector Operator
+                  selects all exist serviceScrapes with selectAllByDefault: false
+                  - selects nothing'
+                type: boolean
               serviceAccountName:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use to run the VMAlert Pods.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmauths.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmauths.yaml
@@ -75,12 +75,14 @@ spec:
                       type: string
                     value:
                       description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
+                        the previously defined environment variables in the container
                         and any service environment variables. If a variable cannot
                         be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
                       type: string
                   required:
                   - name
@@ -212,8 +214,9 @@ spec:
                                         description: Resource is an ObjectRef to another
                                           Kubernetes resource in the namespace of
                                           the Ingress object. If resource is specified,
-                                          serviceName and servicePort must not be
-                                          specified.
+                                          a service.Name and service.Port must not
+                                          be specified. This is a mutually exclusive
+                                          setting with "Service".
                                         properties:
                                           apiGroup:
                                             description: APIGroup is the group for
@@ -235,25 +238,45 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                      serviceName:
-                                        description: Specifies the name of the referenced
-                                          service.
-                                        type: string
-                                      servicePort:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        description: Specifies the port of the referenced
-                                          service.
-                                        x-kubernetes-int-or-string: true
+                                      service:
+                                        description: Service references a Service
+                                          as a Backend. This is a mutually exclusive
+                                          setting with "Resource".
+                                        properties:
+                                          name:
+                                            description: Name is the referenced service.
+                                              The service must exist in the same namespace
+                                              as the Ingress object.
+                                            type: string
+                                          port:
+                                            description: Port of the referenced service.
+                                              A port name or port number is required
+                                              for a IngressServiceBackend.
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  port on the Service. This is a mutually
+                                                  exclusive setting with "Number".
+                                                type: string
+                                              number:
+                                                description: Number is the numerical
+                                                  port number (e.g. 80) on the Service.
+                                                  This is a mutually exclusive setting
+                                                  with "Name".
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
                                     type: object
                                   path:
                                     description: Path is matched against the path
                                       of an incoming request. Currently it can contain
                                       characters disallowed from the conventional
                                       "path" part of a URL as defined by RFC 3986.
-                                      Paths must begin with a '/'. When unspecified,
-                                      all paths from incoming requests are matched.
+                                      Paths must begin with a '/' and must be present
+                                      when using PathType with value "Exact" or "Prefix".
                                     type: string
                                   pathType:
                                     description: 'PathType determines the interpretation
@@ -274,13 +297,14 @@ spec:
                                       IngressClass. Implementations can treat this
                                       as a separate PathType   or treat it identically
                                       to Prefix or Exact path types. Implementations
-                                      are required to support all path types. Defaults
-                                      to ImplementationSpecific.'
+                                      are required to support all path types.'
                                     type: string
                                 required:
                                 - backend
+                                - pathType
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - paths
                           type: object
@@ -302,10 +326,11 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         secretName:
                           description: SecretName is the name of the secret used to
-                            terminate SSL traffic on 443. Field is left optional to
-                            allow SSL routing based on SNI hostname alone. If the
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
                             SNI host in a listener conflicts with the "Host" header
                             field used by an IngressRule, the SNI host is used for
                             termination and value of the Host header is used for routing.
@@ -497,6 +522,12 @@ spec:
                   common container settings. This defaults to the default PodSecurityContext.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              selectAllByDefault:
+                description: 'SelectAllByDefault changes default behavior for empty
+                  CRD selectors, such userSelector. with selectAllByDefault: true
+                  and empty userSelector and userNamespaceSelector Operator selects
+                  all exist users with selectAllByDefault: false - selects nothing'
+                type: boolean
               serviceAccountName:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use to run the VMAuth Pods.
@@ -603,9 +634,10 @@ spec:
                 type: array
               userNamespaceSelector:
                 description: UserNamespaceSelector Namespaces to be selected for  VMAuth
-                  discovery. Works in combination with Selector. If both nil - match
-                  everything. NamespaceSelector nil - only objects at VMAuth namespace.
-                  Selector nil - only objects at NamespaceSelector namespaces.
+                  discovery. Works in combination with Selector. NamespaceSelector
+                  nil - only objects at VMAuth namespace. Selector nil - only objects
+                  at NamespaceSelector namespaces. If both nil - behaviour controlled
+                  by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -650,10 +682,9 @@ spec:
                 type: object
               userSelector:
                 description: UserSelector defines VMUser to be selected for config
-                  file generation. Works in combination with NamespaceSelector. If
-                  both nil - match everything. NamespaceSelector nil - only objects
-                  at VMAuth namespace. Selector nil - only objects at NamespaceSelector
-                  namespaces.
+                  file generation. Works in combination with NamespaceSelector. NamespaceSelector
+                  nil - only objects at VMAuth namespace. If both nil - behaviour
+                  controlled by selectAllByDefault
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -133,13 +133,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                       required:
                       - name
@@ -224,6 +225,8 @@ spec:
                     - PANIC
                     type: string
                   name:
+                    description: Name is deprecated and will be removed at 0.22.0
+                      release
                     type: string
                   nodeSelector:
                     additionalProperties:
@@ -296,7 +299,7 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   replicaCount:
-                    description: ReplicaCount is the expected size of the VMSelect
+                    description: ReplicaCount is the expected size of the VMInsert
                       cluster. The controller will eventually make the size of the
                       running cluster equal to the expected size.
                     format: int32
@@ -600,13 +603,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                       required:
                       - name
@@ -675,6 +679,8 @@ spec:
                     - PANIC
                     type: string
                   name:
+                    description: Name is deprecated and will be removed at 0.22.0
+                      release
                     type: string
                   nodeSelector:
                     additionalProperties:
@@ -978,14 +984,56 @@ spec:
                               dataSource:
                                 description: 'This field can be used to specify either:
                                   * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                  * An existing PVC (PersistentVolumeClaim) * An existing
-                                  custom resource that implements data population
-                                  (Alpha) In order to use custom resource types that
-                                  implement data population, the AnyVolumeDataSource
-                                  feature gate must be enabled. If the provisioner
-                                  or an external controller can support the specified
-                                  data source, it will create a new volume based on
-                                  the contents of the specified data source.'
+                                  * An existing PVC (PersistentVolumeClaim) If the
+                                  provisioner or an external controller can support
+                                  the specified data source, it will create a new
+                                  volume based on the contents of the specified data
+                                  source. If the AnyVolumeDataSource feature gate
+                                  is enabled, this field will always have the same
+                                  contents as the DataSourceRef field.'
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              dataSourceRef:
+                                description: 'Specifies the object from which to populate
+                                  the volume with data, if a non-empty volume is desired.
+                                  This may be any local object from a non-empty API
+                                  group (non core object) or a PersistentVolumeClaim
+                                  object. When this field is specified, volume binding
+                                  will only succeed if the type of the specified object
+                                  matches some installed volume populator or dynamic
+                                  provisioner. This field will replace the functionality
+                                  of the DataSource field and as such if both fields
+                                  are non-empty, they must have the same value. For
+                                  backwards compatibility, both fields (DataSource
+                                  and DataSourceRef) will be set to the same value
+                                  automatically if one of them is empty and the other
+                                  is non-empty. There are two important differences
+                                  between DataSource and DataSourceRef: * While DataSource
+                                  only allows two specific types of objects, DataSourceRef   allows
+                                  any non-core object, as well as PersistentVolumeClaim
+                                  objects. * While DataSource ignores disallowed values
+                                  (dropping them), DataSourceRef   preserves all values,
+                                  and generates an error if a disallowed value is   specified.
+                                  (Alpha) Using this field requires the AnyVolumeDataSource
+                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -1324,13 +1372,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                       required:
                       - name
@@ -1413,6 +1462,8 @@ spec:
                       type: integer
                     type: array
                   name:
+                    description: Name is deprecated and will be removed at 0.22.0
+                      release
                     type: string
                   nodeSelector:
                     additionalProperties:
@@ -1485,7 +1536,7 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   replicaCount:
-                    description: ReplicaCount is the expected size of the VMSelect
+                    description: ReplicaCount is the expected size of the VMStorage
                       cluster. The controller will eventually make the size of the
                       running cluster equal to the expected size.
                     format: int32
@@ -1760,14 +1811,15 @@ spec:
                               type: string
                             value:
                               description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
                                 If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.

--- a/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmsingles.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/bases/operator.victoriametrics.com_vmsingles.yaml
@@ -76,12 +76,14 @@ spec:
                       type: string
                     value:
                       description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
+                        the previously defined environment variables in the container
                         and any service environment variables. If a variable cannot
                         be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
                       type: string
                   required:
                   - name
@@ -361,13 +363,48 @@ spec:
                   dataSource:
                     description: 'This field can be used to specify either: * An existing
                       VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                      * An existing PVC (PersistentVolumeClaim) * An existing custom
-                      resource that implements data population (Alpha) In order to
-                      use custom resource types that implement data population, the
-                      AnyVolumeDataSource feature gate must be enabled. If the provisioner
+                      * An existing PVC (PersistentVolumeClaim) If the provisioner
                       or an external controller can support the specified data source,
                       it will create a new volume based on the contents of the specified
-                      data source.'
+                      data source. If the AnyVolumeDataSource feature gate is enabled,
+                      this field will always have the same contents as the DataSourceRef
+                      field.'
+                    properties:
+                      apiGroup:
+                        description: APIGroup is the group for the resource being
+                          referenced. If APIGroup is not specified, the specified
+                          Kind must be in the core API group. For any other third-party
+                          types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  dataSourceRef:
+                    description: 'Specifies the object from which to populate the
+                      volume with data, if a non-empty volume is desired. This may
+                      be any local object from a non-empty API group (non core object)
+                      or a PersistentVolumeClaim object. When this field is specified,
+                      volume binding will only succeed if the type of the specified
+                      object matches some installed volume populator or dynamic provisioner.
+                      This field will replace the functionality of the DataSource
+                      field and as such if both fields are non-empty, they must have
+                      the same value. For backwards compatibility, both fields (DataSource
+                      and DataSourceRef) will be set to the same value automatically
+                      if one of them is empty and the other is non-empty. There are
+                      two important differences between DataSource and DataSourceRef:
+                      * While DataSource only allows two specific types of objects,
+                      DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim
+                      objects. * While DataSource ignores disallowed values (dropping
+                      them), DataSourceRef   preserves all values, and generates an
+                      error if a disallowed value is   specified. (Alpha) Using this
+                      field requires the AnyVolumeDataSource feature gate to be enabled.'
                     properties:
                       apiGroup:
                         description: APIGroup is the group for the resource being
@@ -603,13 +640,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.

--- a/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmagents.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmagents.yaml
@@ -304,12 +304,14 @@ spec:
                     type: string
                   value:
                     description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
+                      the previously defined environment variables in the container
                       and any service environment variables. If a variable cannot
                       be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
+                      Double $$ are reduced to a single $, which allows for escaping
+                      the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                      string literal "$(VAR_NAME)". Escaped references will never
+                      be expanded, regardless of whether the variable exists or not.
+                      Defaults to "".'
                     type: string
                 required:
                 - name
@@ -495,10 +497,10 @@ spec:
               type: string
             nodeScrapeNamespaceSelector:
               description: NodeScrapeNamespaceSelector defines Namespaces to be selected
-                for VMNodeScrape discovery. Works in combination with Selector. If
-                both nil - match everything. NamespaceSelector nil - only objects
-                at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                namespaces.
+                for VMNodeScrape discovery. Works in combination with Selector. NamespaceSelector
+                nil - only objects at VMAgent namespace. Selector nil - only objects
+                at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -601,9 +603,10 @@ spec:
               type: array
             nodeScrapeSelector:
               description: NodeScrapeSelector defines VMNodeScrape to be selected
-                for scraping. Works in combination with NamespaceSelector. If both
-                nil - match everything. NamespaceSelector nil - only objects at VMAgent
-                namespace. Selector nil - only objects at NamespaceSelector namespaces.
+                for scraping. Works in combination with NamespaceSelector. NamespaceSelector
+                nil - only objects at VMAgent namespace. Selector nil - only objects
+                at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -713,10 +716,10 @@ spec:
               type: object
             podScrapeNamespaceSelector:
               description: PodScrapeNamespaceSelector defines Namespaces to be selected
-                for VMPodScrape discovery. Works in combination with Selector. If
-                both nil - match everything. NamespaceSelector nil - only objects
-                at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                namespaces.
+                for VMPodScrape discovery. Works in combination with Selector. NamespaceSelector
+                nil - only objects at VMAgent namespace. Selector nil - only objects
+                at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -819,10 +822,10 @@ spec:
               type: array
             podScrapeSelector:
               description: PodScrapeSelector defines PodScrapes to be selected for
-                target discovery. Works in combination with NamespaceSelector. If
-                both nil - match everything. NamespaceSelector nil - only objects
-                at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                namespaces.
+                target discovery. Works in combination with NamespaceSelector. NamespaceSelector
+                nil - only objects at VMAgent namespace. Selector nil - only objects
+                at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -876,9 +879,10 @@ spec:
               type: string
             probeNamespaceSelector:
               description: ProbeNamespaceSelector defines Namespaces to be selected
-                for VMProbe discovery. Works in combination with Selector. If both
-                nil - match everything. NamespaceSelector nil - only objects at VMAgent
-                namespace. Selector nil - only objects at NamespaceSelector namespaces.
+                for VMProbe discovery. Works in combination with Selector. NamespaceSelector
+                nil - only objects at VMAgent namespace. Selector nil - only objects
+                at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -981,9 +985,10 @@ spec:
               type: array
             probeSelector:
               description: ProbeSelector defines VMProbe to be selected for target
-                probing. Works in combination with NamespaceSelector. If both nil
-                - match everything. NamespaceSelector nil - only objects at VMAgent
-                namespace. Selector nil - only objects at NamespaceSelector namespaces.
+                probing. Works in combination with NamespaceSelector. NamespaceSelector
+                nil - only objects at VMAgent namespace. Selector nil - only objects
+                at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1554,6 +1559,13 @@ spec:
                 common container settings. This defaults to the default PodSecurityContext.
               type: object
               x-kubernetes-preserve-unknown-fields: true
+            selectAllByDefault:
+              description: 'SelectAllByDefault changes default behavior for empty
+                CRD selectors, such ServiceScrapeSelector. with selectAllScrapes:
+                true and empty serviceScrapeSelector and ServiceScrapeNamespaceSelector
+                Operator selects all exist serviceScrapes with selectAllScrapes: false
+                - selects nothing'
+              type: boolean
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMAgent Pods.
@@ -1561,9 +1573,9 @@ spec:
             serviceScrapeNamespaceSelector:
               description: ServiceScrapeNamespaceSelector Namespaces to be selected
                 for VMServiceScrape discovery. Works in combination with Selector.
-                If both nil - match everything. NamespaceSelector nil - only objects
-                at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                namespaces.
+                NamespaceSelector nil - only objects at VMAgent namespace. Selector
+                nil - only objects at NamespaceSelector namespaces. If both nil -
+                behaviour controlled by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1667,9 +1679,9 @@ spec:
             serviceScrapeSelector:
               description: ServiceScrapeSelector defines ServiceScrapes to be selected
                 for target discovery. Works in combination with NamespaceSelector.
-                If both nil - match everything. NamespaceSelector nil - only objects
-                at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                namespaces.
+                NamespaceSelector nil - only objects at VMAgent namespace. Selector
+                nil - only objects at NamespaceSelector namespaces. If both nil -
+                behaviour controlled by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1763,9 +1775,9 @@ spec:
             staticScrapeNamespaceSelector:
               description: StaticScrapeNamespaceSelector defines Namespaces to be
                 selected for VMStaticScrape discovery. Works in combination with NamespaceSelector.
-                If both nil - match everything. NamespaceSelector nil - only objects
-                at VMAgent namespace. Selector nil - only objects at NamespaceSelector
-                namespaces.
+                NamespaceSelector nil - only objects at VMAgent namespace. Selector
+                nil - only objects at NamespaceSelector namespaces. If both nil -
+                behaviour controlled by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.

--- a/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -71,9 +71,10 @@ spec:
               type: array
             configNamespaceSelector:
               description: ' ConfigNamespaceSelector defines namespace selector for
-                VMAlertmanagerConfig. Works in combination with Selector. If both
-                nil - match everything. NamespaceSelector nil - only objects at VMAlertmanager
-                namespace. Selector nil - only objects at NamespaceSelector namespaces.'
+                VMAlertmanagerConfig. Works in combination with Selector. NamespaceSelector
+                nil - only objects at VMAlertmanager namespace. Selector nil - only
+                objects at NamespaceSelector namespaces. If both nil - behaviour controlled
+                by selectAllByDefault'
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -131,9 +132,10 @@ spec:
             configSelector:
               description: ConfigSelector defines selector for VMAlertmanagerConfig,
                 result config will be merged with with Raw or Secret config. Works
-                in combination with NamespaceSelector. If both nil - match everything.
-                NamespaceSelector nil - only objects at VMAlertmanager namespace.
-                Selector nil - only objects at NamespaceSelector namespaces.
+                in combination with NamespaceSelector. NamespaceSelector nil - only
+                objects at VMAlertmanager namespace. Selector nil - only objects at
+                NamespaceSelector namespaces. If both nil - behaviour controlled by
+                selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -212,12 +214,14 @@ spec:
                     type: string
                   value:
                     description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
+                      the previously defined environment variables in the container
                       and any service environment variables. If a variable cannot
                       be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
+                      Double $$ are reduced to a single $, which allows for escaping
+                      the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                      string literal "$(VAR_NAME)". Escaped references will never
+                      be expanded, regardless of whether the variable exists or not.
+                      Defaults to "".'
                     type: string
                 required:
                 - name
@@ -431,6 +435,13 @@ spec:
                 common container settings. This defaults to the default PodSecurityContext.
               type: object
               x-kubernetes-preserve-unknown-fields: true
+            selectAllByDefault:
+              description: 'SelectAllByDefault changes default behavior for empty
+                CRD selectors, such ConfigSelector. with selectAllScrapes: true and
+                undefined ConfigSelector and ConfigNamespaceSelector Operator selects
+                all exist alertManagerConfigs with selectAllScrapes: false - selects
+                nothing'
+              type: boolean
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use
@@ -571,14 +582,50 @@ spec:
                         dataSource:
                           description: 'This field can be used to specify either:
                             * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                            * An existing PVC (PersistentVolumeClaim) * An existing
-                            custom resource that implements data population (Alpha)
-                            In order to use custom resource types that implement data
-                            population, the AnyVolumeDataSource feature gate must
-                            be enabled. If the provisioner or an external controller
-                            can support the specified data source, it will create
-                            a new volume based on the contents of the specified data
-                            source.'
+                            * An existing PVC (PersistentVolumeClaim) If the provisioner
+                            or an external controller can support the specified data
+                            source, it will create a new volume based on the contents
+                            of the specified data source. If the AnyVolumeDataSource
+                            feature gate is enabled, this field will always have the
+                            same contents as the DataSourceRef field.'
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        dataSourceRef:
+                          description: 'Specifies the object from which to populate
+                            the volume with data, if a non-empty volume is desired.
+                            This may be any local object from a non-empty API group
+                            (non core object) or a PersistentVolumeClaim object. When
+                            this field is specified, volume binding will only succeed
+                            if the type of the specified object matches some installed
+                            volume populator or dynamic provisioner. This field will
+                            replace the functionality of the DataSource field and
+                            as such if both fields are non-empty, they must have the
+                            same value. For backwards compatibility, both fields (DataSource
+                            and DataSourceRef) will be set to the same value automatically
+                            if one of them is empty and the other is non-empty. There
+                            are two important differences between DataSource and DataSourceRef:
+                            * While DataSource only allows two specific types of objects,
+                            DataSourceRef   allows any non-core object, as well as
+                            PersistentVolumeClaim objects. * While DataSource ignores
+                            disallowed values (dropping them), DataSourceRef   preserves
+                            all values, and generates an error if a disallowed value
+                            is   specified. (Alpha) Using this field requires the
+                            AnyVolumeDataSource feature gate to be enabled.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource

--- a/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmalerts.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmalerts.yaml
@@ -271,12 +271,14 @@ spec:
                     type: string
                   value:
                     description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
+                      the previously defined environment variables in the container
                       and any service environment variables. If a variable cannot
                       be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
+                      Double $$ are reduced to a single $, which allows for escaping
+                      the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                      string literal "$(VAR_NAME)". Escaped references will never
+                      be expanded, regardless of whether the variable exists or not.
+                      Defaults to "".'
                     type: string
                 required:
                 - name
@@ -927,9 +929,10 @@ spec:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             remoteRead:
-              description: RemoteRead victoria metrics address for loading state This
-                configuration makes sense only if remoteWrite was configured before
-                and has been successfully persisted its state.
+              description: RemoteRead Optional URL to read vmalert state (persisted
+                via RemoteWrite) This configuration only makes sense if alerts state
+                has been successfully persisted (via RemoteWrite) before. see -remoteRead.url
+                docs in vmalerts for details. E.g. http://127.0.0.1:8428
               properties:
                 basicAuth:
                   description: BasicAuth allow an endpoint to authenticate over basic
@@ -1113,7 +1116,10 @@ spec:
               type: object
             remoteWrite:
               description: RemoteWrite Optional URL to remote-write compatible storage
-                where to write timeseriesbased on active alerts. E.g. http://127.0.0.1:8428
+                to persist vmalert state and rule results to. Rule results will be
+                persisted according to each rule. Alerts state will be persisted in
+                the form of time series named ALERTS and ALERTS_FOR_STATE see -remoteWrite.url
+                docs in vmalerts for details. E.g. http://127.0.0.1:8428
               properties:
                 basicAuth:
                   description: BasicAuth allow an endpoint to authenticate over basic
@@ -1378,8 +1384,9 @@ spec:
               type: object
             ruleNamespaceSelector:
               description: RuleNamespaceSelector to be selected for VMRules discovery.
-                Works in combination with Selector. If both nil - match everything.
-                NamespaceSelector nil - only objects at VMAlert namespace.
+                Works in combination with Selector. If both nil - behaviour controlled
+                by selectAllByDefault NamespaceSelector nil - only objects at VMAlert
+                namespace.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1433,8 +1440,8 @@ spec:
             ruleSelector:
               description: RuleSelector selector to select which VMRules to mount
                 for loading alerting rules from. Works in combination with NamespaceSelector.
-                If both nil - match everything. NamespaceSelector nil - only objects
-                at VMAlert namespace.
+                If both nil - behaviour controlled by selectAllByDefault NamespaceSelector
+                nil - only objects at VMAlert namespace.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -1495,6 +1502,13 @@ spec:
                 common container settings. This defaults to the default PodSecurityContext.
               type: object
               x-kubernetes-preserve-unknown-fields: true
+            selectAllByDefault:
+              description: 'SelectAllByDefault changes default behavior for empty
+                CRD selectors, such RuleSelector. with selectAllByDefault: true and
+                empty serviceScrapeSelector and RuleNamespaceSelector Operator selects
+                all exist serviceScrapes with selectAllByDefault: false - selects
+                nothing'
+              type: boolean
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMAlert Pods.

--- a/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmauths.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmauths.yaml
@@ -75,12 +75,14 @@ spec:
                     type: string
                   value:
                     description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
+                      the previously defined environment variables in the container
                       and any service environment variables. If a variable cannot
                       be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
+                      Double $$ are reduced to a single $, which allows for escaping
+                      the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                      string literal "$(VAR_NAME)". Escaped references will never
+                      be expanded, regardless of whether the variable exists or not.
+                      Defaults to "".'
                     type: string
                 required:
                 - name
@@ -210,7 +212,9 @@ spec:
                                       description: Resource is an ObjectRef to another
                                         Kubernetes resource in the namespace of the
                                         Ingress object. If resource is specified,
-                                        serviceName and servicePort must not be specified.
+                                        a service.Name and service.Port must not be
+                                        specified. This is a mutually exclusive setting
+                                        with "Service".
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -231,25 +235,45 @@ spec:
                                       - kind
                                       - name
                                       type: object
-                                    serviceName:
-                                      description: Specifies the name of the referenced
-                                        service.
-                                      type: string
-                                    servicePort:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: Specifies the port of the referenced
-                                        service.
-                                      x-kubernetes-int-or-string: true
+                                    service:
+                                      description: Service references a Service as
+                                        a Backend. This is a mutually exclusive setting
+                                        with "Resource".
+                                      properties:
+                                        name:
+                                          description: Name is the referenced service.
+                                            The service must exist in the same namespace
+                                            as the Ingress object.
+                                          type: string
+                                        port:
+                                          description: Port of the referenced service.
+                                            A port name or port number is required
+                                            for a IngressServiceBackend.
+                                          properties:
+                                            name:
+                                              description: Name is the name of the
+                                                port on the Service. This is a mutually
+                                                exclusive setting with "Number".
+                                              type: string
+                                            number:
+                                              description: Number is the numerical
+                                                port number (e.g. 80) on the Service.
+                                                This is a mutually exclusive setting
+                                                with "Name".
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
                                   type: object
                                 path:
                                   description: Path is matched against the path of
                                     an incoming request. Currently it can contain
                                     characters disallowed from the conventional "path"
                                     part of a URL as defined by RFC 3986. Paths must
-                                    begin with a '/'. When unspecified, all paths
-                                    from incoming requests are matched.
+                                    begin with a '/' and must be present when using
+                                    PathType with value "Exact" or "Prefix".
                                   type: string
                                 pathType:
                                   description: 'PathType determines the interpretation
@@ -270,13 +294,14 @@ spec:
                                     IngressClass. Implementations can treat this as
                                     a separate PathType   or treat it identically
                                     to Prefix or Exact path types. Implementations
-                                    are required to support all path types. Defaults
-                                    to ImplementationSpecific.'
+                                    are required to support all path types.'
                                   type: string
                               required:
                               - backend
+                              - pathType
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - paths
                         type: object
@@ -298,12 +323,13 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       secretName:
                         description: SecretName is the name of the secret used to
-                          terminate SSL traffic on 443. Field is left optional to
-                          allow SSL routing based on SNI hostname alone. If the SNI
-                          host in a listener conflicts with the "Host" header field
-                          used by an IngressRule, the SNI host is used for termination
+                          terminate TLS traffic on port 443. Field is left optional
+                          to allow TLS routing based on SNI hostname alone. If the
+                          SNI host in a listener conflicts with the "Host" header
+                          field used by an IngressRule, the SNI host is used for termination
                           and value of the Host header is used for routing.
                         type: string
                     type: object
@@ -491,6 +517,12 @@ spec:
                 common container settings. This defaults to the default PodSecurityContext.
               type: object
               x-kubernetes-preserve-unknown-fields: true
+            selectAllByDefault:
+              description: 'SelectAllByDefault changes default behavior for empty
+                CRD selectors, such userSelector. with selectAllByDefault: true and
+                empty userSelector and userNamespaceSelector Operator selects all
+                exist users with selectAllByDefault: false - selects nothing'
+              type: boolean
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMAuth Pods.
@@ -596,9 +628,10 @@ spec:
               type: array
             userNamespaceSelector:
               description: UserNamespaceSelector Namespaces to be selected for  VMAuth
-                discovery. Works in combination with Selector. If both nil - match
-                everything. NamespaceSelector nil - only objects at VMAuth namespace.
-                Selector nil - only objects at NamespaceSelector namespaces.
+                discovery. Works in combination with Selector. NamespaceSelector nil
+                - only objects at VMAuth namespace. Selector nil - only objects at
+                NamespaceSelector namespaces. If both nil - behaviour controlled by
+                selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.
@@ -642,9 +675,9 @@ spec:
               type: object
             userSelector:
               description: UserSelector defines VMUser to be selected for config file
-                generation. Works in combination with NamespaceSelector. If both nil
-                - match everything. NamespaceSelector nil - only objects at VMAuth
-                namespace. Selector nil - only objects at NamespaceSelector namespaces.
+                generation. Works in combination with NamespaceSelector. NamespaceSelector
+                nil - only objects at VMAuth namespace. If both nil - behaviour controlled
+                by selectAllByDefault
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.

--- a/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
@@ -132,13 +132,14 @@ spec:
                         type: string
                       value:
                         description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
+                          using the previously defined environment variables in the
                           container and any service environment variables. If a variable
                           cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
                         type: string
                     required:
                     - name
@@ -223,6 +224,7 @@ spec:
                   - PANIC
                   type: string
                 name:
+                  description: Name is deprecated and will be removed at 0.22.0 release
                   type: string
                 nodeSelector:
                   additionalProperties:
@@ -294,7 +296,7 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 replicaCount:
-                  description: ReplicaCount is the expected size of the VMSelect cluster.
+                  description: ReplicaCount is the expected size of the VMInsert cluster.
                     The controller will eventually make the size of the running cluster
                     equal to the expected size.
                   format: int32
@@ -593,13 +595,14 @@ spec:
                         type: string
                       value:
                         description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
+                          using the previously defined environment variables in the
                           container and any service environment variables. If a variable
                           cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
                         type: string
                     required:
                     - name
@@ -668,6 +671,7 @@ spec:
                   - PANIC
                   type: string
                 name:
+                  description: Name is deprecated and will be removed at 0.22.0 release
                   type: string
                 nodeSelector:
                   additionalProperties:
@@ -968,14 +972,55 @@ spec:
                             dataSource:
                               description: 'This field can be used to specify either:
                                 * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                * An existing PVC (PersistentVolumeClaim) * An existing
-                                custom resource that implements data population (Alpha)
-                                In order to use custom resource types that implement
-                                data population, the AnyVolumeDataSource feature gate
-                                must be enabled. If the provisioner or an external
-                                controller can support the specified data source,
-                                it will create a new volume based on the contents
-                                of the specified data source.'
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. If the
+                                AnyVolumeDataSource feature gate is enabled, this
+                                field will always have the same contents as the DataSourceRef
+                                field.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            dataSourceRef:
+                              description: 'Specifies the object from which to populate
+                                the volume with data, if a non-empty volume is desired.
+                                This may be any local object from a non-empty API
+                                group (non core object) or a PersistentVolumeClaim
+                                object. When this field is specified, volume binding
+                                will only succeed if the type of the specified object
+                                matches some installed volume populator or dynamic
+                                provisioner. This field will replace the functionality
+                                of the DataSource field and as such if both fields
+                                are non-empty, they must have the same value. For
+                                backwards compatibility, both fields (DataSource and
+                                DataSourceRef) will be set to the same value automatically
+                                if one of them is empty and the other is non-empty.
+                                There are two important differences between DataSource
+                                and DataSourceRef: * While DataSource only allows
+                                two specific types of objects, DataSourceRef   allows
+                                any non-core object, as well as PersistentVolumeClaim
+                                objects. * While DataSource ignores disallowed values
+                                (dropping them), DataSourceRef   preserves all values,
+                                and generates an error if a disallowed value is   specified.
+                                (Alpha) Using this field requires the AnyVolumeDataSource
+                                feature gate to be enabled.'
                               properties:
                                 apiGroup:
                                   description: APIGroup is the group for the resource
@@ -1306,13 +1351,14 @@ spec:
                         type: string
                       value:
                         description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
+                          using the previously defined environment variables in the
                           container and any service environment variables. If a variable
                           cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
                         type: string
                     required:
                     - name
@@ -1395,6 +1441,7 @@ spec:
                     type: integer
                   type: array
                 name:
+                  description: Name is deprecated and will be removed at 0.22.0 release
                   type: string
                 nodeSelector:
                   additionalProperties:
@@ -1466,9 +1513,9 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 replicaCount:
-                  description: ReplicaCount is the expected size of the VMSelect cluster.
-                    The controller will eventually make the size of the running cluster
-                    equal to the expected size.
+                  description: ReplicaCount is the expected size of the VMStorage
+                    cluster. The controller will eventually make the size of the running
+                    cluster equal to the expected size.
                   format: int32
                   type: integer
                 resources:
@@ -1736,13 +1783,15 @@ spec:
                             type: string
                           value:
                             description: 'Variable references $(VAR_NAME) are expanded
-                              using the previous defined environment variables in
+                              using the previously defined environment variables in
                               the container and any service environment variables.
                               If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. The $(VAR_NAME) syntax
-                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                              references will never be expanded, regardless of whether
-                              the variable exists or not. Defaults to "".'
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
                             type: string
                           valueFrom:
                             description: Source for the environment variable's value.

--- a/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmsingles.yaml
+++ b/monitoring/base/victoriametrics/upstream/crd/legacy/operator.victoriametrics.com_vmsingles.yaml
@@ -75,12 +75,14 @@ spec:
                     type: string
                   value:
                     description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
+                      the previously defined environment variables in the container
                       and any service environment variables. If a variable cannot
                       be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
+                      Double $$ are reduced to a single $, which allows for escaping
+                      the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                      string literal "$(VAR_NAME)". Escaped references will never
+                      be expanded, regardless of whether the variable exists or not.
+                      Defaults to "".'
                     type: string
                 required:
                 - name
@@ -358,12 +360,48 @@ spec:
                 dataSource:
                   description: 'This field can be used to specify either: * An existing
                     VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                    * An existing PVC (PersistentVolumeClaim) * An existing custom
-                    resource that implements data population (Alpha) In order to use
-                    custom resource types that implement data population, the AnyVolumeDataSource
-                    feature gate must be enabled. If the provisioner or an external
-                    controller can support the specified data source, it will create
-                    a new volume based on the contents of the specified data source.'
+                    * An existing PVC (PersistentVolumeClaim) If the provisioner or
+                    an external controller can support the specified data source,
+                    it will create a new volume based on the contents of the specified
+                    data source. If the AnyVolumeDataSource feature gate is enabled,
+                    this field will always have the same contents as the DataSourceRef
+                    field.'
+                  properties:
+                    apiGroup:
+                      description: APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in
+                        the core API group. For any other third-party types, APIGroup
+                        is required.
+                      type: string
+                    kind:
+                      description: Kind is the type of resource being referenced
+                      type: string
+                    name:
+                      description: Name is the name of resource being referenced
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                dataSourceRef:
+                  description: 'Specifies the object from which to populate the volume
+                    with data, if a non-empty volume is desired. This may be any local
+                    object from a non-empty API group (non core object) or a PersistentVolumeClaim
+                    object. When this field is specified, volume binding will only
+                    succeed if the type of the specified object matches some installed
+                    volume populator or dynamic provisioner. This field will replace
+                    the functionality of the DataSource field and as such if both
+                    fields are non-empty, they must have the same value. For backwards
+                    compatibility, both fields (DataSource and DataSourceRef) will
+                    be set to the same value automatically if one of them is empty
+                    and the other is non-empty. There are two important differences
+                    between DataSource and DataSourceRef: * While DataSource only
+                    allows two specific types of objects, DataSourceRef   allows any
+                    non-core object, as well as PersistentVolumeClaim objects. * While
+                    DataSource ignores disallowed values (dropping them), DataSourceRef   preserves
+                    all values, and generates an error if a disallowed value is   specified.
+                    (Alpha) Using this field requires the AnyVolumeDataSource feature
+                    gate to be enabled.'
                   properties:
                     apiGroup:
                       description: APIGroup is the group for the resource being referenced.
@@ -597,13 +635,14 @@ spec:
                         type: string
                       value:
                         description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
+                          using the previously defined environment variables in the
                           container and any service environment variables. If a variable
                           cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
                         type: string
                       valueFrom:
                         description: Source for the environment variable's value.

--- a/monitoring/base/victoriametrics/upstream/rbac/role.yaml
+++ b/monitoring/base/victoriametrics/upstream/rbac/role.yaml
@@ -75,6 +75,7 @@ rules:
   resources:
     - statefulsets
     - statefulsets/finalizers
+    - statefulsets/status
   verbs:
     - '*'
 - apiGroups:

--- a/monitoring/base/victoriametrics/vmalert-largeset.yaml
+++ b/monitoring/base/victoriametrics/vmalert-largeset.yaml
@@ -11,6 +11,8 @@ spec:
   - url: "http://vmalertmanager-vmalertmanager-largeset-0.vmalertmanager-vmalertmanager-largeset.monitoring.svc:9093"
   - url: "http://vmalertmanager-vmalertmanager-largeset-1.vmalertmanager-vmalertmanager-largeset.monitoring.svc:9093"
   - url: "http://vmalertmanager-vmalertmanager-largeset-2.vmalertmanager-vmalertmanager-largeset.monitoring.svc:9093"
+  remoteWrite:
+    url: "http://vminsert-vmcluster-largeset.monitoring.svc:8480/insert/0/prometheus"
   evaluationInterval: "30s"
   ruleNamespaceSelector:
     matchLabels:

--- a/monitoring/base/victoriametrics/vmalert-smallset.yaml
+++ b/monitoring/base/victoriametrics/vmalert-smallset.yaml
@@ -9,6 +9,8 @@ spec:
     url: "http://vmsingle-vmsingle-smallset.monitoring.svc:8429"
   notifiers:
   - url: "http://vmalertmanager-vmalertmanager-smallset-0.vmalertmanager-vmalertmanager-smallset.monitoring.svc:9093"
+  remoteWrite:
+    url: "http://vmsingle-vmsingle-smallset.monitoring.svc:8429"
   evaluationInterval: "30s"
   ruleNamespaceSelector:
     matchLabels:


### PR DESCRIPTION
Part of the container reguler update.

Update MetalLB to v0.11.0 
Update VictoriaMetrics to v0.70.0 and config-reloader to v0.53.0 
Update VictoriaMetrics operator to v0.21.0 
Update Prometheus Adapter to v0.9.1 (Chart v3.0.0) 
Update Pushgateway to v1.4.2 

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>