### PR TITLE
rook: prevent osd crash

### DIFF
--- a/rook/base/ceph-object-store.yaml
+++ b/rook/base/ceph-object-store.yaml
@@ -825,7 +825,7 @@ metadata:
   namespace: ceph-object-store
 spec:
   cephVersion:
-    image: quay.io/cybozu/ceph:16.2.7.3
+    image: quay.io/cybozu/ceph:16.2.7.2
   dashboard:
     ssl: true
   dataDirHostPath: /var/lib/rook

--- a/rook/base/ceph-object-store/cluster.yaml
+++ b/rook/base/ceph-object-store/cluster.yaml
@@ -69,7 +69,7 @@ spec:
               app: rook-ceph-mgr
           topologyKey: topology.kubernetes.io/zone
   cephVersion:
-    image: quay.io/cybozu/ceph:16.2.7.3
+    image: quay.io/cybozu/ceph:16.2.7.2
   dashboard:
     ssl: true
   priorityClassNames:

--- a/rook/base/ceph-ssd.yaml
+++ b/rook/base/ceph-ssd.yaml
@@ -846,7 +846,7 @@ metadata:
   namespace: ceph-ssd
 spec:
   cephVersion:
-    image: quay.io/cybozu/ceph:16.2.7.3
+    image: quay.io/cybozu/ceph:16.2.7.2
   dashboard:
     ssl: true
   dataDirHostPath: /var/lib/rook

--- a/rook/base/ceph-ssd/cluster.yaml
+++ b/rook/base/ceph-ssd/cluster.yaml
@@ -69,7 +69,7 @@ spec:
               app: rook-ceph-mgr
           topologyKey: topology.kubernetes.io/zone
   cephVersion:
-    image: quay.io/cybozu/ceph:16.2.7.3
+    image: quay.io/cybozu/ceph:16.2.7.2
   dashboard:
     ssl: true
   priorityClassNames:

--- a/rook/overlays/stage0/kustomization.yaml
+++ b/rook/overlays/stage0/kustomization.yaml
@@ -4,3 +4,14 @@ resources:
   - ../../base
   - ceph-poc
   - ceph-object-store/httpproxy.yaml
+patches:
+  # A serious regression in stage0 after applying PR#2539.
+  # So we must not upgrade ceph image to 16.2.7.3.
+  # However, we must keep version to 16.2.7.3 in stage0.
+  # It's because downgrading to 16.2.7.2 causes osd crash.
+  - patch: |-
+      - op: replace
+        path: /spec/cephVersion/image
+        value: quay.io/cybozu/ceph:16.2.7.3
+    target:
+      kind: CephCluster


### PR DESCRIPTION
A serious regression in stage0 after applying PR#2539.
So we must not upgrade ceph image to 16.2.7.3.
However, we must keep version to 16.2.7.3 in stage0.
It's because downgrading to 16.2.7.2 causes osd crash.

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>
Co-authored-by: Satoru Takeuchi <satoru.takeuchi@gmail.com>
Co-authored-by: Daichi Mukai <daichi-mukai@cybozu.co.jp>