### PR TITLE
Fix tests for network policy

### DIFF
--- a/test/testdata/network-policy.yaml
+++ b/test/testdata/network-policy.yaml
@@ -38,8 +38,11 @@ metadata:
   namespace: default
 spec:
   securityContext:
-    runAsUser: 10000
-    runAsGroup: 10000
+    runAsUser: 1000
+    runAsGroup: 1000
+    sysctls:
+      - name: net.ipv4.ping_group_range
+        value: 0 1000
   containers:
   - name: ubuntu
     image: quay.io/cybozu/ubuntu-debug:20.04


### PR DESCRIPTION
This PR fixes the broken network policy tests in which ping failed because the ubuntu pod doesn't have the permission to ping. Also it fixes the domestic egress test.