### PR TITLE
[Merge to main on Jan 24]Remove exported_namespace label for cert-manager metrics

### DIFF
--- a/monitoring/base/victoriametrics/rules/cert-manager-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/cert-manager-scrape.yaml
@@ -19,7 +19,3 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_container_name]
       regex: cert-manager
       action: keep
-    metricRelabelConfigs:
-    # TODO: remove here config when no use the exported_namespace label.
-    - sourceLabels: [namespace]
-      targetLabel: exported_namespace


### PR DESCRIPTION
Will be applied to stage on Jan 25 and prod on Jan 26.

Signed-off-by: kouki <kouworld0123@gmail.com>