### PR TITLE
use AvailableReplicas instead of ReadyReplicas

### DIFF
--- a/test/reboot_test.go
+++ b/test/reboot_test.go
@@ -313,10 +313,10 @@ func testRebootAllNodes() {
 					replicas = *d.Spec.Replicas
 				}
 
-				if replicas != d.Status.ReadyReplicas {
+				if replicas != d.Status.AvailableReplicas {
 					return fmt.Errorf(
 						"the number of replicas of Deployment %s/%s should be %d: %d",
-						d.Namespace, d.Name, replicas, d.Status.ReadyReplicas,
+						d.Namespace, d.Name, replicas, d.Status.AvailableReplicas,
 					)
 				}
 			}
@@ -343,10 +343,10 @@ func testRebootAllNodes() {
 					replicas = *d.Spec.Replicas
 				}
 
-				if replicas != d.Status.ReadyReplicas {
+				if replicas != d.Status.AvailableReplicas {
 					return fmt.Errorf(
 						"the number of replicas of StatefulSet %s/%s should be %d: %d",
-						d.Namespace, d.Name, replicas, d.Status.ReadyReplicas,
+						d.Namespace, d.Name, replicas, d.Status.AvailableReplicas,
 					)
 				}
 			}

--- a/test/replica_test.go
+++ b/test/replica_test.go
@@ -39,7 +39,7 @@ func checkDeploymentReplicas(name, namespace string, desiredReplicas int) error 
 	return nil
 }
 
-// checkStatefulSetReplicas checks the number of ready replicas and updated replicas for a StatefulSet.
+// checkStatefulSetReplicas checks the number of available replicas and updated replicas for a StatefulSet.
 // If desiredReplicas is less than zero, `.spec.replicas` is used instead.
 func checkStatefulSetReplicas(name, namespace string, desiredReplicas int) error {
 	stdout, stderr, err := ExecAt(boot0, "kubectl", "get", "statefulset", "-n", namespace, name, "-o", "json")
@@ -61,9 +61,8 @@ func checkStatefulSetReplicas(name, namespace string, desiredReplicas int) error
 		}
 	}
 
-	// TODO: this should be AvailableReplicas in k8s 1.22
-	if int(sts.Status.ReadyReplicas) != desiredReplicas {
-		return fmt.Errorf("ReadyReplicas of StatefulSet %s/%s is not %d: %d", namespace, name, desiredReplicas, sts.Status.ReadyReplicas)
+	if int(sts.Status.AvailableReplicas) != desiredReplicas {
+		return fmt.Errorf("AvailableReplicas of StatefulSet %s/%s is not %d: %d", namespace, name, desiredReplicas, sts.Status.AvailableReplicas)
 	}
 	if int(sts.Status.UpdatedReplicas) != desiredReplicas {
 		return fmt.Errorf("UpdatedReplicas of StatefulSet %s/%s is not %d: %d", namespace, name, desiredReplicas, sts.Status.UpdatedReplicas)


### PR DESCRIPTION
`AvailableReplicas` in StatefulSetStatus is available since k8s 1.22. It is more preferable than ReadyReplicas.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>