### PR TITLE
Add .github/workflows

### DIFF
--- a/.github/actions/dctest/action.yaml
+++ b/.github/actions/dctest/action.yaml
@@ -1,0 +1,81 @@
+name: 'dctest'
+description: 'run dctest'
+inputs:
+  target:
+    description: 'dctest or dctest-reboot or dctest-upgrade'
+    required: false
+    default: 'dctest'
+  base-branch:
+    description: ''
+    required: false
+    default: 'main'
+  target-branch:
+    description: ''
+    required: false
+    default: 'main'
+  neco-branch:
+    description: ''
+    required: false
+    default: 'release'
+
+runs:
+  using: composite
+  steps:
+    - name: checkout neco
+      run: |
+        git clone --depth 1 -b ${{ inputs.neco-branch }} https://github.com/cybozu-go/neco.git ${NECO_DIR}
+        REV=$(git -C ${NECO_DIR} rev-parse HEAD)
+        echo "revision: ${REV}"
+      shell: sh
+    - name: watch all pod logs
+      id: watch-all-pod-logs
+      run: |
+        cd ${NECO_DIR}
+        ./bin/watch_podlogs_directly > /tmp/pods.log 2>&1 &
+        WATCH_PROCESS_ID=$!
+        echo "WATCH_PROCESS_ID=${WATCH_PROCESS_ID}" >> $GITHUB_ENV
+      shell: sh
+    - name: neco bootstrap
+      run: |
+        echo ${QUAY_PASSWORD} > ${NECO_DIR}/secrets
+        echo ${NECO_GITHUB_TOKEN} > ${NECO_DIR}/github-token
+        make -C ${NECO_DIR} clean
+        make -C ${NECO_DIR}/dctest setup
+        make -C ${NECO_DIR}/dctest run-placemat-inside-container MENU_ARG=menu-ss.yml
+        make -C ${NECO_DIR}/dctest test SUITE=bootstrap
+      shell: sh
+    - name: neco-apps ${{ inputs.target }}
+      run: |
+        git clone -b ${{ inputs.target-branch }} "https://cybozu-neco:${CYBOZU_PRIVATE_REPO_READ_PAT}@github.com/cybozu-go/neco-apps.git" ${NECO_APPS_DIR}
+        REV=$(git -C ${NECO_APPS_DIR} rev-parse HEAD)
+        echo "revision: ${REV}"
+        export CIRCLE_BUILD_NUM="${{ github.run_id }}${{ github.run_attempt }}"
+        echo "CIRCLE_BUILD_NUM=${CIRCLE_BUILD_NUM}"
+        # actually use github.sha
+        export SHA1=$(git -C ${NECO_APPS_DIR} rev-parse HEAD)
+        echo "${GCLOUD_SERVICE_ACCOUNT}" > ${NECO_APPS_DIR}/test/account.json
+        echo "${CYBOZU_PRIVATE_REPO_READ_PAT}" > ${NECO_APPS_DIR}/test/cybozu_private_repo_read_pat
+        curl -sSLf -o ${NECO_APPS_DIR}/test/lets.crt https://letsencrypt.org/certs/fakelerootx1.pem
+        echo ${MEOWS_SECRET} > ${NECO_APPS_DIR}/test/meows-secret.json
+        make -C ${NECO_APPS_DIR}/test setup
+        make -C ${NECO_APPS_DIR}/test COMMIT_ID=${SHA1} BASE_BRANCH=${{ inputs.base-branch }} ${{ inputs.target }} SUITE=prepare
+        make -C ${NECO_APPS_DIR}/test COMMIT_ID=${SHA1} BASE_BRANCH=${{ inputs.base-branch }} ${{ inputs.target }} SUITE=run
+        make -C ${NECO_APPS_DIR}/test COMMIT_ID=${SHA1} BASE_BRANCH=${{ inputs.base-branch }} ${{ inputs.target }} SUITE=alertcheck
+      shell: bash
+    - name: kill watch all pod logs
+      if: always()
+      run: kill ${{ env.WATCH_PROCESS_ID }}
+      shell: sh
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ inputs.target }}_${{ inputs.base-branch }}_pods.log
+        path: /tmp/pods.log
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.target }}_${{ inputs.base-branch }}_junit.xml
+        path: /tmp/junit.xml
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.target }}_${{ inputs.base-branch }}_image_list.txt
+        path: /tmp/image_list.txt

--- a/.github/actions/dctest/action.yaml
+++ b/.github/actions/dctest/action.yaml
@@ -6,15 +6,15 @@ inputs:
     required: false
     default: 'dctest'
   base-branch:
-    description: ''
+    description: 'The name of the branch to be bootstrapped the first when target=dctest-upgrade. Otherwise it is ignored.'
     required: false
     default: 'main'
   target-branch:
-    description: ''
+    description: 'Name of the branch in neco-apps where you want to run dctest.'
     required: false
     default: 'main'
   neco-branch:
-    description: ''
+    description: 'Name of the branch in neco where you want to run dctest.'
     required: false
     default: 'release'
 

--- a/.github/actions/prepare-git/action.yaml
+++ b/.github/actions/prepare-git/action.yaml
@@ -1,0 +1,9 @@
+name: preapre git
+description: ''
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: |
+        git config --global user.email "neco@cybozu.com"
+        git config --global user.name "cybozu-neco"

--- a/.github/actions/teleport-dns-cname/action.yaml
+++ b/.github/actions/teleport-dns-cname/action.yaml
@@ -1,0 +1,11 @@
+name: teleport-dns-cname
+description: Add CNAME record for Teleport
+runs:
+  using: composite
+  steps:
+    - uses: 'google-github-actions/auth@v0.7.0'
+      with:
+        credentials_json: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+    - uses: 'google-github-actions/setup-gcloud@v0.6.0'
+    - shell: sh
+      run: ./bin/teleport-cname.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,85 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+defaults:
+  run:
+    shell: sh
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - uses: actions/cache@v3
+        with:
+          path: download
+          key: ${{ runner.os }}-test-download-${{ hashFiles('team-management/template/Makefile') }}-${{ hashFiles('test/Makefile') }}
+          restore-keys: ${{ runner.os }}-test-download-
+      - name: Setup team-management tools
+        run: make -C team-management/template setup SUDO=
+      - name: Setup test tools
+        run: make -C test setup SUDO=
+      - run: |
+          make -C team-management/template validation
+      - name: Check diff
+        run: |
+          make test-generate
+          git diff --exit-code
+      - run: make -C test test
+  dctest-bootstrap:
+    uses: ./.github/workflows/dctest-bootstrap.yaml
+    needs: test
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+      MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+      CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+  dctest-upgrade:
+    uses: ./.github/workflows/dctest-upgrade.yaml
+    needs: test
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+      MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+      CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+  create-pull-request-stage:
+    runs-on: ubuntu-20.04
+    needs:
+      - dctest-bootstrap
+      - dctest-upgrade
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/prepare-git
+      - name: Check diff
+        run: |
+          git fetch -t origin
+          diffs=$(git diff --name-only main origin/stage)
+          if [ "$diffs" = "" ]; then touch .skip; exit 0; fi
+          printf "%s\n" "$diffs"
+      - name: Create a pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f .skip ]; then exit 0; fi
+          BRANCH_NAME="stage-$(date +%Y.%m.%d)-${{ github.run_id }}"
+          git checkout -b op-${BRANCH_NAME} origin/stage
+          git merge --no-edit main
+          git push origin op-${BRANCH_NAME}
+          gh pr create --title "[CI] Stage ${BRANCH_NAME}" --body "" --base=stage --head=op-${BRANCH_NAME}
+      - name: Create a pull request for neco-apps-secret staging branch
+        env:
+          CIRCLE_API_TOKEN: ${{ secrets.CIRCLE_API_TOKEN }}
+        run: |
+          if [ -f .skip ]; then exit 0; fi
+          ./bin/run-neco-apps-secret-ci.sh

--- a/.github/workflows/create-pull-request-release.yaml
+++ b/.github/workflows/create-pull-request-release.yaml
@@ -1,0 +1,27 @@
+name: create-pull-request-release
+on:
+  push:
+    tags:
+      - 'release-*'
+defaults:
+  run:
+    # For use ${GITHUB_REF##*/} to get tag name.
+    shell: bash
+
+jobs:
+  create-pull-request-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/prepare-git
+      - name: Create a pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${GITHUB_REF##*/}
+          git checkout -b op-${TAG_NAME} origin/release
+          git merge --no-edit ${TAG_NAME}
+          git push origin op-${TAG_NAME}
+          gh pr create --title "[CI] Release ${TAG_NAME}" --body "" --base=release --head=op-${TAG_NAME}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,0 +1,44 @@
+name: daily
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 0 * * 1-5'
+
+jobs:
+  clean-dns:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: 'google-github-actions/auth@v0.7.0'
+        with:
+          credentials_json: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      - uses: 'google-github-actions/setup-gcloud@v0.6.0'
+      - name: Delete DNS records
+        run: ./bin/clean-dns.sh
+  dctest-reboot:
+    needs: clean-dns
+    uses: ./.github/workflows/dctest-reboot.yaml
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+      MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+      CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+  dctest-bootstrap:
+    needs: clean-dns
+    uses: ./.github/workflows/dctest-bootstrap.yaml
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+      MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+      CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+  dctest-upgrade:
+    needs: clean-dns
+    uses: ./.github/workflows/dctest-upgrade.yaml
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+      MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+      CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -2,7 +2,7 @@ name: daily
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 0 * * 1-5'
+    - cron: '0 23 * * 0-4'
 
 jobs:
   clean-dns:

--- a/.github/workflows/dctest-bootstrap.yaml
+++ b/.github/workflows/dctest-bootstrap.yaml
@@ -2,7 +2,7 @@ name: dctest-bootstrap
 on:
   workflow_call:
     inputs:
-      feature-branch:
+      is-feature-branch:
         description: ''
         required: false
         default: false
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/dctest
         with:
           target-branch: ${{ github.head_ref || steps.extract_branch.outputs.branch }}
-          neco-branch: ${{ (inputs.feature-branch && steps.extract_branch.outputs.branch ) || 'release' }}
+          neco-branch: ${{ (inputs.is-feature-branch && steps.extract_branch.outputs.branch ) || 'release' }}
         env:
           GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/dctest-bootstrap.yaml
+++ b/.github/workflows/dctest-bootstrap.yaml
@@ -1,0 +1,50 @@
+name: dctest-bootstrap
+on:
+  workflow_call:
+    inputs:
+      feature-branch:
+        description: ''
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+      NECO_GITHUB_TOKEN:
+        required: true
+      MEOWS_SECRET:
+        required: true
+      CYBOZU_PRIVATE_REPO_READ_PAT:
+        required: true
+defaults:
+  run:
+    shell: sh
+jobs:
+  dctest-bootstrap:
+    runs-on: [self-hosted, meows-runner/neco-apps-runner]
+    steps:
+      - run: job-started
+      - uses: actions/checkout@v3
+      - name: Extract branch name
+        shell: bash
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        id: extract_branch
+      - name: bootstrap
+        uses: ./.github/actions/dctest
+        with:
+          target-branch: ${{ github.head_ref || steps.extract_branch.outputs.branch }}
+          neco-branch: ${{ (inputs.feature-branch && steps.extract_branch.outputs.branch ) || 'release' }}
+        env:
+          GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+          MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+          CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+      - if: success()
+        run: job-success
+      - if: cancelled()
+        run: job-cancelled
+      - if: failure()
+        run: job-failure

--- a/.github/workflows/dctest-bootstrap.yaml
+++ b/.github/workflows/dctest-bootstrap.yaml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       is-feature-branch:
-        description: ''
+        description: "If set to true, then neco's branch will be the same as neco-apps."
         required: false
         default: false
         type: boolean

--- a/.github/workflows/dctest-reboot.yaml
+++ b/.github/workflows/dctest-reboot.yaml
@@ -1,0 +1,45 @@
+name: dctest-reboot
+on:
+  workflow_call:
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+      NECO_GITHUB_TOKEN:
+        required: true
+      MEOWS_SECRET:
+        required: true
+      CYBOZU_PRIVATE_REPO_READ_PAT:
+        required: true
+  workflow_dispatch:
+defaults:
+  run:
+    shell: sh
+jobs:
+  dctest-reboot:
+    runs-on: [self-hosted, meows-runner/neco-apps-runner]
+    steps:
+      - run: job-started
+      - uses: actions/checkout@v3
+      - name: Extract branch name
+        shell: bash
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        id: extract_branch
+      - name: reboot
+        uses: ./.github/actions/dctest
+        with:
+          target: dctest-reboot
+          target-branch: ${{ github.head_ref || steps.extract_branch.outputs.branch }}
+        env:
+          GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+          MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+          CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+      - if: success()
+        run: job-success
+      - if: cancelled()
+        run: job-cancelled
+      - if: failure()
+        run: job-failure

--- a/.github/workflows/dctest-upgrade.yaml
+++ b/.github/workflows/dctest-upgrade.yaml
@@ -1,0 +1,49 @@
+name: dctest-upgrade
+on:
+  workflow_call:
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+      NECO_GITHUB_TOKEN:
+        required: true
+      MEOWS_SECRET:
+        required: true
+      CYBOZU_PRIVATE_REPO_READ_PAT:
+        required: true
+defaults:
+  run:
+    shell: sh
+jobs:
+  dctest-upgrade:
+    runs-on: [self-hosted, meows-runner/neco-apps-runner]
+    strategy:
+      fail-fast: false
+      matrix:
+        base-branch: [stage, release] 
+    steps:
+      - run: job-started
+      - uses: actions/checkout@v3
+      - name: Extract branch name
+        shell: bash
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        id: extract_branch
+      - name: upgrade-${{ matrix.base-branch }}
+        uses: ./.github/actions/dctest
+        with:
+          target: dctest-upgrade
+          base-branch: ${{ matrix.base-branch }}
+          target-branch: ${{ github.head_ref || steps.extract_branch.outputs.branch }}
+        env:
+          GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+          MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+          CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}
+      - if: success()
+        run: job-success
+      - if: cancelled()
+        run: job-cancelled
+      - if: failure()
+        run: job-failure

--- a/.github/workflows/dctest-with-neco-feature-branch.yaml
+++ b/.github/workflows/dctest-with-neco-feature-branch.yaml
@@ -8,7 +8,7 @@ jobs:
   dctest-bootstrap:
     uses: ./.github/workflows/dctest-bootstrap.yaml
     with:
-      feature-branch: true
+      is-feature-branch: true
     secrets:
       GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/dctest-with-neco-feature-branch.yaml
+++ b/.github/workflows/dctest-with-neco-feature-branch.yaml
@@ -1,0 +1,17 @@
+name: dctest-with-neco-feature-branch
+on:
+  workflow_dispatch:
+defaults:
+  run:
+    shell: sh
+jobs:
+  dctest-bootstrap:
+    uses: ./.github/workflows/dctest-bootstrap.yaml
+    with:
+      feature-branch: true
+    secrets:
+      GCLOUD_SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      NECO_GITHUB_TOKEN: ${{ secrets.NECO_GITHUB_TOKEN }}
+      MEOWS_SECRET: ${{ secrets.MEOWS_SECRET }}
+      CYBOZU_PRIVATE_REPO_READ_PAT: ${{ secrets.CYBOZU_PRIVATE_REPO_READ_PAT }}

--- a/.github/workflows/push-release-tag.yaml
+++ b/.github/workflows/push-release-tag.yaml
@@ -1,0 +1,26 @@
+name: push-release-tag
+on:
+  push:
+    branches:
+      - "stage"
+defaults:
+  run:
+    shell: sh
+
+jobs:
+  push-release-tag:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # For trigger create-pull-request-release when push tag.
+          token: ${{ secrets.GH_PAT }}
+      - uses: ./.github/actions/prepare-git
+      - run: |
+          git checkout stage
+          git merge --no-commit --no-ff ${{ github.sha }}
+      - name: Push tag to GitHub
+        run: |
+          TAG_NAME="release-$(date +%Y.%m.%d)-${{ github.run_id }}"
+          git tag ${TAG_NAME}
+          git push origin ${TAG_NAME}

--- a/meows/overlays/stage0/neco-apps-runner.yaml
+++ b/meows/overlays/stage0/neco-apps-runner.yaml
@@ -10,8 +10,8 @@ spec:
   notification:
     slack:
       enable: true
-      channel: "#kmdkuk-dev"
-    extendDuration: "30m"
+      channel: "#neco"
+    extendDuration: "3h"
   workVolume:
     ephemeral:
       volumeClaimTemplate:


### PR DESCRIPTION
Added workflows for migrating from CircleCI to GitHubActions.
We are currently disabling GitHub Actions in order to use the self-hosted runner, but we will enable these workflows after we make this repository private.

Under `.github/actions`, we place composite actions that cut out the parts common to multiple workflows, such as launching dctest.

The workflow created is described below.
- ci.yaml: The jobs to be executed when pushing to each branch are summarized. (minimum test, dctest-bootstrap and dctest-upgrade. At main merge, create PR for release.)
- daily.yaml: Jobs to be performed daily are summarized. (Delete DNS records, dctest-reboot, dctest-bootstrap and dctest-upgrade)
- dctest-bootstrap.yaml: Workflow for bootstrap testing. Called from daily.yaml and ci.yaml.
- dctest-upgrade.yaml: Workflow for upgrade testing, including upgrade-stage and upgrade-release. Called from daily.yaml and ci.yaml too.
- dctest-reboot.yaml: Workflow for reboot testing. Called from daily.yaml.
- dctest-with-neco-feature-branch.yaml: Workflow for bootstrap testing by specifying a branch of neco. If necessary, create a branch in neco-apps with the same name as the branch of neco you wish to specify and use it from workflow dispatch.
- create-pull-request-release.yaml: Workflow to create a PR to the release branch when a release-* tag is pushed.
- push-release-tag.yaml: Workflow to push tags for release when pushed to stage branch.

In order to execute these workflows, the Secret that must be registered is as follows.
- MEOWS_SECRET
- QUAY_PASSWORD
- NECO_GITHUB_TOKEN
- GCLOUD_SERVICE_ACCOUNT
- GH_PAT
- CYBOZU_PRIVATE_REPO_READ_PAT
- CIRCLE_API_TOKEN

Signed-off-by: kouki <kouworld0123@gmail.com>