### PR TITLE
Fix flaky in testTenantNetworkPolicy

### DIFF
--- a/test/tenant_networkpolicy_test.go
+++ b/test/tenant_networkpolicy_test.go
@@ -76,7 +76,9 @@ func testTenantNetworkPolicy() {
 		}
 
 		By("ensuring ingress for same team is allowed")
-		Eventually(testConnectivity("ubuntu", testTenantNamespace, "testhttpd", testTenantNamespace2)).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return testConnectivity("ubuntu", testTenantNamespace, "testhttpd", testTenantNamespace2)
+		}).ShouldNot(HaveOccurred())
 
 		// TODO: actually verify non-connectivity once the temporary
 		// tenant-ingress-cluster-allow policy is removed


### PR DESCRIPTION
I found a case where `testConnectivity` failed, probably due to a delay in applying `tenant-ingress-cluster-allow`. Therefore, I made a fix to run `testConnectivity` periodically.
In addition, I also modified it to wait for the ubuntu pod in the `testTenantNamespace/2`NS.

Signed-off-by: kouki <kouworld0123@gmail.com>