### PR TITLE
Add neco-apps-runner and tolerations/nodeSelector in RunnerPool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ update-meows:
 	sed -i -E '/name:.*meows-controller$$/!b;n;s/newTag:.*$$/newTag: $(patsubst v%,%,$(latest_gh))/' meows/overlays/gcp/kustomization.yaml
 	$(call get-latest-tag,meows-dctest-runner)
 	sed -i -E 's,quay.io/cybozu/meows-dctest-runner:.*$$,quay.io/cybozu/meows-dctest-runner:$(latest_tag),' meows/overlays/stage0/runnerpool.yaml
+	sed -i -E 's,quay.io/cybozu/meows-dctest-runner:.*$$,quay.io/cybozu/meows-dctest-runner:$(latest_tag),' meows/overlays/stage0/neco-apps-runner.yaml
 	$(call get-latest-tag,meows-neco-runner)
 	sed -i -E 's,quay.io/cybozu/meows-neco-runner:.*$$,quay.io/cybozu/meows-neco-runner:$(latest_tag),' meows/overlays/gcp/deployment.yaml
 

--- a/meows/overlays/stage0/kustomization.yaml
+++ b/meows/overlays/stage0/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - ../gcp
   - ./runnerpool.yaml
+  - ./neco-apps-runner.yaml
 patchesStrategicMerge:
   - ./configmap.yaml

--- a/meows/overlays/stage0/neco-apps-runner.yaml
+++ b/meows/overlays/stage0/neco-apps-runner.yaml
@@ -1,17 +1,17 @@
 apiVersion: meows.cybozu.com/v1alpha1
 kind: RunnerPool
 metadata:
-  name: dctest-runner
+  name: neco-apps-runner
   namespace: meows-runner
 spec:
   organization: cybozu-private
-  replicas: 2
+  replicas: 3
+  maxRunnerPods: 25
   notification:
     slack:
       enable: true
-      channel: "#neco"
+      channel: "#kmdkuk-dev"
     extendDuration: "30m"
-  setupCommand: ["/usr/local/bin/dctest-bootstrap"]
   workVolume:
     ephemeral:
       volumeClaimTemplate:
@@ -35,21 +35,6 @@ spec:
       image: quay.io/cybozu/meows-dctest-runner:0.7.0.4
       securityContext:
         privileged: true
-      env:
-      - name: NECO_BRANCH
-        value: "release"
-      - name: NECO_APPS_BRANCH
-        value: "release"
-      - name: GITHUB_USER
-        valueFrom:
-          secretKeyRef:
-            name: cybozu-private-repo-read-pat
-            key: GITHUB_USER
-      - name: GITHUB_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: cybozu-private-repo-read-pat
-            key: GITHUB_TOKEN
       resources:
         requests:
           cpu: 15000m
@@ -72,9 +57,6 @@ spec:
             mountPath: /opt/hostedtoolcache
           - name: tmp
             mountPath: /tmp
-          - name: secrets
-            mountPath: /secrets
-            readOnly: true
     volumes:
         - name: bird
           emptyDir: {}
@@ -120,6 +102,3 @@ spec:
                 resources:
                   requests:
                     storage: 15Gi
-        - name: secrets
-          secret:
-            secretName: clouddns


### PR DESCRIPTION
- Add neco-apps-runner as a RunnerPool to run CI for neco-apps
- Set nodeSelector and tolerations to schedule RunnerPool that running dctest to dedicated nodes. Targets are as follows.
    - dctest-runner: for neco-tenant-apps
    - neco-apps-runner: for neco-apps

Signed-off-by: kouki <kouworld0123@gmail.com>