### PR TITLE
Add workaround for switching app with overlays for garoon-apps.

### DIFF
--- a/argocd-config/overlays/stage0/tenants/garoon-apps.yaml
+++ b/argocd-config/overlays/stage0/tenants/garoon-apps.yaml
@@ -15,7 +15,7 @@ spec:
   project: tenant-app-of-apps
   source:
     path: argocd-config/overlays/stage0
-    repoURL: https://github.com/garoon-private/garoon-apps.git
+    repoURL: https://github.com/cybozu-private/garoon-apps.git
     targetRevision: main
   syncPolicy:
     automated:

--- a/team-management/template/argocd-config/overlays/template/tenants/main.libsonnet
+++ b/team-management/template/argocd-config/overlays/template/tenants/main.libsonnet
@@ -3,7 +3,10 @@ local kustomization_template = import 'kustomization.libsonnet';
 local app_template = import 'template-apps.libsonnet';
 local generate_app_content = function(settings, app, overlay)
   local info = utility.get_app(settings, app);
-  app_template(app, info.repo, overlay, info.destinations[overlay]);
+  // TODO: revert here when app has been switched completely.
+  // Workaround for switching app with overlays.
+  local repo = if overlay == 'stage0' && info.repo == 'https://github.com/garoon-private/garoon-apps.git' then 'https://github.com/cybozu-private/garoon-apps.git' else info.repo;
+  app_template(app, repo, overlay, info.destinations[overlay]);
 function(settings, overlay)
   local apps = utility.get_destination_apps(settings, overlay);
   {


### PR DESCRIPTION
Migrate only stage0 to migrate garoon-apps repoURL step by step.
Edit jsonnet directly to put in specific processing.

before(only stage0 overlay): https://github.com/garoon-private/garoon-apps.git
after(only stage0 overlay): https://github.com/cybozu-private/garoon-apps.git 

Signed-off-by: kouki <kouworld0123@gmail.com>