### PR TITLE
rename grafana ConfigMap

### DIFF
--- a/grafana-sandbox/overlays/common/grafana.yaml
+++ b/grafana-sandbox/overlays/common/grafana.yaml
@@ -62,7 +62,7 @@ spec:
         - name: config
           configMap:
             defaultMode: 420
-            name: grafana
+            name: grafana-config
         - name: datasources-provider
           configMap:
             name: grafana-datasources-provider

--- a/grafana-sandbox/overlays/common/kustomization.yaml
+++ b/grafana-sandbox/overlays/common/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - rbac.yaml
   - service.yaml
 configMapGenerator:
-  - name: grafana
+  - name: grafana-config
     namespace: grafana-sandbox
     files:
       - config/grafana.ini


### PR DESCRIPTION
to prevent `kustomize` from incorrectly rewriting the name of the Secret
in the Role.

part of https://github.com/cybozu-go/neco/issues/1871

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>