### PR TITLE
loosen PersistentVolumeUsageRapidIncrease alert for VictoriaMetrics PVs

### DIFF
--- a/monitoring/base/victoriametrics/rules/kubernetes-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/kubernetes-alertrule.yaml
@@ -673,10 +673,22 @@ spec:
             runbook: Please consider resizing volume
         - alert: PersistentVolumeUsageRapidIncrease
           expr: |
-            delta(kubelet_volume_stats_used_bytes[10m])
+            delta(kubelet_volume_stats_used_bytes{persistentvolumeclaim!~"(vmsingle|vmstorage)-.*"}[10m])
             * on(namespace) group_left kube_namespace_labels{label_team="neco"}
             / (1024 * 1024 * 1024) > 10
           for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: Disk usage of `{{ $labels.persistentvolumeclaim }}, {{ $labels.namespace }}` increases rapidly over 10GiB in 10 minutes.
+            runbook: TBD
+        - alert: PersistentVolumeUsageRapidIncrease
+          expr: |
+            delta(kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"(vmsingle|vmstorage)-.*"}[10m])
+            * on(namespace) group_left kube_namespace_labels{label_team="neco"}
+            / (1024 * 1024 * 1024) > 10
+          # longer `for` for VictoriaMetrics PVs. 1m is too sensitive and causes many false positives.
+          for: 15m
           labels:
             severity: warning
           annotations:

--- a/test/vmalert_test/kubernetes.yaml
+++ b/test/vmalert_test/kubernetes.yaml
@@ -1033,3 +1033,24 @@ tests:
             exp_annotations:
               runbook: TBD
               summary: Disk usage of `volume4, foobar` increases rapidly over 10GiB in 10 minutes.
+  - interval: 1m
+    input_series:
+      - series: 'kubelet_volume_stats_used_bytes{job="prometheus", persistentvolumeclaim="vmsingle-foo", namespace="foo"}'
+        values: '0+1073741825x30' # 0 1GiB+1 2GiB+2 ... 10GiB+10 ...
+      - series: 'kube_namespace_labels{job="kube-state-metrics", label_team="neco", namespace="foo"}'
+        values: '1+0x30'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PersistentVolumeUsageRapidIncrease
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: PersistentVolumeUsageRapidIncrease
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: prometheus
+              namespace: foo
+              persistentvolumeclaim: vmsingle-foo
+            exp_annotations:
+              runbook: TBD
+              summary: Disk usage of `vmsingle-foo, foo` increases rapidly over 10GiB in 10 minutes.


### PR DESCRIPTION
The usage of VictoriaMetrics PVs is saw-toothed. The original alert rule is too sensitive and causes many false positives.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>