### PR TITLE
remove incomplete storage version migration detection

### DIFF
--- a/monitoring/base/victoriametrics/rules/kube-storage-version-migrator-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/kube-storage-version-migrator-alertrule.yaml
@@ -16,11 +16,3 @@ spec:
         for: 60m
         labels:
           severity: error
-      - alert: KubeStorageVersionMigratorRunning
-        annotations:
-          summary: migrating {{ $labels.resource }}
-        expr: |
-          rate(storage_migrator_core_migrator_migrated_objects[5m]) > 0
-        for: 1m
-        labels:
-          severity: info

--- a/test/vmalert_test/kube-storage-version-migrator.yaml
+++ b/test/vmalert_test/kube-storage-version-migrator.yaml
@@ -15,16 +15,3 @@ tests:
             exp_annotations:
               runbook: TBD
               summary: kube-storage-version-migrator migrator has disappeared.
-  - interval: 1m
-    input_series:
-      - series: 'storage_migrator_core_migrator_migrated_objects{resource="configmaps"}'
-        values: '0+0x5 1+0x5'
-    alert_rule_test:
-      - eval_time: 7m
-        alertname: KubeStorageVersionMigratorRunning
-        exp_alerts:
-          - exp_labels:
-              severity: info
-              resource: configmaps
-            exp_annotations:
-              summary: migrating configmaps


### PR DESCRIPTION
This alert rule can only detect migration rarely. It is useless.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>