### PR TITLE
Remove resources limits from Grafana deployment

### DIFF
--- a/monitoring/base/grafana-operator/grafana.yaml
+++ b/monitoring/base/grafana-operator/grafana.yaml
@@ -14,6 +14,10 @@ spec:
           name: github-auth-20200423
     securityContext:
       runAsUser: 10000
+  resources:
+    requests:
+      cpu: "3"
+      memory: 1Gi
   config:
     log:
       mode: "console"

--- a/monitoring/overlays/gcp/grafana-operator/grafana.yaml
+++ b/monitoring/overlays/gcp/grafana-operator/grafana.yaml
@@ -3,6 +3,12 @@ kind: Grafana
 metadata:
   name: grafana
 spec:
+  # Overwrite with default requests value.
+  # refs: https://github.com/grafana-operator/grafana-operator/blob/v4.2.0/controllers/model/grafanaDeployment.go#L22-L23
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
   # If Grafana uses MySQL, main container initialization takes muuuuuuch longer on dctest.
   livenessProbeSpec:
     periodSeconds: 10


### PR DESCRIPTION
Grafana pods are throttled hard.
There is no need to set the CPU limits (it is the defualt value of grafana operator), so I remove it.

Current CPU limits of Grafana Deployment.

```
        resources:
          limits:
            cpu: 500m
            memory: 1Gi
          requests:
            cpu: 100m
            memory: 256Mi
```

Actual CPU usage.

```
$ kubectl top pod -n monitoring | grep grafana-deployment
grafana-deployment-857d76dd56-gtrxl                    233m         135Mi
grafana-deployment-857d76dd56-xn4gw                    2m           111Mi
```

![grafana](https://user-images.githubusercontent.com/47380942/160337245-91e55099-177e-42cd-af7c-4512ed774e9c.png)

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>