### PR TITLE
Allow teleport apps to access teleport-proxy LB

### DIFF
--- a/network-policy/base/policies/teleport.yaml
+++ b/network-policy/base/policies/teleport.yaml
@@ -51,3 +51,23 @@ spec:
     - ports:
       - port: "2379"
         protocol: TCP
+---
+# Temporary fix: This policy allow teleport apps to access teleport-proxy LB
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: egress-teleport-app-allow
+  namespace: teleport
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:app.kubernetes.io/name: teleport
+      k8s:app.kubernetes.io/component: app
+  egress:
+  - toEntities:
+    - host
+    - remote-node
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP


### PR DESCRIPTION
Teleport apps can't access teleport-proxy LB because Cilium doesn't properly handle packets destined to LB services from Pod. It manages backends for LB services only if NodePort is enabled. Cilium is aware of those packets' destination as host. 

https://github.com/cilium/cilium/blob/917051f8efcd477552d649e4af38f9dbbbc55e97/pkg/k8s/service.go#L452 

This PR works around this issue by adding the policy that allows teleport apps to access teleport-proxy LB.