### PR TITLE
deploy tenet 0.3.0 and add forbidden entities to networkpolicyadmissionrules

### DIFF
--- a/argocd-config/base/tenet.yaml
+++ b/argocd-config/base/tenet.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://cybozu-go.github.io/tenet
     chart: tenet
-    targetRevision: 0.2.0
+    targetRevision: 0.3.0
     helm:
       version: v3
   destination:

--- a/tenet-policy/base/admission/forbid-egress-node.yaml
+++ b/tenet-policy/base/admission/forbid-egress-node.yaml
@@ -9,3 +9,8 @@ spec:
     forbiddenIPRanges:
       - cidr: 10.69.0.0/16
         type: egress
+    forbiddenEntities:
+      - entity: host
+        type: egress
+      - entity: remote-node
+        type: egress

--- a/test/tenant_networkpolicy_test.go
+++ b/test/tenant_networkpolicy_test.go
@@ -22,6 +22,8 @@ var (
 	tenantNetworkPolicyBmcYAML []byte
 	//go:embed testdata/tenant-networkpolicy-node.yaml
 	tenantNetworkPolicyNodeYAML []byte
+	//go:embed testdata/tenant-networkpolicy-node-entity.yaml
+	tenantNetworkPolicyNodeEntityYAML []byte
 )
 
 func prepareTenantNetworkPolicy() {
@@ -81,6 +83,10 @@ func testTenantNetworkPolicy() {
 		_, _, err := ExecAtWithInput(boot0, tenantNetworkPolicyNodeYAML, "kubectl", "apply", "-f", "-")
 		Expect(err).To(HaveOccurred())
 		_, _, err = ExecAtWithInput(boot0, tenantNetworkPolicyBmcYAML, "kubectl", "apply", "-f", "-")
+		Expect(err).To(HaveOccurred())
+
+		By("attempting to apply policy with forbidden entity")
+		_, _, err = ExecAtWithInput(boot0, tenantNetworkPolicyNodeEntityYAML, "kubectl", "apply", "-f", "-")
 		Expect(err).To(HaveOccurred())
 	})
 }

--- a/test/testdata/tenant-networkpolicy-node-entity.yaml
+++ b/test/testdata/tenant-networkpolicy-node-entity.yaml
@@ -1,0 +1,11 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: egress-node-forbidden-entity
+  namespace: test-tenant-netpol
+spec:
+  endpointSelector: {}
+  egress:
+  - toEntities:
+    - host
+    - remote-node


### PR DESCRIPTION
This deploys the updated 0.3.0 version of tenet which adds support for specifying forbidden entities in tenant network policies. Accordingly, the NetworkPolicyAdmissionRule for restricting node access has been updated to forbid the relevant entities on top of their IPs.