### PR TITLE
Allow dbre team to deploy to app-dbre-monitoring

### DIFF
--- a/team-management/base/dbre/project.yaml
+++ b/team-management/base/dbre/project.yaml
@@ -12,6 +12,8 @@ spec:
       server: '*'
     - namespace: app-cybozu-com-mysql-restore
       server: '*'
+    - namespace: app-dbre-monitoring
+      server: '*'
     - namespace: app-mysql-tenant-service
       server: '*'
     - namespace: dev-*

--- a/team-management/base/maneki/project.yaml
+++ b/team-management/base/maneki/project.yaml
@@ -16,6 +16,8 @@ spec:
       server: '*'
     - namespace: app-cydec
       server: '*'
+    - namespace: app-dbre-monitoring
+      server: '*'
     - namespace: app-elasticsearch
       server: '*'
     - namespace: app-endpoint-discovery

--- a/team-management/template/settings.json
+++ b/team-management/template/settings.json
@@ -11,6 +11,7 @@
       "app-cybozu-com-mysql",
       "app-cybozu-com-mysql-replica",
       "app-cybozu-com-mysql-restore",
+      "app-dbre-monitoring",
       "app-mysql-tenant-service"
     ],
     "garoon": [


### PR DESCRIPTION
DBRE team requests permission to deploy to `app-dbre-monitoring` namespace.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>