### PR TITLE
Add cred for neco-apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
           name: Test neco-apps
           command: |
             export NECO_DIR=$(pwd)/neco
+            echo "$SECRET_GITHUB_TOKEN" > cybozu_private_repo_read_pat
             ./bin/run-test.sh
           no_output_timeout: 61m
       - run:
@@ -251,6 +252,7 @@ jobs:
           name: Run upgrade test from stage branch
           command: |
             export NECO_DIR=$(pwd)/neco
+            echo "$SECRET_GITHUB_TOKEN" > cybozu_private_repo_read_pat
             TARGET=dctest-upgrade BASE_BRANCH=stage ./bin/run-test.sh
           no_output_timeout: 61m
       - store_test_results:
@@ -270,6 +272,7 @@ jobs:
           name: Run upgrade test from release branch
           command: |
             export NECO_DIR=$(pwd)/neco
+            echo "$SECRET_GITHUB_TOKEN" > cybozu_private_repo_read_pat
             TARGET=dctest-upgrade BASE_BRANCH=release ./bin/run-test.sh
           no_output_timeout: 61m
       - store_test_results:


### PR DESCRIPTION
Fixed the problem that registration of credentials is required to make neco-apps private.
In addition, the order of setup_test.go has been partially rearranged.

Signed-off-by: kouki <kouworld0123@gmail.com>