### PR TITLE
Fix false NodeUnreachable alerts.

### DIFF
--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -37,10 +37,10 @@ spec:
             severity: error
         - alert: NodeUnreachable
           annotations:
-            summary: "Unreachable node with a address of {{ $labels.address }} and a serial of {{ $labels.serial }} exist."
+            summary: "Node `{{ $labels.serial }}` at `{{ $labels.address }}` is unreachable."
             runbook: "Perform the server retirement procedure."
           expr: |
-            sum by(instance, address, serial) (sabakan_machine_status{status="unreachable"}) > 0
+            sum by(address, serial) (sabakan_machine_status{status="unreachable"}) > 0
           for: 60m
           labels:
             severity: urgent

--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -40,7 +40,7 @@ spec:
             summary: "Unreachable node(s) exist."
             runbook: "Perform the server retirement procedure."
           expr: |
-            sum(sabakan_machine_status{status="unreachable"}) > 0
+            sum by(instance, address, serial) (sabakan_machine_status{status="unreachable"}) > 0
           for: 60m
           labels:
             severity: urgent

--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -37,7 +37,7 @@ spec:
             severity: error
         - alert: NodeUnreachable
           annotations:
-            summary: "Unreachable node(s) exist."
+            summary: "Unreachable node with a address of {{ $labels.address }} and a serial of {{ $labels.serial }} exist."
             runbook: "Perform the server retirement procedure."
           expr: |
             sum by(instance, address, serial) (sabakan_machine_status{status="unreachable"}) > 0

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -65,7 +65,7 @@ tests:
               address: "1.2.3.4"
               serial: "abcd"
             exp_annotations:
-              summary: Unreachable node(s) exist.
+              summary: "Unreachable node with a address of 1.2.3.4 and a serial of abcd exist."
               runbook: "Perform the server retirement procedure."
   - interval: 1m
     input_series:

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -61,6 +61,27 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: urgent
+              instance: "1.2.3.4"
+              address: "1.2.3.4"
+              serial: "abcd"
             exp_annotations:
               summary: Unreachable node(s) exist.
               runbook: "Perform the server retirement procedure."
+  - interval: 1m
+    input_series:
+      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="healthy"}
+        values: 0+0x30 1+0x30
+      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unreachable"}
+        values: 1+0x30 0+0x30
+      - series: sabakan_machine_status{instance="1.2.3.5", address="1.2.3.5", serial="abce", status="healthy"}
+        values: 1+0x20 0+0x30 1+0x10
+      - series: sabakan_machine_status{instance="1.2.3.5", address="1.2.3.5", serial="abce", status="unreachable"}
+        values: 0+0x20 1+0x30 0+0x10
+      - series: sabakan_machine_status{instance="1.2.3.6", address="1.2.3.6", serial="abcf", status="healthy"}
+        values: 1+0x40 0+0x20
+      - series: sabakan_machine_status{instance="1.2.3.6", address="1.2.3.6", serial="abcf", status="unreachable"}
+        values: 0+0x40 1+0x20
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: NodeUnreachable
+        exp_alerts: []

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -51,9 +51,9 @@ tests:
               runbook: TBD
   - interval: 1m
     input_series:
-      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="healthy"}
         values: 0+0x60
-      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="unreachable"}
         values: 1+0x60
     alert_rule_test:
       - eval_time: 60m
@@ -61,25 +61,24 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: urgent
-              instance: "1.2.3.4"
               address: "1.2.3.4"
               serial: "abcd"
             exp_annotations:
-              summary: "Unreachable node with a address of 1.2.3.4 and a serial of abcd exist."
+              summary: "Node `abcd` at `1.2.3.4` is unreachable."
               runbook: "Perform the server retirement procedure."
   - interval: 1m
     input_series:
-      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="healthy"}
         values: 0+0x30 1+0x30
-      - series: sabakan_machine_status{instance="1.2.3.4", address="1.2.3.4", serial="abcd", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="unreachable"}
         values: 1+0x30 0+0x30
-      - series: sabakan_machine_status{instance="1.2.3.5", address="1.2.3.5", serial="abce", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.5", serial="abce", status="healthy"}
         values: 1+0x20 0+0x30 1+0x10
-      - series: sabakan_machine_status{instance="1.2.3.5", address="1.2.3.5", serial="abce", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.5", serial="abce", status="unreachable"}
         values: 0+0x20 1+0x30 0+0x10
-      - series: sabakan_machine_status{instance="1.2.3.6", address="1.2.3.6", serial="abcf", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.6", serial="abcf", status="healthy"}
         values: 1+0x40 0+0x20
-      - series: sabakan_machine_status{instance="1.2.3.6", address="1.2.3.6", serial="abcf", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.6", serial="abcf", status="unreachable"}
         values: 0+0x40 1+0x20
     alert_rule_test:
       - eval_time: 60m


### PR DESCRIPTION
Fixed false NodeUnreachable alerts when multiple machines were in the `sabakan_machine_status{status="unreachable"}` state alternately.
By changing the evaluation formula to separate instance, address, and serial, an alert will be issued only when one unit is unreachable for 60 minutes.

Signed-off-by: kouki <kouworld0123@gmail.com>