### PR TITLE
Replace a URL for the node-exporter dashboard.

### DIFF
--- a/monitoring/base/grafana-operator/dashboards/node-exporter.yaml
+++ b/monitoring/base/grafana-operator/dashboards/node-exporter.yaml
@@ -3,7 +3,11 @@ kind: GrafanaDashboard
 metadata:
   name: node-exporter
 spec:
-  url: https://grafana.com/api/dashboards/1860/revisions/21/download
+  # source: https://grafana.com/grafana/dashboards/1860
+  # Prepare files to the following steps.
+  # wget -O node-exporter-full_rev21.json https://grafana.com/api/dashboards/1860/revisions/21/download
+  # gsutil cp -a public-read node-exporter-full_rev21.json gs://neco-public
+  url: https://storage.googleapis.com/neco-public/node-exporter-full_rev21.json
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "vmcluster-largeset"


### PR DESCRIPTION
When importing a dashboard using the `.spec.url` of `GrafanaDashboard`, a 429 error often occurs, so I replaced it with a url that was hosted independently on gcloud storage.

Signed-off-by: kouki <kouworld0123@gmail.com>