### PR TITLE
Use namespace label for cert-manager alerts

### DIFF
--- a/monitoring/base/victoriametrics/rules/cert-manager-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/cert-manager-alertrule.yaml
@@ -18,7 +18,7 @@ spec:
             severity: error
         - alert: CertificateNotReady
           expr: |
-            certmanager_certificate_ready_status{condition="False"} *on(exported_namespace) group_left(label_team) label_replace(kube_namespace_labels{label_team="neco"}, "exported_namespace", "$1", "namespace", "(^.*$)") > 0
+            certmanager_certificate_ready_status{condition="False"} * on(namespace) group_left(label_team) kube_namespace_labels{label_team="neco"} > 0
           for: 10m
           labels:
             severity: error
@@ -29,7 +29,7 @@ spec:
           expr: |
             (
               certmanager_certificate_expiration_timestamp_seconds
-                * on(exported_namespace) group_left(label_team) label_replace(kube_namespace_labels{label_team="neco"}, "exported_namespace", "$1", "namespace", "(^.*$)")
+                * on(namespace) group_left(label_team) kube_namespace_labels{label_team="neco"}
               - time()
             ) <= 14*24*60*60
           for: 120m
@@ -37,18 +37,18 @@ spec:
             severity: error
             frequency: daily
           annotations:
-            summary: Certificate {{ $labels.exported_namespace}}/{{ $labels.name }} will expire in 14 day(s).
+            summary: Certificate {{ $labels.namespace }}/{{ $labels.name }} will expire in 14 day(s).
             runbook: Please check the status of Cert Manager and Certificate resources.
         - alert: CertificateExpire
           expr: |
             (
               certmanager_certificate_expiration_timestamp_seconds
-                * on(exported_namespace) group_left(label_team) label_replace(kube_namespace_labels{label_team="neco"}, "exported_namespace", "$1", "namespace", "(^.*$)")
+                * on(namespace) group_left(label_team) kube_namespace_labels{label_team="neco"}
               - time()
             ) <= 0
           for: 120m
           labels:
             severity: critical
           annotations:
-            summary: Certificate {{ $labels.exported_namespace}}/{{ $labels.name }} has already expired.
+            summary: Certificate {{ $labels.namespace}}/{{ $labels.name }} has already expired.
             runbook: Please check the status of Cert Manager and Certificate resources.

--- a/test/vmalert_test/cert-manager.yaml
+++ b/test/vmalert_test/cert-manager.yaml
@@ -17,7 +17,7 @@ tests:
               runbook: TBD
   - interval: 1m
     input_series:
-      - series: 'certmanager_certificate_ready_status{condition="False",exported_namespace="ours",name="certname"}'
+      - series: 'certmanager_certificate_ready_status{condition="False",namespace="ours",name="certname"}'
         values: 1+0x10
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: 1+0x10
@@ -27,7 +27,7 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: error
-              exported_namespace: ours
+              namespace: ours
               name: certname
               label_team: neco
               condition: "False"
@@ -36,7 +36,7 @@ tests:
               runbook: Please check the status of Cert Manager and Certificate resources.
   - interval: 1m
     input_series:
-      - series: 'certmanager_certificate_ready_status{condition="False",exported_namespace="others",name="certname"}'
+      - series: 'certmanager_certificate_ready_status{condition="False",namespace="others",name="certname"}'
         values: 1+0x10
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: 1+0x10
@@ -46,7 +46,7 @@ tests:
         exp_alerts: []
   - interval: 1m
     input_series:
-      - series: 'certmanager_certificate_expiration_timestamp_seconds{exported_namespace="ours",name="certname"}'
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{namespace="ours",name="certname"}'
         values: 1209600+0x120 # 14 days
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: 1+0x120
@@ -57,7 +57,7 @@ tests:
           - exp_labels:
               severity: error
               frequency: daily
-              exported_namespace: ours
+              namespace: ours
               name: certname
               label_team: neco
             exp_annotations:
@@ -65,7 +65,7 @@ tests:
               runbook: Please check the status of Cert Manager and Certificate resources.
   - interval: 1m
     input_series:
-      - series: 'certmanager_certificate_expiration_timestamp_seconds{exported_namespace="ours",name="certname"}'
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{namespace="ours",name="certname"}'
         values: 0+0x120
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: 1+0x120
@@ -76,7 +76,7 @@ tests:
           - exp_labels:
               severity: error
               frequency: daily
-              exported_namespace: ours
+              namespace: ours
               name: certname
               label_team: neco
             exp_annotations:
@@ -84,7 +84,7 @@ tests:
               runbook: Please check the status of Cert Manager and Certificate resources.
           - exp_labels:
               severity: critical
-              exported_namespace: ours
+              namespace: ours
               name: certname
               label_team: neco
             exp_annotations:
@@ -92,7 +92,7 @@ tests:
               runbook: Please check the status of Cert Manager and Certificate resources.
   - interval: 1m
     input_series:
-      - series: 'certmanager_certificate_expiration_timestamp_seconds{exported_namespace="ours",name="certname"}'
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{namespace="ours",name="certname"}'
         values: 1296000+0x120 # 15 days
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: 1+0x120
@@ -102,7 +102,7 @@ tests:
         exp_alerts: []
   - interval: 1m
     input_series:
-      - series: 'certmanager_certificate_expiration_timestamp_seconds{exported_namespace="others",name="certname"}'
+      - series: 'certmanager_certificate_expiration_timestamp_seconds{namespace="others",name="certname"}'
         values: 0+0x120
       - series: 'kube_namespace_labels{namespace="ours",label_team="neco"}'
         values: 1+0x120


### PR DESCRIPTION
After confirming that https://github.com/cybozu-go/neco-apps/pull/2163 is stage-released and correctly labeled, modify the alert rules to stop using the `exported_namespace` label and use the `namespace` label.

Signed-off-by: kouki <kouworld0123@gmail.com>