### PR TITLE
Enable oom_envent

### DIFF
--- a/monitoring/base/cadvisor/daemonset.yaml
+++ b/monitoring/base/cadvisor/daemonset.yaml
@@ -18,13 +18,16 @@ spec:
         - --max_housekeeping_interval=15s
         - --event_storage_event_limit=default=0
         - --event_storage_age_limit=default=0
-        - --enable_metrics=app,cpu,cpuLoad,disk,diskIO,memory,network,process
+        - --enable_metrics=app,cpu,cpuLoad,disk,diskIO,memory,network,oom_event,process
         - --containerd=/var/run/k8s-containerd.sock
         - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace
         env:
         - name: GOMAXPROCS
           value: "1"
+        resources:
+          limits:
+            cpu: "1"
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
Enable `oom_event`
- `container_oom_events_total` is useful to check memory limits.

Increase CPU limits
- cAdvisor pods are still throttled.
  ref: https://github.com/cybozu-go/neco-apps/pull/2423

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>