### PR TITLE
Fix namespace label on cert-manager metrics.

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/cert-manager.yaml
+++ b/monitoring/base/grafana-operator/dashboards/cert-manager.yaml
@@ -104,9 +104,9 @@ spec:
                 ],
                 "targets": [
                     {
-                        "expr": "sort_desc( sum(certmanager_certificate_expiration_timestamp_seconds{exported_namespace=~\"$Namespace\"} - time()) BY (name,exported_namespace) )",
+                        "expr": "sort_desc( sum(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$Namespace\"} - time()) BY (name,namespace) )",
                         "instant": true,
-                        "legendFormat": " {{exported_namespace}} / {{name}}",
+                        "legendFormat": " {{namespace}} / {{name}}",
                         "refId": "A"
                     }
                 ],
@@ -253,10 +253,10 @@ spec:
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "sum(certmanager_certificate_expiration_timestamp_seconds{exported_namespace=~\"$Namespace\"} - time()) BY (name,exported_namespace)",
+                        "expr": "sum(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$Namespace\"} - time()) BY (name,namespace)",
                         "instant": false,
                         "intervalFactor": 1,
-                        "legendFormat": " {{exported_namespace}} / {{name}}",
+                        "legendFormat": " {{namespace}} / {{name}}",
                         "refId": "A"
                     }
                 ],
@@ -1217,14 +1217,14 @@ spec:
                         "value": "$__all"
                     },
                     "datasource": "$Datasource",
-                    "definition": "label_values(exported_namespace)",
+                    "definition": "label_values(namespace)",
                     "hide": 0,
                     "includeAll": true,
                     "label": null,
                     "multi": false,
                     "name": "Namespace",
                     "options": [],
-                    "query": "label_values(exported_namespace)",
+                    "query": "label_values(namespace)",
                     "refresh": 1,
                     "regex": "",
                     "skipUrlSync": false,
@@ -1243,14 +1243,14 @@ spec:
                         "value": "$__all"
                     },
                     "datasource": "$Datasource",
-                    "definition": "label_values(certmanager_certificate_expiration_timestamp_seconds{exported_namespace=~\"$Namespace\"},name) ",
+                    "definition": "label_values(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$Namespace\"},name) ",
                     "hide": 0,
                     "includeAll": true,
                     "label": null,
                     "multi": false,
                     "name": "Certificate",
                     "options": [],
-                    "query": "label_values(certmanager_certificate_expiration_timestamp_seconds{exported_namespace=~\"$Namespace\"},name) ",
+                    "query": "label_values(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$Namespace\"},name) ",
                     "refresh": 2,
                     "regex": "",
                     "skipUrlSync": false,

--- a/monitoring/base/victoriametrics/rules/cert-manager-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/cert-manager-scrape.yaml
@@ -12,9 +12,14 @@ spec:
       app.kubernetes.io/instance: cert-manager
       app.kubernetes.io/name: cert-manager
   podMetricsEndpoints:
-  - relabelConfigs:
+  - honorLabels: true
+    relabelConfigs:
     - replacement: cert-manager
       targetLabel: job
     - sourceLabels: [__meta_kubernetes_pod_container_name]
       regex: cert-manager
       action: keep
+    metricRelabelConfigs:
+    # TODO: remove here config when no use the exported_namespace label.
+    - sourceLabels: [namespace]
+      targetLabel: exported_namespace


### PR DESCRIPTION
The `namespace=cert-manager` label in the metrics retrieved from cert-manager is meaningless, so change it to be the name of the namespace where the certificate exists.

before metrics

```
certmanager_certificate_*{exported_namespace="<name of namespace where the certificate>", namespace="cert-manager"}
```

after metrics

```
certmanager_certificate_*{exported_namespace="<name of namespace where the certificate>", namespace="<<namespace name where the certificate>>"}
```

The `exported_namespace` label is already in use for alerts and dashboards, so `exported_namespace` will be kept temporarily.
The `exported_namespace` label will be removed when it is no longer used.

- With this change, metrics other than certmanager_certificate_* will also have the new label exported_namaspace=certmanager, which was not there before. However, I think this will not have any side effects as it is only temporary.
- In this PR, I haven't changed the label used for alerts from `exported_namespace` to `namespace`. After applying stage and confirming that the `namespace` label is correctly attached, I will change the alert rules in another PR.

Signed-off-by: kouki <kouworld0123@gmail.com>