### PR TITLE
Add system level ignoreDifferences for Certificate

### DIFF
--- a/argocd-config/base/accurate.yaml
+++ b/argocd-config/base/accurate.yaml
@@ -136,9 +136,3 @@ spec:
     automated:
       prune: true
       selfHeal: true
-  ignoreDifferences:
-    - group: cert-manager.io
-      kind: Certificate
-      jsonPointers:
-        - /spec/duration
-        - /spec/renewBefore

--- a/argocd-config/base/cattage.yaml
+++ b/argocd-config/base/cattage.yaml
@@ -115,9 +115,3 @@ spec:
     automated:
       prune: true
       selfHeal: true
-  ignoreDifferences:
-    - group: cert-manager.io
-      kind: Certificate
-      jsonPointers:
-        - /spec/duration
-        - /spec/renewBefore

--- a/argocd-config/base/moco.yaml
+++ b/argocd-config/base/moco.yaml
@@ -23,9 +23,3 @@ spec:
     automated:
       prune: true
       selfHeal: true
-  ignoreDifferences:
-    - group: cert-manager.io
-      kind: Certificate
-      jsonPointers:
-        - /spec/duration
-        - /spec/renewBefore

--- a/argocd-config/base/prometheus-adapter.yaml
+++ b/argocd-config/base/prometheus-adapter.yaml
@@ -17,10 +17,6 @@ spec:
       prune: true
       selfHeal: true
   ignoreDifferences:
-  - group: cert-manager.io
-    kind: Certificate
-    jsonPointers:
-    - /spec/duration
   - group: apiregistration.k8s.io
     kind: APIService
     jsonPointers:

--- a/argocd-config/base/tenet.yaml
+++ b/argocd-config/base/tenet.yaml
@@ -23,9 +23,3 @@ spec:
     automated:
       prune: true
       selfHeal: true
-  ignoreDifferences:
-    - group: cert-manager.io
-      kind: Certificate
-      jsonPointers:
-        - /spec/duration
-        - /spec/renewBefore

--- a/argocd-config/base/topolvm.yaml
+++ b/argocd-config/base/topolvm.yaml
@@ -17,12 +17,6 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: topolvm-system
-  ignoreDifferences:
-  - group: cert-manager.io
-    kind: Certificate
-    jsonPointers:
-    - /spec/duration
-    - /spec/renewBefore
   syncPolicy:
     automated:
       prune: true

--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -16,6 +16,10 @@ data:
           orgs:
           - name: cybozu-private
           teamNameField: slug
+  resource.customizations.ignoreDifferences.cert-manager.io_Certificate: |
+    jsonPointers:
+    - /spec/duration
+    - /spec/renewBefore
   resource.customizations: |
     argoproj.io/Application:
       health.lua: |

--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -20,90 +20,84 @@ data:
     jsonPointers:
     - /spec/duration
     - /spec/renewBefore
-  resource.customizations: |
-    argoproj.io/Application:
-      health.lua: |
-        hs = {}
-        hs.status = "Progressing"
-        hs.message = ""
-        if obj.metadata ~= nil and obj.metadata.labels ~= nil and obj.metadata.labels["app.kubernetes.io/instance"] == "argocd-config" and obj.metadata.labels["is-tenant"] == "true" then
+  resource.customizations.health.argoproj.io_Application: |
+    hs = {}
+    hs.status = "Progressing"
+    hs.message = ""
+    if obj.metadata ~= nil and obj.metadata.labels ~= nil and obj.metadata.labels["app.kubernetes.io/instance"] == "argocd-config" and obj.metadata.labels["is-tenant"] == "true" then
+      hs.status = "Healthy"
+      hs.message = ""
+      return hs
+    end
+    if obj.status ~= nil then
+      if obj.status.health ~= nil then
+        hs.status = obj.status.health.status
+        if obj.status.health.message ~= nil then
+          hs.message = obj.status.health.message
+        end
+      end
+    end
+    return hs
+  resource.customizations.health.ceph.rook.io_CephCluster: |
+    hs = {}
+    if obj.status ~= nil then
+      if obj.status.ceph ~= nil then
+        if obj.status.ceph.health == "HEALTH_OK" or obj.status.ceph.health == "HEALTH_WARN" then
           hs.status = "Healthy"
-          hs.message = ""
+          hs.message = obj.status.message
           return hs
         end
-        if obj.status ~= nil then
-          if obj.status.health ~= nil then
-            hs.status = obj.status.health.status
-            if obj.status.health.message ~= nil then
-              hs.message = obj.status.health.message
-            end
-          end
-        end
-        return hs
-    ceph.rook.io/CephCluster:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status.ceph ~= nil then
-            if obj.status.ceph.health == "HEALTH_OK" or obj.status.ceph.health == "HEALTH_WARN" then
-              hs.status = "Healthy"
-              hs.message = obj.status.message
-              return hs
-            end
-          end
-        end
+      end
+    end
 
-        hs.status = "Progressing"
-        hs.message = "Waiting for Ceph cluster to become HEALTH_OK or HEALTH_WARN"
+    hs.status = "Progressing"
+    hs.message = "Waiting for Ceph cluster to become HEALTH_OK or HEALTH_WARN"
+    return hs
+  resource.customizations.health.objectbucket.io_ObjectBucketClaim: |
+    hs = {}
+    if obj.status ~= nil then
+      if obj.status.phase == "Bound" then
+        hs.status = "Healthy"
+        hs.message = "Bound"
         return hs
-    objectbucket.io/ObjectBucketClaim:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status.phase == "Bound" then
+      end
+    end
+
+    hs.status = "Progressing"
+    hs.message = "Waiting for a bucket to get created"
+    return hs
+  resource.customizations.health.accurate.cybozu.com_SubNamespace: |
+    hs = {}
+    if obj.status ~= nil then
+      if obj.status == "ok" then
+        hs.status = "Healthy"
+        hs.message = obj.status
+        return hs
+      end
+    end
+
+    hs.status = "Progressing"
+    hs.message = "Waiting for namespace creation"
+    return hs
+  resource.customizations.health.moco.cybozu.com_MySQLCluster:
+    hs = {}
+    if obj.status ~= nil and obj.status.conditions ~= nil then
+      for idx, cond in pairs(obj.status.conditions) do
+        if cond.type == "Healthy" then
+          if cond.status == "True" then
             hs.status = "Healthy"
-            hs.message = "Bound"
-            return hs
+          else
+            hs.status = "Progressing"
           end
+          hs.message = cond.message
+          return hs
         end
+      end
+    end
 
-        hs.status = "Progressing"
-        hs.message = "Waiting for a bucket to get created"
-        return hs
-    accurate.cybozu.com/SubNamespace:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status == "ok" then
-            hs.status = "Healthy"
-            hs.message = obj.status
-            return hs
-          end
-        end
-
-        hs.status = "Progressing"
-        hs.message = "Waiting for namespace creation"
-        return hs
-    moco.cybozu.com/MySQLCluster:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil and obj.status.conditions ~= nil then
-          for idx, cond in pairs(obj.status.conditions) do
-            if cond.type == "Healthy" then
-              if cond.status == "True" then
-                hs.status = "Healthy"
-              else
-                hs.status = "Progressing"
-              end
-              hs.message = cond.message
-              return hs
-            end
-          end
-        end
-
-        hs.status = "Progressing"
-        hs.message = "Waiting for MySQLCluster to become healthy"
-        return hs
+    hs.status = "Progressing"
+    hs.message = "Waiting for MySQLCluster to become healthy"
+    return hs
   resource.compareoptions: |
     ignoreAggregatedRoles: true
   resource.exclusions: |


### PR DESCRIPTION
- Add system level ignoreDifferences for Certificate.
    - All tenant users may need this setting.
- Convert to new keys in `argocd-cm` ConfigMap.
    - The new kay format is introduced in Argo CD v2.1.0. And the old format is deprecated.
    - https://blog.argoproj.io/argo-cd-v2-1-first-release-candidate-is-ready-c1aab7795638

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>