### PR TITLE
improve node unreachable alerts

### DIFF
--- a/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
+++ b/monitoring/base/victoriametrics/rules/sabakan-alertrule.yaml
@@ -28,19 +28,19 @@ spec:
             severity: warning
         - alert: BootServerNotHealthy
           annotations:
-            summary: "Not-healthy boot server(s) exist."
+            summary: "Boot server `{{ $labels.serial }}` at `{{ $labels.address }}` in rack `{{ $labels.rack }}` is not healthy."
             runbook: TBD
           expr: |
-            sum(sabakan_machine_status{status!~"healthy|retired", role="boot"}) > 0
+            sum by(address, serial, rack) (sabakan_machine_status{status!~"healthy|retired", role="boot"}) > 0
           for: 30m
           labels:
             severity: error
         - alert: NodeUnreachable
           annotations:
-            summary: "Node `{{ $labels.serial }}` at `{{ $labels.address }}` is unreachable."
+            summary: "Node `{{ $labels.serial }}` at `{{ $labels.address }}` in rack `{{ $labels.rack }}` is unreachable."
             runbook: "Perform the server retirement procedure."
           expr: |
-            sum by(address, serial) (sabakan_machine_status{status="unreachable"}) > 0
+            sum by(address, serial, rack) (sabakan_machine_status{status="unreachable"}) > 0
           for: 60m
           labels:
             severity: urgent

--- a/test/vmalert_test/sabakan.yaml
+++ b/test/vmalert_test/sabakan.yaml
@@ -36,9 +36,9 @@ tests:
               runbook: TBD
   - interval: 1m
     input_series:
-      - series: 'sabakan_machine_status{instance="boot-0", address="1.2.3.4", serial="abcd", status="healthy", role="boot"}'
+      - series: 'sabakan_machine_status{instance="boot-0", address="1.2.3.4", serial="abcd", rack="2", status="healthy", role="boot"}'
         values: 0+0x30
-      - series: 'sabakan_machine_status{instance="boot-0", address="1.2.3.4", serial="abcd", status="unhealthy", role="boot"}'
+      - series: 'sabakan_machine_status{instance="boot-0", address="1.2.3.4", serial="abcd", rack="2", status="unhealthy", role="boot"}'
         values: 1+0x30
     alert_rule_test:
       - eval_time: 30m
@@ -46,14 +46,17 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: error
+              address: "1.2.3.4"
+              serial: "abcd"
+              rack: "2"
             exp_annotations:
-              summary: Not-healthy boot server(s) exist.
+              summary: "Boot server `abcd` at `1.2.3.4` in rack `2` is not healthy."
               runbook: TBD
   - interval: 1m
     input_series:
-      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", rack="2", status="healthy"}
         values: 0+0x60
-      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", rack="2", status="unreachable"}
         values: 1+0x60
     alert_rule_test:
       - eval_time: 60m
@@ -63,22 +66,23 @@ tests:
               severity: urgent
               address: "1.2.3.4"
               serial: "abcd"
+              rack: "2"
             exp_annotations:
-              summary: "Node `abcd` at `1.2.3.4` is unreachable."
+              summary: "Node `abcd` at `1.2.3.4` in rack `2` is unreachable."
               runbook: "Perform the server retirement procedure."
   - interval: 1m
     input_series:
-      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", rack="2", status="healthy"}
         values: 0+0x30 1+0x30
-      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.4", serial="abcd", rack="2", status="unreachable"}
         values: 1+0x30 0+0x30
-      - series: sabakan_machine_status{address="1.2.3.5", serial="abce", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.5", serial="abce", rack="2", status="healthy"}
         values: 1+0x20 0+0x30 1+0x10
-      - series: sabakan_machine_status{address="1.2.3.5", serial="abce", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.5", serial="abce", rack="2", status="unreachable"}
         values: 0+0x20 1+0x30 0+0x10
-      - series: sabakan_machine_status{address="1.2.3.6", serial="abcf", status="healthy"}
+      - series: sabakan_machine_status{address="1.2.3.6", serial="abcf", rack="2", status="healthy"}
         values: 1+0x40 0+0x20
-      - series: sabakan_machine_status{address="1.2.3.6", serial="abcf", status="unreachable"}
+      - series: sabakan_machine_status{address="1.2.3.6", serial="abcf", rack="2", status="unreachable"}
         values: 0+0x40 1+0x20
     alert_rule_test:
       - eval_time: 60m


### PR DESCRIPTION
- `BootServerNotHealthy`: fire individual alerts for each boot server.
- `NodeUnreachable`: output rack number in alerts.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>