### PR TITLE
Add dbre team to deploy to app-dashboard-server-db

### DIFF
--- a/team-management/base/dbre/project.yaml
+++ b/team-management/base/dbre/project.yaml
@@ -12,6 +12,8 @@ spec:
       server: '*'
     - namespace: app-cybozu-com-mysql-restore
       server: '*'
+    - namespace: app-dashboard-server-db
+      server: '*'
     - namespace: app-dbre-monitoring
       server: '*'
     - namespace: app-mysql-tenant-service

--- a/team-management/base/maneki/project.yaml
+++ b/team-management/base/maneki/project.yaml
@@ -16,6 +16,8 @@ spec:
       server: '*'
     - namespace: app-cydec
       server: '*'
+    - namespace: app-dashboard-server-db
+      server: '*'
     - namespace: app-dbre-monitoring
       server: '*'
     - namespace: app-elasticsearch

--- a/team-management/template/settings.json
+++ b/team-management/template/settings.json
@@ -11,6 +11,7 @@
       "app-cybozu-com-mysql",
       "app-cybozu-com-mysql-replica",
       "app-cybozu-com-mysql-restore",
+      "app-dashboard-server-db",
       "app-dbre-monitoring",
       "app-mysql-tenant-service"
     ],


### PR DESCRIPTION
DBRE team requests permission to deploy to `app-dashboard-server-db` namespace.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>