### PR TITLE
rook: replace cephcsi container with self-built one.

### DIFF
--- a/rook/base/ceph-object-store-clusterrolebinding/values.yaml
+++ b/rook/base/ceph-object-store-clusterrolebinding/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/ceph-object-store.yaml
+++ b/rook/base/ceph-object-store.yaml
@@ -523,6 +523,7 @@ data:
       operator: Exists
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: "300"
   ROOK_CSI_ATTACHER_IMAGE: quay.io/cybozu/csi-attacher:3.4.0.1
+  ROOK_CSI_CEPH_IMAGE: quay.io/cybozu/cephcsi:3.5.1.1
   ROOK_CSI_ENABLE_CEPHFS: "false"
   ROOK_CSI_ENABLE_GRPC_METRICS: "false"
   ROOK_CSI_ENABLE_RBD: "true"

--- a/rook/base/ceph-object-store/values.yaml
+++ b/rook/base/ceph-object-store/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/ceph-poc-clusterrolebinding/values.yaml
+++ b/rook/base/ceph-poc-clusterrolebinding/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/ceph-poc/values.yaml
+++ b/rook/base/ceph-poc/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/ceph-ssd-clusterrolebinding/values.yaml
+++ b/rook/base/ceph-ssd-clusterrolebinding/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/ceph-ssd.yaml
+++ b/rook/base/ceph-ssd.yaml
@@ -534,6 +534,7 @@ data:
       operator: Exists
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: "300"
   ROOK_CSI_ATTACHER_IMAGE: quay.io/cybozu/csi-attacher:3.4.0.1
+  ROOK_CSI_CEPH_IMAGE: quay.io/cybozu/cephcsi:3.5.1.1
   ROOK_CSI_ENABLE_CEPHFS: "false"
   ROOK_CSI_ENABLE_GRPC_METRICS: "false"
   ROOK_CSI_ENABLE_RBD: "true"

--- a/rook/base/ceph-ssd/values.yaml
+++ b/rook/base/ceph-ssd/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/common/values.yaml
+++ b/rook/base/common/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/base/values.yaml
+++ b/rook/base/values.yaml
@@ -16,8 +16,8 @@ csi:
   rbdPluginTolerations:
   - key: node.cybozu.io/cluster-not-ready
     operator: Exists
-  #cephcsi:
-    #image: quay.io/cephcsi/cephcsi:v3.5.1
+  cephcsi:
+    image: quay.io/cybozu/cephcsi:3.5.1.1
   registrar:
     image: quay.io/cybozu/csi-node-driver-registrar:2.4.0.1
   provisioner:

--- a/rook/overlays/stage0/ceph-poc/ceph-poc.yaml
+++ b/rook/overlays/stage0/ceph-poc/ceph-poc.yaml
@@ -558,6 +558,7 @@ data:
       operator: Exists
   ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS: "300"
   ROOK_CSI_ATTACHER_IMAGE: quay.io/cybozu/csi-attacher:3.4.0.1
+  ROOK_CSI_CEPH_IMAGE: quay.io/cybozu/cephcsi:3.5.1.1
   ROOK_CSI_ENABLE_CEPHFS: "false"
   ROOK_CSI_ENABLE_GRPC_METRICS: "false"
   ROOK_CSI_ENABLE_RBD: "true"


### PR DESCRIPTION
issue: cybozu/csa#21

cephcsi is replaced with the self-built container.
(cf. https://github.com/cybozu/neco-containers/pull/769)

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>