### PR TITLE
Send token when downloading materials from GitHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,14 +379,14 @@ setup:
 	rm -f /tmp/helm.tgz
 
 	# tanka
-	curl -sSLf -o $$(go env GOPATH)/bin/tk https://github.com/grafana/tanka/releases/download/v$(TANKA_VERSION)/tk-linux-amd64
+	./bin/curl-github -sSLf -o $$(go env GOPATH)/bin/tk https://github.com/grafana/tanka/releases/download/v$(TANKA_VERSION)/tk-linux-amd64
 	chmod +x $$(go env GOPATH)/bin/tk
 
 	# jb
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 
 	# yq
-	curl -sSLf -o /tmp/yq.tar.gz https://github.com/mikefarah/yq/releases/download/v$(YQ_VERSION)/yq_linux_amd64.tar.gz
+	./bin/curl-github -sSLf -o /tmp/yq.tar.gz https://github.com/mikefarah/yq/releases/download/v$(YQ_VERSION)/yq_linux_amd64.tar.gz
 	tar --strip-components=1 -C $$(go env GOPATH)/bin -xzf /tmp/yq.tar.gz
 	mv $$(go env GOPATH)/bin/yq_linux_amd64 $$(go env GOPATH)/bin/yq
 	rm -f /tmp/yq.tar.gz

--- a/bin/curl-github
+++ b/bin/curl-github
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+TOKEN_FILE=${NECO_DIR}/github-token
+SAFE_SITES="(api.github.com|github.com|raw.githubusercontent.com)"
+if [ -e ${TOKEN_FILE} ]; then
+    if ! echo $@ | grep -q -E "https://${SAFE_SITES}/"; then
+        echo "Do not use curl-github for non-GitHub sites" 1>&2
+        exit 1
+    fi
+    exec curl --header "Authorization: token $(cat ${TOKEN_FILE})" "$@"
+else
+    exec curl "$@"
+fi

--- a/bin/wget-github
+++ b/bin/wget-github
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+TOKEN_FILE=${NECO_DIR}/github-token
+SAFE_SITES="(api.github.com|github.com|raw.githubusercontent.com)"
+if [ -e ${TOKEN_FILE} ]; then
+    if ! echo $@ | grep -q -E "https://${SAFE_SITES}/"; then
+        echo "Do not use wget-github for non-GitHub sites" 1>&2
+        exit 1
+    fi
+    exec wget --header "Authorization: token $(cat ${TOKEN_FILE})" "$@"
+else
+    exec wget "$@"
+fi

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,9 @@ TEST_ID := test$(CIRCLE_BUILD_NUM)
 BASE_BRANCH = main
 COMMIT_ID = $(shell git rev-parse HEAD)
 SUDO = sudo
-WGET=wget --retry-on-http-error=503 --retry-connrefused --no-verbose
+WGET_OPTIONS=--retry-on-http-error=503 --retry-connrefused --no-verbose
+WGET=wget $(WGET_OPTIONS)
+WGET_GITHUB=../bin/wget-github $(WGET_OPTIONS)
 NUM_DASHBOARD = $(shell KUSTOMIZE_ENABLE_ALPHA_COMMANDS=true ./bin/kustomize cfg count ../monitoring/base/grafana-operator/dashboards | \
 	grep GrafanaDashboard | cut -d' ' -f2)
 export BOOT0 BOOT1 BOOT2 GINKGO SSH_PRIVKEY TEST_ID COMMIT_ID NUM_DASHBOARD SUDO
@@ -103,12 +105,12 @@ $(KUBECTL):
 
 $(KUSTOMIZE):
 	$(MAKE) setup-download
-	$(WGET) -O $(KUSTOMIZE_DLPATH) https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz
+	$(WGET_GITHUB) -O $(KUSTOMIZE_DLPATH) https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz
 	tar zxf $(KUSTOMIZE_DLPATH) -C $(BINDIR)
 
 $(PROMTOOL):
 	$(MAKE) setup-download
-	$(WGET) -O $(PROMTOOL_DLPATH) https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).linux-amd64.tar.gz
+	$(WGET_GITHUB) -O $(PROMTOOL_DLPATH) https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).linux-amd64.tar.gz
 	tar zxf $(PROMTOOL_DLPATH) -C $(BINDIR) --strip-components=1 prometheus-$(PROMTOOL_VERSION).linux-amd64/promtool
 
 $(TSH):
@@ -118,7 +120,7 @@ $(TSH):
 
 $(ARGOCD):
 	$(MAKE) setup-download
-	$(WGET) -O $(BINDIR)/argocd https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VERSION)/argocd-linux-amd64
+	$(WGET_GITHUB) -O $(BINDIR)/argocd https://github.com/argoproj/argo-cd/releases/download/v$(ARGOCD_VERSION)/argocd-linux-amd64
 	chmod +x $@
 
 .PHONY: setup


### PR DESCRIPTION
This PR enables the GitHub auth token in the neco-apps test in a similar way to https://github.com/cybozu-go/neco/pull/1926 .
Shell scripts are copied from cybozu-go/neco rather than referred because cybozu-go/neco does not always exist, especially in setup.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
