### PR TITLE
Add tolerations for meows

### DIFF
--- a/logging-small/overlays/stage0/kustomization.yaml
+++ b/logging-small/overlays/stage0/kustomization.yaml
@@ -21,3 +21,8 @@ patchesJSON6902:
         value:
           key: "neco/exclude_noisy_neighbor"
           operator: "Exists"
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          key: "neco/reserved_for_meows"
+          operator: "Exists"

--- a/logging/overlays/gcp/kustomization.yaml
+++ b/logging/overlays/gcp/kustomization.yaml
@@ -34,6 +34,11 @@ patchesJSON6902:
         value:
           key: "neco/exclude_noisy_neighbor"
           operator: "Exists"
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          key: "neco/reserved_for_meows"
+          operator: "Exists"
   - target:
       group: apps
       version: v1
@@ -50,4 +55,9 @@ patchesJSON6902:
         path: /spec/template/spec/tolerations/-
         value:
           key: "neco/exclude_noisy_neighbor"
+          operator: "Exists"
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          key: "neco/reserved_for_meows"
           operator: "Exists"

--- a/logging/overlays/stage0/kustomization.yaml
+++ b/logging/overlays/stage0/kustomization.yaml
@@ -21,6 +21,11 @@ patchesJSON6902:
         value:
           key: "neco/exclude_noisy_neighbor"
           operator: "Exists"
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          key: "neco/reserved_for_meows"
+          operator: "Exists"
   - target:
       group: apps
       version: v1
@@ -37,4 +42,9 @@ patchesJSON6902:
         path: /spec/template/spec/tolerations/-
         value:
           key: "neco/exclude_noisy_neighbor"
+          operator: "Exists"
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          key: "neco/reserved_for_meows"
           operator: "Exists"

--- a/metallb/base/patch.yaml
+++ b/metallb/base/patch.yaml
@@ -36,6 +36,8 @@ spec:
         operator: Exists
       - key: neco/exclude_noisy_neighbor
         operator: Exists
+      - key: neco/reserved_for_meows
+        operator: Exists
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/monitoring/base/cadvisor/daemonset.yaml
+++ b/monitoring/base/cadvisor/daemonset.yaml
@@ -48,3 +48,5 @@ spec:
         operator: Exists
       - key: neco/exclude_noisy_neighbor
         operator: Exists
+      - key: neco/reserved_for_meows
+        operator: Exists

--- a/topolvm/base/values.yaml
+++ b/topolvm/base/values.yaml
@@ -47,6 +47,8 @@ lvmd:
       operator: Exists
     - key: neco/exclude_noisy_neighbor
       operator: Exists
+    - key: neco/reserved_for_meows
+      operator: Exists
     # for L4LB applying operation
     - key: node.cybozu.io/cluster-not-ready
       operator: Exists
@@ -70,6 +72,8 @@ node:
     - key: csa/exclude_noisy_neighbor
       operator: Exists
     - key: neco/exclude_noisy_neighbor
+      operator: Exists
+    - key: neco/reserved_for_meows
       operator: Exists
     # for L4LB applying operation
     - key: node.cybozu.io/cluster-not-ready


### PR DESCRIPTION
I will add a `neco/reserved_for_meows=true:NoExecute` taint when reserving a node for meows.
Therefore, I have added tolerations to the components required for meows execution.

Signed-off-by: kouki <kouworld0123@gmail.com>