### PR TITLE
rook/ceph: change the number of OSD to 30 in ceph-ssd.

### DIFF
--- a/rook/overlays/stage0/kustomization.yaml
+++ b/rook/overlays/stage0/kustomization.yaml
@@ -15,3 +15,11 @@ patches:
         value: quay.io/cybozu/ceph:16.2.7.4
     target:
       kind: CephCluster
+  - patch: |-
+      - op: replace
+        path: /spec/storage/storageClassDeviceSets/0/count
+        value: 30
+    target:
+      kind: CephCluster
+      name: ceph-ssd
+      namespace: ceph-ssd


### PR DESCRIPTION
issue: cybozu/csa#106
Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>