### PR TITLE
use HTTPS port to scrape kube-controller-manager metrics

### DIFF
--- a/monitoring/base/victoriametrics/rules/kubernetes-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/kubernetes-scrape.yaml
@@ -29,7 +29,7 @@ spec:
       - sourceLabels: [__address__]
         action: replace
         regex: ([^:]+)(?::\d+)?
-        replacement: ${1}:10252
+        replacement: ${1}:10257
         targetLabel: __address__
       - sourceLabels: [__address__]
         targetLabel: instance

--- a/network-policy/base/global-policies/controller-manager.yaml
+++ b/network-policy/base/global-policies/controller-manager.yaml
@@ -14,4 +14,4 @@ spec:
       destination:
         selector: role == 'node'
         ports:
-          - 10252
+          - 10257


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco-apps/issues/2075

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>