### PR TITLE
Update sealed-secrets

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -530,11 +530,10 @@ Check the [release notes](https://github.com/bitnami-labs/sealed-secrets/blob/ma
 
 Generate manifests from the official Helm charts.
 
-```
-cd $GOPATH/src/github.com/cybozu-go/neco-apps/sealed-secrets/base
-helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
-helm repo update
-helm search repo -l sealed-secrets
+```console
+$ helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
+$ helm repo update
+$ helm search repo -l sealed-secrets
 # Example output with a header line:
 # NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                  
 # sealed-secrets/sealed-secrets   1.16.1          v0.16.0         Helm chart for the sealed-secrets controller.
@@ -542,9 +541,11 @@ helm search repo -l sealed-secrets
 # sealed-secrets/sealed-secrets   1.13.2          0.13.1          A Helm chart for Sealed Secrets              
 
 # Choose the latest `CHART VERSION` which matches the target sealed-secrets.
-SEALED_SECRETS_CHART_VERSION=X.Y.Z
-helm template sealed-secrets --namespace=kube-system sealed-secrets/sealed-secrets --version=${SEALED_SECRETS_CHART_VERSION} --include-crds > upstream/controller.yaml
-git diff
+$ SEALED_SECRETS_CHART_VERSION=X.Y.Z
+$ helm template sealed-secrets sealed-secrets/sealed-secrets \
+    --namespace=kube-system --set fullnameOverride=sealed-secrets-controller \
+    --version=${SEALED_SECRETS_CHART_VERSION} --include-crds > sealed-secrets/base/upstream/controller.yaml
+$ git diff
 ```
 
 Check the difference between the existing manifest and the new manifest, and update the kustomization patch.

--- a/sealed-secrets/base/deployment.yaml
+++ b/sealed-secrets/base/deployment.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - name: sealed-secrets-controller
+      - name: controller
         command: null
         args:
         - --key-renew-period=8760h

--- a/sealed-secrets/base/kustomization.yaml
+++ b/sealed-secrets/base/kustomization.yaml
@@ -9,4 +9,4 @@ patchesStrategicMerge:
 images:
   - name: quay.io/bitnami/sealed-secrets-controller
     newName: quay.io/cybozu/sealed-secrets
-    newTag: 0.17.0.1
+    newTag: 0.17.4.1

--- a/sealed-secrets/base/upstream/controller.yaml
+++ b/sealed-secrets/base/upstream/controller.yaml
@@ -37,10 +37,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 ---
 # Source: sealed-secrets/templates/cluster-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -49,10 +49,10 @@ metadata:
   name: secrets-unsealer
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 rules:
   - apiGroups:
       - bitnami.com
@@ -74,6 +74,7 @@ rules:
       - secrets
     verbs:
       - get
+      - list
       - create
       - update
       - delete
@@ -92,10 +93,10 @@ metadata:
   name: sealed-secrets-controller
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -114,10 +115,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 rules:
   - apiGroups:
       - ""
@@ -143,21 +144,28 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - 'http:sealed-secrets-controller:'
-  - sealed-secrets-controller
-  resources:
-  - services/proxy
-  verbs:
-  - create
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - 'http:sealed-secrets-controller:'
+      - 'http:sealed-secrets-controller:http'
+      - sealed-secrets-controller
+    resources:
+      - services/proxy
+    verbs:
+      - create
+      - get
 ---
 # Source: sealed-secrets/templates/role-binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -167,10 +175,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -189,10 +197,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -210,17 +218,20 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 spec:
+  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 8080
+    - name: http
+      port: 8080
+      targetPort: http
+      nodePort: null
   selector:
     app.kubernetes.io/name: sealed-secrets
-  type: ClusterIP
+    app.kubernetes.io/instance: sealed-secrets
 ---
 # Source: sealed-secrets/templates/deployment.yaml
 apiVersion: apps/v1
@@ -230,54 +241,65 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: sealed-secrets
-    helm.sh/chart: sealed-secrets-1.16.1
+    helm.sh/chart: sealed-secrets-2.1.5
+    app.kubernetes.io/instance: sealed-secrets
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: sealed-secrets-controller
-    app.kubernetes.io/version: v0.16.0
+    app.kubernetes.io/version: v0.17.4
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: sealed-secrets
-      app.kubernetes.io/instance: sealed-secrets-controller
+      app.kubernetes.io/instance: sealed-secrets
   template:
     metadata:
-      annotations:
       labels:
         app.kubernetes.io/name: sealed-secrets
-        app.kubernetes.io/instance: sealed-secrets-controller
+        app.kubernetes.io/instance: sealed-secrets
     spec:
+      securityContext:
+        fsGroup: 65534
       serviceAccountName: sealed-secrets-controller
       containers:
-        - name: sealed-secrets-controller
+        - name: controller
           command:
             - controller
           args:
-            - "--key-prefix"
+            - --update-status
+            - --key-prefix
             - "sealed-secrets-key"
-          image: quay.io/bitnami/sealed-secrets-controller:v0.16.0
+          image: quay.io/bitnami/sealed-secrets-controller:v0.17.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
               name: http
-          volumeMounts:
-          - mountPath: /tmp
-            name: tmp
           livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
             httpGet:
               path: /healthz
-              port: 8080
+              port: http
           readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
             httpGet:
               path: /healthz
-              port: 8080
+              port: http
+          resources:
+            limits: {}
+            requests: {}
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1001
-          resources:
-            {}
-      securityContext:
-        fsGroup: 65534
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
       volumes:
-      - name: tmp
-        emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -518,6 +518,16 @@ func applyAndWaitForApplications(commitID string) {
 				// ignore error
 			}
 
+			// TODO: remove this block after release the PR bellow
+			// https://github.com/cybozu-go/neco-apps/pull/2509
+			if doUpgrade {
+				if app.Name == "sealed-secrets" && app.Operation == nil && app.Status.Sync.Status == SyncStatusCodeOutOfSync {
+					fmt.Printf("%s sync sealed-secrets app manually: syncStatus=%s, healthStatus=%s\n",
+						time.Now().Format(time.RFC3339), app.Status.Sync.Status, app.Status.Health.Status)
+					ExecSafeAt(boot0, "argocd", "app", "sync", "sealed-secrets", "--force")
+				}
+			}
+
 			// In upgrade test, syncing network-policy app may cause temporal network disruption.
 			// It leads to ArgoCD's improper behavior. In spite of the network-policy app becomes Synced/Healthy, the operation does not end.
 			// So terminate the unexpected operation manually in upgrade test.


### PR DESCRIPTION
Update sealed-secrets to v0.17.4 (chart v2.1.5)

```
$ helm search repo -l sealed-secrets
NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                  
sealed-secrets/sealed-secrets   2.1.6           v0.17.5         Helm chart for the sealed-secrets controller.
sealed-secrets/sealed-secrets   2.1.5           v0.17.4         Helm chart for the sealed-secrets controller. // Use this chart.
sealed-secrets/sealed-secrets   2.1.4           v0.17.3         Helm chart for the sealed-secrets controller.
...
```

This PR has two notable changes.

1. I override the controller name from `sealed-secrets` to `sealed-secrets-controller` to prevent additional options for the `kubeseal` command.
https://github.com/bitnami-labs/sealed-secrets/tree/v0.17.4#helm-chart
    > NOTE: the helm chart by default installs the controller with the name sealed-secrets, while the kubeseal command line interface (CLI) tries to access the controller with the name sealed-secrets-controller. You can explicitly pass --controller-name to the CLI:
    > `kubeseal --controller-name sealed-secrets <args>`
    >Alternatively, you can override fullnameOverride on the helm chart install.

2. This PR will change the match labels in the Deployment of the controller. So we need force sync when upgrading.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>