### PR TITLE
Update cattage to v0.1.1

### DIFF
--- a/argocd-config/base/cattage.yaml
+++ b/argocd-config/base/cattage.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://cybozu-go.github.io/cattage
     chart: cattage
-    targetRevision: 0.1.2
+    targetRevision: 0.1.3
     helm:
       version: v3
       values: |


### PR DESCRIPTION
helm chart v0.1.3 is for cattage v0.1.1

Signed-off-by: zoetrope <a.ikezoe@gmail.com>