### PR TITLE
Loki 2.5.0 (loki-small)

### DIFF
--- a/logging-small/base/loki.yaml
+++ b/logging-small/base/loki.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
   name: loki-small
@@ -15,7 +15,7 @@ kind: Role
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
   name: loki-small
@@ -26,7 +26,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
   name: loki-small
@@ -42,12 +42,12 @@ subjects:
 ---
 apiVersion: v1
 data:
-  loki.yaml: YXV0aF9lbmFibGVkOiBmYWxzZQpjaHVua19zdG9yZV9jb25maWc6CiAgbWF4X2xvb2tfYmFja19wZXJpb2Q6IDBzCmNvbXBhY3RvcjoKICByZXRlbnRpb25fZGVsZXRlX2RlbGF5OiAyaAogIHJldGVudGlvbl9lbmFibGVkOiB0cnVlCiAgc2hhcmVkX3N0b3JlOiBmaWxlc3lzdGVtCiAgd29ya2luZ19kaXJlY3Rvcnk6IC9kYXRhL2xva2kvYm9sdGRiLXNoaXBwZXItY29tcGFjdG9yCmluZ2VzdGVyOgogIGNodW5rX2Jsb2NrX3NpemU6IDI2MjE0NAogIGNodW5rX2lkbGVfcGVyaW9kOiAzbQogIGNodW5rX3JldGFpbl9wZXJpb2Q6IDFtCiAgbGlmZWN5Y2xlcjoKICAgIHJpbmc6CiAgICAgIGt2c3RvcmU6CiAgICAgICAgc3RvcmU6IGlubWVtb3J5CiAgICAgIHJlcGxpY2F0aW9uX2ZhY3RvcjogMQogIG1heF90cmFuc2Zlcl9yZXRyaWVzOiAwCmxpbWl0c19jb25maWc6CiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogZmFsc2UKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAogIHJldGVudGlvbl9wZXJpb2Q6IDE2OGgKc2NoZW1hX2NvbmZpZzoKICBjb25maWdzOgogIC0gZnJvbTogIjIwMjAtMTAtMjQiCiAgICBpbmRleDoKICAgICAgcGVyaW9kOiAyNGgKICAgICAgcHJlZml4OiBpbmRleF8KICAgIG9iamVjdF9zdG9yZTogZmlsZXN5c3RlbQogICAgc2NoZW1hOiB2MTEKICAgIHN0b3JlOiBib2x0ZGItc2hpcHBlcgpzZXJ2ZXI6CiAgaHR0cF9saXN0ZW5fcG9ydDogMzEwMApzdG9yYWdlX2NvbmZpZzoKICBib2x0ZGJfc2hpcHBlcjoKICAgIGFjdGl2ZV9pbmRleF9kaXJlY3Rvcnk6IC9kYXRhL2xva2kvYm9sdGRiLXNoaXBwZXItYWN0aXZlCiAgICBjYWNoZV9sb2NhdGlvbjogL2RhdGEvbG9raS9ib2x0ZGItc2hpcHBlci1jYWNoZQogICAgY2FjaGVfdHRsOiAyNGgKICAgIHNoYXJlZF9zdG9yZTogZmlsZXN5c3RlbQogIGZpbGVzeXN0ZW06CiAgICBkaXJlY3Rvcnk6IC9kYXRhL2xva2kvY2h1bmtzCnRhYmxlX21hbmFnZXI6CiAgcmV0ZW50aW9uX2RlbGV0ZXNfZW5hYmxlZDogZmFsc2UKICByZXRlbnRpb25fcGVyaW9kOiAwcw==
+  loki.yaml: YXV0aF9lbmFibGVkOiBmYWxzZQpjaHVua19zdG9yZV9jb25maWc6CiAgbWF4X2xvb2tfYmFja19wZXJpb2Q6IDBzCmNvbXBhY3RvcjoKICByZXRlbnRpb25fZGVsZXRlX2RlbGF5OiAyaAogIHJldGVudGlvbl9lbmFibGVkOiB0cnVlCiAgc2hhcmVkX3N0b3JlOiBmaWxlc3lzdGVtCiAgd29ya2luZ19kaXJlY3Rvcnk6IC9kYXRhL2xva2kvYm9sdGRiLXNoaXBwZXItY29tcGFjdG9yCmluZ2VzdGVyOgogIGNodW5rX2Jsb2NrX3NpemU6IDI2MjE0NAogIGNodW5rX2lkbGVfcGVyaW9kOiAzbQogIGNodW5rX3JldGFpbl9wZXJpb2Q6IDFtCiAgbGlmZWN5Y2xlcjoKICAgIHJpbmc6CiAgICAgIHJlcGxpY2F0aW9uX2ZhY3RvcjogMQogIG1heF90cmFuc2Zlcl9yZXRyaWVzOiAwCiAgd2FsOgogICAgZGlyOiAvZGF0YS9sb2tpL3dhbApsaW1pdHNfY29uZmlnOgogIGVuZm9yY2VfbWV0cmljX25hbWU6IGZhbHNlCiAgbWF4X2VudHJpZXNfbGltaXRfcGVyX3F1ZXJ5OiA1MDAwCiAgcmVqZWN0X29sZF9zYW1wbGVzOiB0cnVlCiAgcmVqZWN0X29sZF9zYW1wbGVzX21heF9hZ2U6IDE2OGgKICByZXRlbnRpb25fcGVyaW9kOiAxNjhoCm1lbWJlcmxpc3Q6CiAgam9pbl9tZW1iZXJzOgogIC0gJ2xva2ktc21hbGwtbWVtYmVybGlzdCcKc2NoZW1hX2NvbmZpZzoKICBjb25maWdzOgogIC0gZnJvbTogIjIwMjAtMTAtMjQiCiAgICBpbmRleDoKICAgICAgcGVyaW9kOiAyNGgKICAgICAgcHJlZml4OiBpbmRleF8KICAgIG9iamVjdF9zdG9yZTogZmlsZXN5c3RlbQogICAgc2NoZW1hOiB2MTEKICAgIHN0b3JlOiBib2x0ZGItc2hpcHBlcgpzZXJ2ZXI6CiAgZ3JwY19saXN0ZW5fcG9ydDogOTA5NQogIGh0dHBfbGlzdGVuX3BvcnQ6IDMxMDAKc3RvcmFnZV9jb25maWc6CiAgYm9sdGRiX3NoaXBwZXI6CiAgICBhY3RpdmVfaW5kZXhfZGlyZWN0b3J5OiAvZGF0YS9sb2tpL2JvbHRkYi1zaGlwcGVyLWFjdGl2ZQogICAgY2FjaGVfbG9jYXRpb246IC9kYXRhL2xva2kvYm9sdGRiLXNoaXBwZXItY2FjaGUKICAgIGNhY2hlX3R0bDogMjRoCiAgICBzaGFyZWRfc3RvcmU6IGZpbGVzeXN0ZW0KICBmaWxlc3lzdGVtOgogICAgZGlyZWN0b3J5OiAvZGF0YS9sb2tpL2NodW5rcwp0YWJsZV9tYW5hZ2VyOgogIHJldGVudGlvbl9kZWxldGVzX2VuYWJsZWQ6IGZhbHNlCiAgcmV0ZW50aW9uX3BlcmlvZDogMHM=
 kind: Secret
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
   name: loki-small
@@ -58,7 +58,7 @@ kind: Service
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
   name: loki-small
@@ -79,7 +79,7 @@ kind: Service
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
     variant: headless
@@ -95,6 +95,29 @@ spec:
   selector:
     app: loki
     release: loki-small
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: loki
+    chart: loki-2.12.0
+    heritage: Helm
+    release: loki-small
+  name: loki-small-memberlist
+  namespace: logging-small
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 7946
+    protocol: TCP
+    targetPort: memberlist-port
+  publishNotReadyAddresses: true
+  selector:
+    app: loki
+    release: loki-small
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -118,7 +141,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: loki
-    chart: loki-2.7.0
+    chart: loki-2.12.0
     heritage: Helm
     release: loki-small
   name: loki-small
@@ -134,12 +157,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2247e3e289a75d99a6aec20bb7b3409ceb8a6e9130151ab9758b758b5267d808
+        checksum/config: f48edcd3edb55d979c4a869b3820e150abff5ca8aa5670898ebb24815b932952
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
       labels:
         app: loki
-        name: loki
+        name: loki-small
         release: loki-small
     spec:
       affinity: {}
@@ -147,7 +170,7 @@ spec:
       - args:
         - -config.file=/etc/loki/loki.yaml
         env: null
-        image: quay.io/cybozu/loki:2.3.0.1
+        image: quay.io/cybozu/loki:2.5.0.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -159,6 +182,12 @@ spec:
         - containerPort: 3100
           name: http-metrics
           protocol: TCP
+        - containerPort: 9095
+          name: grpc
+          protocol: TCP
+        - containerPort: 7946
+          name: memberlist-port
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready
@@ -168,6 +197,8 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /etc/loki
           name: config
         - mountPath: /data
@@ -184,6 +215,8 @@ spec:
       terminationGracePeriodSeconds: 4800
       tolerations: []
       volumes:
+      - emptyDir: {}
+        name: tmp
       - name: config
         secret:
           secretName: loki-small

--- a/logging-small/base/loki/kustomization.yaml
+++ b/logging-small/base/loki/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     releaseName: loki-small
     repo: https://grafana.github.io/helm-charts
     valuesFile: values.yaml
-    version: 2.7.0
+    version: 2.12.0
 namespace: logging-small
 resources:
   - pvc.yaml

--- a/logging-small/base/loki/values.yaml
+++ b/logging-small/base/loki/values.yaml
@@ -8,7 +8,7 @@ config:
 
 image:
   repository: quay.io/cybozu/loki
-  tag: 2.3.0.1
+  tag: 2.5.0.1
 
 persistence:
   enabled: true


### PR DESCRIPTION
I just run `make update-loki-small`.

As far as I confirmed, these changes have no negative impact to loki-small.
https://grafana.com/docs/loki/latest/upgrading/

NOTE: The `loki.yaml` in the `loki` secret has the following difference.

- Use the memberlist instead of in memory store.
- Specify the WAL dir (`loki-small-data` PVC is aleady mounted to `/data`)

```
$ diff -U30 old.yaml new.yaml 
--- old.yaml    2022-06-02 07:56:51.521710582 +0000
+++ new.yaml    2022-06-02 07:56:40.617594931 +0000
@@ -1,45 +1,50 @@
 auth_enabled: false
 chunk_store_config:
   max_look_back_period: 0s
 compactor:
   retention_delete_delay: 2h
   retention_enabled: true
   shared_store: filesystem
   working_directory: /data/loki/boltdb-shipper-compactor
 ingester:
   chunk_block_size: 262144
   chunk_idle_period: 3m
   chunk_retain_period: 1m
   lifecycler:
     ring:
-      kvstore:
-        store: inmemory
       replication_factor: 1
   max_transfer_retries: 0
+  wal:
+    dir: /data/loki/wal
 limits_config:
   enforce_metric_name: false
+  max_entries_limit_per_query: 5000
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   retention_period: 168h
+memberlist:
+  join_members:
+  - 'loki-small-memberlist'
 schema_config:
   configs:
   - from: "2020-10-24"
     index:
       period: 24h
       prefix: index_
     object_store: filesystem
     schema: v11
     store: boltdb-shipper
 server:
+  grpc_listen_port: 9095
   http_listen_port: 3100
 storage_config:
   boltdb_shipper:
     active_index_directory: /data/loki/boltdb-shipper-active
     cache_location: /data/loki/boltdb-shipper-cache
     cache_ttl: 24h
     shared_store: filesystem
   filesystem:
     directory: /data/loki/chunks
 table_manager:
   retention_deletes_enabled: false
   retention_period: 0s
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>