### PR TITLE
use HTTPS port to scrape kube-controller-manager metrics (fix)

### DIFF
--- a/monitoring/base/victoriametrics/rules/kubernetes-scrape.yaml
+++ b/monitoring/base/victoriametrics/rules/kubernetes-scrape.yaml
@@ -22,7 +22,10 @@ spec:
       - replacement: kubernetes-apiservers
         targetLabel: job
   - port: https
-    scheme: http
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     relabelConfigs:
       - replacement: kube-controller-manager
         targetLabel: job


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco-apps/issues/2075

forgot to use https scheme (and auth tokens) in https://github.com/cybozu-go/neco-apps/pull/2192

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>