### PR TITLE
argocd-config: fix group field to ignore diff of core resources

### DIFF
--- a/argocd-config/base/elastic.yaml
+++ b/argocd-config/base/elastic.yaml
@@ -17,14 +17,6 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: elastic-system
-  ignoreDifferences:
-  - group: core
-    kind: Secret
-    name: webhook-server-secret
-    namespace: elastic-system
-    jsonPointers:
-    - /data
-    - /type
   syncPolicy:
     automated:
       prune: true

--- a/argocd-config/base/logging-small.yaml
+++ b/argocd-config/base/logging-small.yaml
@@ -23,7 +23,7 @@ spec:
       selfHeal: true
   ignoreDifferences:
     # PVC storage size will be change by pvc-autoresizer.
-    - group: core
+    - group: ""
       kind: PersistentVolumeClaim
       name: loki-small-data
       namespace: logging-small


### PR DESCRIPTION
- fix `group` field for `core/v1` resources.
- `ignoreDifferences` field for Secret of elastic-system/webhook-server-secret looks unused.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>