### PR TITLE
The status of app-of-apps application must always be HEALTHY

### DIFF
--- a/argocd/base/configmap.yaml
+++ b/argocd/base/configmap.yaml
@@ -25,6 +25,11 @@ data:
       hs.message = ""
       return hs
     end
+    if obj.metadata ~= nil and obj.metadata.labels ~= nil and obj.metadata.labels["app-of-apps"] == "true" then
+      hs.status = "Healthy"
+      hs.message = ""
+      return hs
+    end
     if obj.status ~= nil then
       if obj.status.health ~= nil then
         hs.status = obj.status.health.status


### PR DESCRIPTION
Tenant users can use cattage to manage app-of-apps application resources themselves.
In order to synchronize app-of-apps application resources, their status must always be HEALTHY.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>